### PR TITLE
Changed registration of recipe types to use create namespace

### DIFF
--- a/src/main/java/com/simibubi/create/AllRecipes.java
+++ b/src/main/java/com/simibubi/create/AllRecipes.java
@@ -31,11 +31,11 @@ public enum AllRecipes {
 	;
 
 	public static class Types {
-		public static IRecipeType<CrushingRecipe> CRUSHING = register("crushing");
-		public static IRecipeType<SplashingRecipe> SPLASHING = register("splashing");
-		public static IRecipeType<PressingRecipe> PRESSING = register("pressing");
-		public static IRecipeType<CuttingRecipe> CUTTING = register("cutting");
-		public static IRecipeType<MixingRecipe> MIXING = register("mixing");
+		public static IRecipeType<CrushingRecipe> CRUSHING = register("create:crushing");
+		public static IRecipeType<SplashingRecipe> SPLASHING = register("create:splashing");
+		public static IRecipeType<PressingRecipe> PRESSING = register("create:pressing");
+		public static IRecipeType<CuttingRecipe> CUTTING = register("create:cutting");
+		public static IRecipeType<MixingRecipe> MIXING = register("create:mixing");
 
 		static <T extends IRecipe<?>> IRecipeType<T> register(final String key) {
 			return Registry.register(Registry.RECIPE_TYPE, new ResourceLocation(key), new IRecipeType<T>() {


### PR DESCRIPTION
Should fix https://github.com/Creators-of-Create/Create/issues/55

I have done some testing on the issue and interestingly for pure data packs Minecraft does not recognize the type "crushing", it does however recognize "create:crushing". This does not change when changing the registry creation to use the create namespace

https://github.com/Creators-of-Create/Create/blob/385a3f449708dfde9ee2036d19839eb0d805d75e/src/main/java/com/simibubi/create/AllRecipes.java#L29-L41

I think it should be safe to change it. This should fix the crafttweaker issue as well
https://github.com/CraftTweaker/CraftTweaker/issues/878
I have not been able to test this however, I have tried to make a script similar to the ones used in the issue but ran into other issues. 
