### PR TITLE
added apparently missing stonecutter recipe for polished_dark_scoria

### DIFF
--- a/src/main/resources/data/create/recipes/stonecutting/polished_dark_scoria.json
+++ b/src/main/resources/data/create/recipes/stonecutting/polished_dark_scoria.json
@@ -1,0 +1,14 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "create:dark_scoria"
+  },
+  "result": "create:polished_dark_scoria",
+  "count": 1,
+	"conditions": [
+		{
+			"type": "create:module",
+			"module": "palettes"
+		}
+	]
+}


### PR DESCRIPTION
While messing around with polished blocks of create, i noticed the stonecutter recipe for polished dark scoria was missing, even though ALL other polished create stones had a stone cutter recipe. The .json file i added should solve this issue.

(The polished dark scoria slab is missing as well, but as i am not good with textures and new blocks, this is nothing i can fix with a quick pull request)