### PR TITLE
Recipe namespace

### DIFF
--- a/src/main/java/com/simibubi/create/AllRecipes.java
+++ b/src/main/java/com/simibubi/create/AllRecipes.java
@@ -31,11 +31,11 @@ public enum AllRecipes {
 	;
 
 	public static class Types {
-		public static IRecipeType<CrushingRecipe> CRUSHING = register("crushing");
-		public static IRecipeType<SplashingRecipe> SPLASHING = register("splashing");
-		public static IRecipeType<PressingRecipe> PRESSING = register("pressing");
-		public static IRecipeType<CuttingRecipe> CUTTING = register("cutting");
-		public static IRecipeType<MixingRecipe> MIXING = register("mixing");
+		public static IRecipeType<CrushingRecipe> CRUSHING = register("create:crushing");
+		public static IRecipeType<SplashingRecipe> SPLASHING = register("create:splashing");
+		public static IRecipeType<PressingRecipe> PRESSING = register("create:pressing");
+		public static IRecipeType<CuttingRecipe> CUTTING = register("create:cutting");
+		public static IRecipeType<MixingRecipe> MIXING = register("create:mixing");
 
 		static <T extends IRecipe<?>> IRecipeType<T> register(final String key) {
 			return Registry.register(Registry.RECIPE_TYPE, new ResourceLocation(key), new IRecipeType<T>() {

--- a/src/main/java/com/simibubi/create/foundation/command/KillTPSCommand.java
+++ b/src/main/java/com/simibubi/create/foundation/command/KillTPSCommand.java
@@ -3,23 +3,27 @@ package com.simibubi.create.foundation.command;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.simibubi.create.Create;
+import com.simibubi.create.foundation.utility.Lang;
 import net.minecraft.command.CommandSource;
 import net.minecraft.command.Commands;
 import net.minecraft.util.text.StringTextComponent;
+import net.minecraft.util.text.TranslationTextComponent;
 
 public class KillTPSCommand {
 
+
+
 	public static void register(CommandDispatcher<CommandSource> dispatcher) {
 		dispatcher.register(
-		Commands.literal("killtps")//todo replace String Components with Translation Components
+		Commands.literal(Lang.translate("command.killTPSCommand"))
 			.requires(cs -> cs.hasPermissionLevel(2))
 			.executes(ctx -> {
 				//killtps no arguments
-				ctx.getSource().sendFeedback(new StringTextComponent(String.format("[Create]: Server tick is currently slowed by %s ms",Create.lagger.isLagging() ? Create.lagger.getTickTime() : 0)), true);
+				ctx.getSource().sendFeedback(Lang.getTranslationComponent("command.killTPSCommand.status.slowed_by.0", Create.lagger.isLagging() ? Create.lagger.getTickTime() : 0), true);
 				if (Create.lagger.isLagging())
-					ctx.getSource().sendFeedback(new StringTextComponent("[Create]: use /killtps stop to bring back server tick to regular speed"), true);
+					ctx.getSource().sendFeedback(Lang.getTranslationComponent("command.killTPSCommand.status.usage.0"), true);
 				else
-					ctx.getSource().sendFeedback(new StringTextComponent("[Create]: use /killtps start <tickTime> to artificially slow down the server tick"),true);
+					ctx.getSource().sendFeedback(Lang.getTranslationComponent("command.killTPSCommand.status.usage.1"),true);
 
 				return 1;
 			})
@@ -29,22 +33,22 @@ public class KillTPSCommand {
 					int tickTime = Create.lagger.getTickTime();
 					if (tickTime > 0){
 						Create.lagger.setLagging(true);
-						ctx.getSource().sendFeedback(new StringTextComponent(String.format("[Create]: Server tick is slowed by %s ms now :)", tickTime)),true);
-						ctx.getSource().sendFeedback(new StringTextComponent("[Create]: use /killtps stop to bring back server tick to regular speed"),true);
+						ctx.getSource().sendFeedback((Lang.getTranslationComponent("command.killTPSCommand.status.slowed_by.1", tickTime)),true);
+						ctx.getSource().sendFeedback(Lang.getTranslationComponent("command.killTPSCommand.status.usage.0"),true);
 					} else {
-						ctx.getSource().sendFeedback(new StringTextComponent("[Create]: use /killtps start <tickTime> to artificially slow down the server tick"),true);
+						ctx.getSource().sendFeedback(Lang.getTranslationComponent("command.killTPSCommand.status.usage.1"),true);
 					}
 
 					return 1;
 				})
-				.then(Commands.argument("tickTime", IntegerArgumentType.integer(1))
+				.then(Commands.argument(Lang.translate("command.killTPSCommand.argument.tickTime"), IntegerArgumentType.integer(1))
 					.executes(ctx -> {
 						//killtps start tickTime
-						int tickTime = IntegerArgumentType.getInteger(ctx, "tickTime");
+						int tickTime = IntegerArgumentType.getInteger(ctx, Lang.translate("command.killTPSCommand.argument.tickTime"));
 						Create.lagger.setTickTime(tickTime);
 						Create.lagger.setLagging(true);
-						ctx.getSource().sendFeedback(new StringTextComponent(String.format("[Create]: Server tick is slowed by %s ms now :)", tickTime)),true);
-						ctx.getSource().sendFeedback(new StringTextComponent("[Create]: use /killtps stop to bring server tick to regular speed again"),true);
+						ctx.getSource().sendFeedback((Lang.getTranslationComponent("command.killTPSCommand.status.slowed_by.1", tickTime)),true);
+						ctx.getSource().sendFeedback(Lang.getTranslationComponent("command.killTPSCommand.status.usage.0"),true);
 
 						return 1;
 					})
@@ -54,7 +58,7 @@ public class KillTPSCommand {
 				.executes(ctx -> {
 					//killtps stop
 					Create.lagger.setLagging(false);
-					ctx.getSource().sendFeedback(new StringTextComponent("[Create]: Server tick is back to regular speed"), false);
+					ctx.getSource().sendFeedback(Lang.getTranslationComponent("command.killTPSCommand.status.slowed_by.2"), false);
 
 					return 1;
 				})

--- a/src/main/java/com/simibubi/create/foundation/utility/Lang.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/Lang.java
@@ -15,7 +15,7 @@ public class Lang {
 		return getTranslationComponent(key, args).getFormattedText();
 	}
 
-	private static TranslationTextComponent getTranslationComponent(String key, Object... args) {
+	public static TranslationTextComponent getTranslationComponent(String key, Object... args) {
 		return new TranslationTextComponent(Create.ID + "." + key, args);
 	}
 

--- a/src/main/resources/assets/create/lang/en_us.json
+++ b/src/main/resources/assets/create/lang/en_us.json
@@ -432,6 +432,14 @@
 
 	"create.mechanical_mixer.min_ingredients": "Min. Ingredients",
 
+	"create.command.killTPSCommand": "killtps",
+	"create.command.killTPSCommand.status.slowed_by.0": "[Create]: Server tick is currently slowed by %s ms",
+	"create.command.killTPSCommand.status.slowed_by.1": "[Create]: Server tick is slowed by %s ms now :)",
+	"create.command.killTPSCommand.status.slowed_by.2": "[Create]: Server tick is back to regular speed",
+	"create.command.killTPSCommand.status.usage.0": "[Create]: use /killtps stop to bring back server tick to regular speed",
+	"create.command.killTPSCommand.status.usage.1": "[Create]: use /killtps start <tickTime> to artificially slow down the server tick",
+	"create.command.killTPSCommand.argument.tickTime": "tickTime",
+
 	"_comment": "-------------------------]  ITEM DESCRIPTIONS  [------------------------------------------------",
 
 	"item.create.example_item.tooltip": "EXAMPLE ITEM (just a marker that this tooltip exists)",


### PR DESCRIPTION
Should fix https://github.com/Creators-of-Create/Create/issues/55

I have done some testing on the issue and interestingly for pure data packs Minecraft does not recognize the type "crushing", it does however recognize "create:crushing". This does not change when changing the registry creation to use the create namespace

https://github.com/Creators-of-Create/Create/blob/385a3f449708dfde9ee2036d19839eb0d805d75e/src/main/java/com/simibubi/create/AllRecipes.java#L29-L41

I think it should be safe to change it. This should fix the crafttweaker issue as well
https://github.com/CraftTweaker/CraftTweaker/issues/878
I have not been able to test this however, I have tried to make a script similar to the ones used in the issue but ran into other issues. 
