### PR TITLE
Open up stress config

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/base/KineticTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/base/KineticTileEntity.java
@@ -55,8 +55,8 @@ public abstract class KineticTileEntity extends SmartTileEntity
 	private int flickerTally;
 	private int networkSize;
 	private int validationCountdown;
-	private float lastStressApplied;
-	private float lastCapacityProvided;
+	protected float lastStressApplied;
+	protected float lastCapacityProvided;
 
 	public KineticTileEntity(TileEntityType<?> typeIn) {
 		super(typeIn);

--- a/src/main/java/com/simibubi/create/content/contraptions/base/KineticTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/base/KineticTileEntity.java
@@ -156,7 +156,7 @@ public abstract class KineticTileEntity extends SmartTileEntity
 	}
 
 	public float calculateStressApplied() {
-		float impact = (float) AllConfigs.SERVER.kinetics.stressValues.getImpactOf(getBlockState().getBlock());
+		float impact = (float) AllConfigs.SERVER.kinetics.stressValues.getImpactOf(getStressConfigKey());
 		this.lastStressApplied = impact;
 		return impact;
 	}

--- a/src/main/java/com/simibubi/create/foundation/config/StressConfigDefaults.java
+++ b/src/main/java/com/simibubi/create/foundation/config/StressConfigDefaults.java
@@ -28,14 +28,14 @@ public class StressConfigDefaults {
 	
 	public static <B extends Block, P> NonNullUnaryOperator<BlockBuilder<B, P>> setImpact(double impact) {
 		return b -> {
-			registeredDefaultImpacts.put(Create.asResource(b.getName()), impact);
+			registeredDefaultImpacts.put(new ResourceLocation(b.getName()), impact);
 			return b;
 		};
 	}
 	
 	public static <B extends Block, P> NonNullUnaryOperator<BlockBuilder<B, P>> setCapacity(double capacity) {
 		return b -> {
-			registeredDefaultCapacities.put(Create.asResource(b.getName()), capacity);
+			registeredDefaultCapacities.put(new ResourceLocation(b.getName()), capacity);
 			return b;
 		};
 	}


### PR DESCRIPTION
Making a way for other mods to more easily hook into stress. (By overriding KineticTileEntity#calculateAddedStressCapacity) Will enable modders to create custom stress configs as it is currently not possible from what I can tell.

Work-around for the issue with StressConfigDefaults which uses Create#asResource that limits configs to the create mod blocks only. Fixing this would allow me to Override a few things to add in my own configs as I cannot now. #755 