### PR TITLE
Allow harvesters to harvest kelp tops

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/components/actors/HarvesterMovementBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/actors/HarvesterMovementBehaviour.java
@@ -15,6 +15,7 @@ import net.minecraft.block.Blocks;
 import net.minecraft.block.CocoaBlock;
 import net.minecraft.block.CropsBlock;
 import net.minecraft.block.KelpBlock;
+import net.minecraft.block.KelpTopBlock;
 import net.minecraft.block.SugarCaneBlock;
 import net.minecraft.client.renderer.IRenderTypeBuffer;
 import net.minecraft.item.ItemStack;
@@ -109,6 +110,11 @@ public class HarvesterMovementBehaviour extends MovementBehaviour {
 
 		if (state.getCollisionShape(world, pos)
 			.isEmpty() || state.getBlock() instanceof CocoaBlock) {
+			if (state.getBlock() instanceof KelpBlock)
+				return true;
+			if (state.getBlock() instanceof KelpTopBlock)
+				return true;
+
 			for (IProperty<?> property : state.getProperties()) {
 				if (!(property instanceof IntegerProperty))
 					continue;
@@ -118,8 +124,6 @@ public class HarvesterMovementBehaviour extends MovementBehaviour {
 				return false;
 			}
 
-			if (state.getBlock() instanceof KelpBlock)
-				return true;
 			if (state.getBlock() instanceof IPlantable)
 				return true;
 		}
@@ -132,7 +136,7 @@ public class HarvesterMovementBehaviour extends MovementBehaviour {
 			CropsBlock crop = (CropsBlock) state.getBlock();
 			return crop.withAge(0);
 		}
-		if (state.getBlock() == Blocks.SUGAR_CANE) {
+		if (state.getBlock() == Blocks.SUGAR_CANE || state.getBlock() == Blocks.KELP)  {
 			if (state.getFluidState()
 				.isEmpty())
 				return Blocks.AIR.getDefaultState();


### PR DESCRIPTION
Adds checks for kelp tops in the harvester code so it will recognize them as harvestable and breakable.
This allows harvesters to be used to harvest kelp in a similar manner to sugarcane.