### PR TITLE
No crash while rendering unsupported blocks

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/utility/TileEntityRenderHelper.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/TileEntityRenderHelper.java
@@ -44,8 +44,14 @@ public class TileEntityRenderHelper {
 				Vector4f vec = new Vector4f(pos.getX() + .5f, pos.getY() + .5f, pos.getZ() + .5f, 1);
 				vec.transform(matrix);
 				BlockPos lightPos = new BlockPos(vec.getX(), vec.getY(), vec.getZ());
-				renderer.render(tileEntity, pt, ms, buffer, WorldRenderer.getLightmapCoordinates(world, lightPos),
-					OverlayTexture.DEFAULT_UV);
+				try {
+					renderer.render(tileEntity, pt, ms, buffer, WorldRenderer.getLightmapCoordinates(world, lightPos),
+							OverlayTexture.DEFAULT_UV);
+				} catch (NullPointerException e) {
+					if(AllConfigs.CLIENT.explainRenderErrors.get()) {
+						throw e;
+					}
+				}
 				ms.pop();
 
 			} catch (Exception e) {
@@ -54,13 +60,14 @@ public class TileEntityRenderHelper {
 				String message = "TileEntity " + tileEntity.getType()
 					.getRegistryName()
 					.toString() + " didn't want to render while moved.\n";
+
+
 				if (AllConfigs.CLIENT.explainRenderErrors.get()) {
 					Create.logger.error(message, e);
 					continue;
 				}
 				
 				Create.logger.error(message);
-				continue;
 			}
 		}
 	}


### PR DESCRIPTION
https://github.com/Creators-of-Create/Create/issues/410
https://github.com/Creators-of-Create/Create/issues/845

We have constant issues where we have to grab regions from backups because the players are using unsupported blocks.
I'm well aware supporting other mods can be hard to keep up with or is even on your planning.

This pull will not crash your client anymore at least. It may not look nice but will solve a lot of issues for server owners.

explainRenderErrors=true will still crash the client as this may of course be useful for debugging.