### PR TITLE
Add lead crushed ore recipes when Eidolon present

### DIFF
--- a/src/generated/resources/data/create/advancements/recipes/building_blocks/blasting/lead_ingot_compat_eidolon.json
+++ b/src/generated/resources/data/create/advancements/recipes/building_blocks/blasting/lead_ingot_compat_eidolon.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "create:blasting/lead_ingot_compat_eidolon"
+    ]
+  },
+  "criteria": {
+    "has_item": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "create:crushed_lead_ore"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "create:blasting/lead_ingot_compat_eidolon"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_item",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/create/advancements/recipes/building_blocks/smelting/lead_ingot_compat_eidolon.json
+++ b/src/generated/resources/data/create/advancements/recipes/building_blocks/smelting/lead_ingot_compat_eidolon.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "create:smelting/lead_ingot_compat_eidolon"
+    ]
+  },
+  "criteria": {
+    "has_item": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "create:crushed_lead_ore"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "create:smelting/lead_ingot_compat_eidolon"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_item",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/create/recipes/blasting/lead_ingot_compat_eidolon.json
+++ b/src/generated/resources/data/create/recipes/blasting/lead_ingot_compat_eidolon.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:blasting",
+  "ingredient": {
+    "item": "create:crushed_lead_ore"
+  },
+  "result": "eidolon:lead_ingot",
+  "experience": 0.1,
+  "cookingtime": 100,
+  "conditions": [
+    {
+      "modid": "eidolon",
+      "type": "forge:mod_loaded"
+    }
+  ]
+}

--- a/src/generated/resources/data/create/recipes/smelting/lead_ingot_compat_eidolon.json
+++ b/src/generated/resources/data/create/recipes/smelting/lead_ingot_compat_eidolon.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:smelting",
+  "ingredient": {
+    "item": "create:crushed_lead_ore"
+  },
+  "result": "eidolon:lead_ingot",
+  "experience": 0.1,
+  "cookingtime": 200,
+  "conditions": [
+    {
+      "modid": "eidolon",
+      "type": "forge:mod_loaded"
+    }
+  ]
+}

--- a/src/generated/resources/data/create/recipes/splashing/eidolon/crushed_lead_ore.json
+++ b/src/generated/resources/data/create/recipes/splashing/eidolon/crushed_lead_ore.json
@@ -1,0 +1,25 @@
+{
+  "type": "create:splashing",
+  "ingredients": [
+    {
+      "item": "create:crushed_lead_ore"
+    }
+  ],
+  "results": [
+    {
+      "item": "eidolon:lead_nugget",
+      "count": 10
+    },
+    {
+      "item": "eidolon:lead_nugget",
+      "count": 5,
+      "chance": 0.5
+    }
+  ],
+  "conditions": [
+    {
+      "modid": "eidolon",
+      "type": "forge:mod_loaded"
+    }
+  ]
+}

--- a/src/main/java/com/simibubi/create/foundation/data/recipe/Mods.java
+++ b/src/main/java/com/simibubi/create/foundation/data/recipe/Mods.java
@@ -8,7 +8,8 @@ public enum Mods {
 	TH("thermal", false), 
 	MW("mysticalworld", false), 
 	SM("silents_mechanisms", false), 
-	IE("immersiveengineering", true)
+	IE("immersiveengineering", true),
+	EID("eidolon", false)
 
 	;
 

--- a/src/main/java/com/simibubi/create/foundation/data/recipe/StandardRecipeGen.java
+++ b/src/main/java/com/simibubi/create/foundation/data/recipe/StandardRecipeGen.java
@@ -5,6 +5,7 @@ import static com.simibubi.create.foundation.data.recipe.Mods.MEK;
 import static com.simibubi.create.foundation.data.recipe.Mods.MW;
 import static com.simibubi.create.foundation.data.recipe.Mods.SM;
 import static com.simibubi.create.foundation.data.recipe.Mods.TH;
+import static com.simibubi.create.foundation.data.recipe.Mods.EID;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -974,7 +975,7 @@ public class StandardRecipeGen extends CreateRecipeProvider {
 		CRUSHED_PLATINUM = blastModdedCrushedMetal(AllItems.CRUSHED_PLATINUM, "platinum", SM),
 		CRUSHED_SILVER = blastModdedCrushedMetal(AllItems.CRUSHED_SILVER, "silver", MW, TH, IE, SM),
 		CRUSHED_TIN = blastModdedCrushedMetal(AllItems.CRUSHED_TIN, "tin", MEK, TH, MW, SM),
-		CRUSHED_LEAD = blastModdedCrushedMetal(AllItems.CRUSHED_LEAD, "lead", MEK, MW, TH, IE, SM),
+		CRUSHED_LEAD = blastModdedCrushedMetal(AllItems.CRUSHED_LEAD, "lead", MEK, MW, TH, IE, SM, EID),
 		CRUSHED_QUICKSILVER = blastModdedCrushedMetal(AllItems.CRUSHED_QUICKSILVER, "quicksilver", MW),
 		CRUSHED_BAUXITE = blastModdedCrushedMetal(AllItems.CRUSHED_BAUXITE, "aluminum", IE, SM),
 		CRUSHED_URANIUM = blastModdedCrushedMetal(AllItems.CRUSHED_URANIUM, "uranium", MEK, IE, SM),

--- a/src/main/java/com/simibubi/create/foundation/data/recipe/WashingRecipeGen.java
+++ b/src/main/java/com/simibubi/create/foundation/data/recipe/WashingRecipeGen.java
@@ -5,6 +5,7 @@ import static com.simibubi.create.foundation.data.recipe.Mods.MEK;
 import static com.simibubi.create.foundation.data.recipe.Mods.MW;
 import static com.simibubi.create.foundation.data.recipe.Mods.SM;
 import static com.simibubi.create.foundation.data.recipe.Mods.TH;
+import static com.simibubi.create.foundation.data.recipe.Mods.EID;
 
 import java.util.function.Supplier;
 
@@ -54,7 +55,7 @@ public class WashingRecipeGen extends ProcessingRecipeGen {
 		CRUSHED_PLATINUM = moddedCrushedOre(AllItems.CRUSHED_PLATINUM, "platinum", SM),
 		CRUSHED_SILVER = moddedCrushedOre(AllItems.CRUSHED_SILVER, "silver", TH, MW, IE, SM),
 		CRUSHED_TIN = moddedCrushedOre(AllItems.CRUSHED_TIN, "tin", TH, MEK, MW, SM),
-		CRUSHED_LEAD = moddedCrushedOre(AllItems.CRUSHED_LEAD, "lead", MEK, TH, MW, IE, SM),
+		CRUSHED_LEAD = moddedCrushedOre(AllItems.CRUSHED_LEAD, "lead", MEK, TH, MW, IE, SM, EID),
 		CRUSHED_QUICKSILVER = moddedCrushedOre(AllItems.CRUSHED_QUICKSILVER, "quicksilver", MW),
 		CRUSHED_BAUXITE = moddedCrushedOre(AllItems.CRUSHED_BAUXITE, "aluminum", IE, SM),
 		CRUSHED_URANIUM = moddedCrushedOre(AllItems.CRUSHED_URANIUM, "uranium", MEK, IE, SM),


### PR DESCRIPTION
A simple fix for #622. Just following what's already there.

Eidolon is a 1.16 only mod so I assume that this is the correct branch for this change. I am not sure what the proper protocol is when commiting generated files, so I have only included those that the fix presumably touches. 