### PR TITLE
Check for Forge tag for wheat

### DIFF
--- a/src/main/resources/data/create/recipes/crushing/wheat.json
+++ b/src/main/resources/data/create/recipes/crushing/wheat.json
@@ -3,7 +3,7 @@
     "group": "minecraft:misc",
     "ingredients": [
     	{
-    		"item": "minecraft:wheat"
+    		"tag": "forge:crops/wheat"
     	}
     ], 
 	"results": [


### PR DESCRIPTION
Allows for more cross-mod compatibility with other variants of wheat. Perhaps reverting the name of flour to "flour" instead of "wheat flour" would be more inclusive as well.