### PR TITLE
Fix a typo in ko_kr.json

### DIFF
--- a/ko_kr.json
+++ b/ko_kr.json
@@ -68,7 +68,7 @@
 	"block.create.brass_casing": "황동 케이스",
 	"block.create.copper_casing": "구리 케이스",
 
-	"block.create.cogwheel": "톱나바퀴",
+	"block.create.cogwheel": "톱니바퀴",
 	"block.create.large_cogwheel": "큰 톱니바퀴",
 	"block.create.turntable": "돌림판",
 	"block.create.gearbox": "수평 기어박스",


### PR DESCRIPTION
Changed typo(톱나바퀴) to correct(톱니바퀴)