### PR TITLE
Technically add support for Ice and Fire

### DIFF
--- a/src/generated/resources/data/create/advancements/recipes/building_blocks/blasting/silver_ingot_compat_iceandfire.json
+++ b/src/generated/resources/data/create/advancements/recipes/building_blocks/blasting/silver_ingot_compat_iceandfire.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "create:blasting/silver_ingot_compat_iceandfire"
+    ]
+  },
+  "criteria": {
+    "has_item": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "create:crushed_silver_ore"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "create:blasting/silver_ingot_compat_iceandfire"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_item",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/create/advancements/recipes/building_blocks/smelting/silver_ingot_compat_iceandfire.json
+++ b/src/generated/resources/data/create/advancements/recipes/building_blocks/smelting/silver_ingot_compat_iceandfire.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "create:smelting/silver_ingot_compat_iceandfire"
+    ]
+  },
+  "criteria": {
+    "has_item": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "create:crushed_silver_ore"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "create:smelting/silver_ingot_compat_iceandfire"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_item",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/create/recipes/blasting/silver_ingot_compat_iceandfire.json
+++ b/src/generated/resources/data/create/recipes/blasting/silver_ingot_compat_iceandfire.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:blasting",
+  "ingredient": {
+    "item": "create:crushed_silver_ore"
+  },
+  "result": "iceandfire:silver_ingot",
+  "experience": 0.1,
+  "cookingtime": 100,
+  "conditions": [
+    {
+      "modid": "iceandfire",
+      "type": "forge:mod_loaded"
+    }
+  ]
+}

--- a/src/generated/resources/data/create/recipes/smelting/silver_ingot_compat_iceandfire.json
+++ b/src/generated/resources/data/create/recipes/smelting/silver_ingot_compat_iceandfire.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:smelting",
+  "ingredient": {
+    "item": "create:crushed_silver_ore"
+  },
+  "result": "iceandfire:silver_ingot",
+  "experience": 0.1,
+  "cookingtime": 200,
+  "conditions": [
+    {
+      "modid": "iceandfire",
+      "type": "forge:mod_loaded"
+    }
+  ]
+}

--- a/src/generated/resources/data/create/recipes/splashing/iceandfire/crushed_silver_ore.json
+++ b/src/generated/resources/data/create/recipes/splashing/iceandfire/crushed_silver_ore.json
@@ -1,0 +1,25 @@
+{
+  "type": "create:splashing",
+  "ingredients": [
+    {
+      "item": "create:crushed_silver_ore"
+    }
+  ],
+  "results": [
+    {
+      "item": "iceandfire:silver_nugget",
+      "count": 10
+    },
+    {
+      "item": "iceandfire:silver_nugget",
+      "count": 5,
+      "chance": 0.5
+    }
+  ],
+  "conditions": [
+    {
+      "modid": "iceandfire",
+      "type": "forge:mod_loaded"
+    }
+  ]
+}

--- a/src/main/java/com/simibubi/create/foundation/data/recipe/Mods.java
+++ b/src/main/java/com/simibubi/create/foundation/data/recipe/Mods.java
@@ -8,7 +8,8 @@ public enum Mods {
 	TH("thermal", false), 
 	MW("mysticalworld", false), 
 	SM("silents_mechanisms", false), 
-	IE("immersiveengineering", true)
+	IE("immersiveengineering", true),
+	INF("iceandfire", false)
 
 	;
 

--- a/src/main/java/com/simibubi/create/foundation/data/recipe/StandardRecipeGen.java
+++ b/src/main/java/com/simibubi/create/foundation/data/recipe/StandardRecipeGen.java
@@ -5,6 +5,7 @@ import static com.simibubi.create.foundation.data.recipe.Mods.MEK;
 import static com.simibubi.create.foundation.data.recipe.Mods.MW;
 import static com.simibubi.create.foundation.data.recipe.Mods.SM;
 import static com.simibubi.create.foundation.data.recipe.Mods.TH;
+import static com.simibubi.create.foundation.data.recipe.Mods.INF;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -972,7 +973,7 @@ public class StandardRecipeGen extends CreateRecipeProvider {
 
 		CRUSHED_OSMIUM = blastModdedCrushedMetal(AllItems.CRUSHED_OSMIUM, "osmium", MEK),
 		CRUSHED_PLATINUM = blastModdedCrushedMetal(AllItems.CRUSHED_PLATINUM, "platinum", SM),
-		CRUSHED_SILVER = blastModdedCrushedMetal(AllItems.CRUSHED_SILVER, "silver", MW, TH, IE, SM),
+		CRUSHED_SILVER = blastModdedCrushedMetal(AllItems.CRUSHED_SILVER, "silver", MW, TH, IE, SM, INF),
 		CRUSHED_TIN = blastModdedCrushedMetal(AllItems.CRUSHED_TIN, "tin", MEK, TH, MW, SM),
 		CRUSHED_LEAD = blastModdedCrushedMetal(AllItems.CRUSHED_LEAD, "lead", MW, TH, IE, SM),
 		CRUSHED_QUICKSILVER = blastModdedCrushedMetal(AllItems.CRUSHED_QUICKSILVER, "quicksilver", MW),

--- a/src/main/java/com/simibubi/create/foundation/data/recipe/WashingRecipeGen.java
+++ b/src/main/java/com/simibubi/create/foundation/data/recipe/WashingRecipeGen.java
@@ -5,6 +5,7 @@ import static com.simibubi.create.foundation.data.recipe.Mods.MEK;
 import static com.simibubi.create.foundation.data.recipe.Mods.MW;
 import static com.simibubi.create.foundation.data.recipe.Mods.SM;
 import static com.simibubi.create.foundation.data.recipe.Mods.TH;
+import static com.simibubi.create.foundation.data.recipe.Mods.INF;
 
 import java.util.function.Supplier;
 
@@ -52,7 +53,7 @@ public class WashingRecipeGen extends ProcessingRecipeGen {
 
 		CRUSHED_OSMIUM = moddedCrushedOre(AllItems.CRUSHED_OSMIUM, "osmium", MEK),
 		CRUSHED_PLATINUM = moddedCrushedOre(AllItems.CRUSHED_PLATINUM, "platinum", SM),
-		CRUSHED_SILVER = moddedCrushedOre(AllItems.CRUSHED_SILVER, "silver", TH, MW, IE, SM),
+		CRUSHED_SILVER = moddedCrushedOre(AllItems.CRUSHED_SILVER, "silver", TH, MW, IE, SM, INF),
 		CRUSHED_TIN = moddedCrushedOre(AllItems.CRUSHED_TIN, "tin", TH, MEK, MW, SM),
 		CRUSHED_LEAD = moddedCrushedOre(AllItems.CRUSHED_LEAD, "lead", TH, MW, IE, SM),
 		CRUSHED_QUICKSILVER = moddedCrushedOre(AllItems.CRUSHED_QUICKSILVER, "quicksilver", MW),


### PR DESCRIPTION
Ice and Fire does not seem to tag their copper and silver ores as copper and silver ores, so this change does not really do much.

Fixes #633 the best it can on this side