### PR TITLE
Added github action

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,22 @@
+name: Java CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Build with Gradle
+      run: ./gradlew clean build
+    - name: Upload Jar
+      uses: actions/upload-artifact@v1
+      with:
+        name: Create
+        path: build/libs


### PR DESCRIPTION
As I wanted to try the mod out in MC 1.16 I made a github action to build it for me.
As you can see it builds and you can download the created artifacts as a zip(containing  two jar files, whereas one is the slim version). The non slim version worked for me with the most recent forge version in MC 1.16.3
https://github.com/jvbsl/Create/runs/1347496582

That should help with easier releasing steps. If something else is needed you can ask and I can introduce it as well with a little bit of help.

E.g. I don't know if there is a server version that needs to be built separately(as the jars don't work on a dedicated server at least for me).