### PR TITLE
Fix Bell contraptions and Schematic usage

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/components/actors/BellMovementBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/actors/BellMovementBehaviour.java
@@ -25,7 +25,8 @@ public class BellMovementBehaviour extends MovementBehaviour {
 
 	@Override
 	public void stopMoving(MovementContext context) {
-		context.world.playSound(null, new BlockPos(context.position), SoundEvents.BLOCK_BELL_USE, SoundCategory.BLOCKS,
-			2.0F, 1.0F);
+		if (context.position != null)
+			context.world.playSound(null, new BlockPos(context.position), SoundEvents.BLOCK_BELL_USE, SoundCategory.BLOCKS,
+				2.0F, 1.0F);
 	}
 }

--- a/src/main/java/com/simibubi/create/content/schematics/client/SchematicHandler.java
+++ b/src/main/java/com/simibubi/create/content/schematics/client/SchematicHandler.java
@@ -221,14 +221,14 @@ public class SchematicHandler {
 	}
 
 	public boolean mouseScrolled(double delta) {
-		if (!active || Minecraft.getInstance().player.isSneaking())
+		if (!active)
 			return false;
 
 		if (selectionScreen.focused) {
 			selectionScreen.cycle((int) delta);
 			return true;
 		}
-		if (AllKeys.ACTIVATE_TOOL.isPressed())
+		if (!AllKeys.ctrlDown())
 			return currentTool.getTool()
 				.handleMouseWheel(delta);
 		return false;


### PR DESCRIPTION
- Bell contraptions no longer causes a NullPointerException when they
  are stopped
- Schematic usage shouldn't require a player to not be sneaking, and
  changes the key to CTRL to match tool tips