### PR TITLE
Correctly update inserted ItemEntity on belt collision to prevent #618.

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/relays/belt/BeltBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/relays/belt/BeltBlock.java
@@ -185,10 +185,12 @@ public class BeltBlock extends HorizontalKineticBlock implements ITE<BeltTileEnt
 					.orElse(null);
 				if (handler == null)
 					return;
-				ItemStack remainder = handler.insertItem(0, itemEntity.getItem()
-					.copy(), false);
+				ItemStack toInsert = itemEntity.getItem();
+				ItemStack remainder = handler.insertItem(0, toInsert.copy(), false);
 				if (remainder.isEmpty())
 					itemEntity.remove();
+				if (remainder.getCount() < toInsert.getCount())
+					itemEntity.setItem(remainder);
 			});
 			return;
 		}


### PR DESCRIPTION
As documented in #618, in some cases, `ItemEntity` objects launched from a belt can collide with multiple entities at once (i.e. in the same tick).

If the game processes the collision with a `BeltBlock` prior to other collisions, the `ItemStack` in the `ItemEntity` is **not** updated to account for any items inserted into the belt.

This change edits the on-collide logic in `BeltBlock` to update the passed-in `ItemEntity` with the `ItemStack` of items not inserted into the belt.

This prevents the duplication glitch:

https://user-images.githubusercontent.com/1288716/103390148-728a7500-4ad8-11eb-89a8-d0948720a1e3.mp4