### PR TITLE
Fixed issues with the blockzapper and FTBChunks

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/components/fan/AirCurrent.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/fan/AirCurrent.java
@@ -82,7 +82,7 @@ public class AirCurrent {
 	protected void tickAffectedEntities(World world, Direction facing) {
 		for (Iterator<Entity> iterator = caughtEntities.iterator(); iterator.hasNext();) {
 			Entity entity = iterator.next();
-			if (!entity.getBoundingBox()
+			if (!entity.isAlive() ||!entity.getBoundingBox()
 				.intersects(bounds)) {
 				iterator.remove();
 				continue;

--- a/src/main/java/com/simibubi/create/content/contraptions/components/press/MechanicalPressTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/press/MechanicalPressTileEntity.java
@@ -154,6 +154,8 @@ public class MechanicalPressTileEntity extends BasinOperatingTileEntity {
 
 					for (ItemEntity itemEntity : world.getEntitiesWithinAABB(ItemEntity.class,
 						new AxisAlignedBB(pos.down()).shrink(.125f))) {
+						if (!itemEntity.isAlive() || !itemEntity.isOnGround())
+							continue;
 						ItemStack stack = itemEntity.getItem();
 						Optional<PressingRecipe> recipe = getRecipe(stack);
 						if (!recipe.isPresent())
@@ -234,7 +236,7 @@ public class MechanicalPressTileEntity extends BasinOperatingTileEntity {
 		for (Entity entity : world.getEntitiesWithinAABBExcludingEntity(null, bb)) {
 			if (!(entity instanceof ItemEntity))
 				continue;
-			if (!entity.isAlive())
+			if (!entity.isAlive() || !entity.isOnGround())
 				continue;
 			ItemEntity itemEntity = (ItemEntity) entity;
 			pressedItems.add(itemEntity.getItem());

--- a/src/main/java/com/simibubi/create/content/curiosities/zapper/blockzapper/BlockzapperItem.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/zapper/blockzapper/BlockzapperItem.java
@@ -299,7 +299,6 @@ public class BlockzapperItem extends ZapperItem {
 	public static boolean isAllowedToPlace(World world, BlockPos pos,PlayerEntity player){
 		BlockSnapshot blocksnapshot = BlockSnapshot.create(world.getRegistryKey(), world, pos);
 		if (ForgeEventFactory.onBlockPlace(player, blocksnapshot, Direction.UP)) {
-			blocksnapshot.restore(true, false);
 			return false;
 		}
 		return true;

--- a/src/main/java/com/simibubi/create/content/curiosities/zapper/blockzapper/BlockzapperItem.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/zapper/blockzapper/BlockzapperItem.java
@@ -109,7 +109,7 @@ public class BlockzapperItem extends ZapperItem {
 				continue;
 			if (!selectedState.isValidPosition(world, placed))
 				continue;
-			if (!player.isCreative() && !canBreak(stack, world.getBlockState(placed), world, placed))
+			if (!player.isCreative() && !canBreak(stack, world.getBlockState(placed), world, placed,player))
 				continue;
 			if (!player.isCreative() && BlockHelper.findAndRemoveInInventory(selectedState, player, 1) == 0) {
 				player.getCooldownTracker()
@@ -278,10 +278,13 @@ public class BlockzapperItem extends ZapperItem {
 		return list;
 	}
 
-	public static boolean canBreak(ItemStack stack, BlockState state, World world, BlockPos pos) {
+	public static boolean canBreak(ItemStack stack, BlockState state, World world, BlockPos pos,PlayerEntity player) {
 		ComponentTier tier = getTier(Components.Body, stack);
 		float blockHardness = state.getBlockHardness(world, pos);
-
+		//If we can't change the block (e.g chunk protection)
+		if (!isAllowedToPlace(world,pos,player)){
+			return false;
+		}
 		if (blockHardness == -1)
 			return false;
 		if (tier == ComponentTier.None)
@@ -293,7 +296,14 @@ public class BlockzapperItem extends ZapperItem {
 
 		return false;
 	}
-
+	public static boolean isAllowedToPlace(World world, BlockPos pos,PlayerEntity player){
+		BlockSnapshot blocksnapshot = BlockSnapshot.create(world.getRegistryKey(), world, pos);
+		if (ForgeEventFactory.onBlockPlace(player, blocksnapshot, Direction.UP)) {
+			blocksnapshot.restore(true, false);
+			return false;
+		}
+		return true;
+	}
 	public static int getMaxAoe(ItemStack stack) {
 		ComponentTier tier = getTier(Components.Amplifier, stack);
 		if (tier == ComponentTier.None)

--- a/src/main/java/com/simibubi/create/content/logistics/block/chute/ChuteTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/chute/ChuteTileEntity.java
@@ -226,6 +226,8 @@ public class ChuteTileEntity extends SmartTileEntity implements IHaveGoggleInfor
 		AxisAlignedBB searchArea =
 			new AxisAlignedBB(center.add(0, -bottomPullDistance - 0.5, 0), center.add(0, -0.5, 0)).grow(.45f);
 		for (ItemEntity itemEntity : world.getEntitiesWithinAABB(ItemEntity.class, searchArea)) {
+			if (!itemEntity.isAlive())
+				continue;
 			setItem(itemEntity.getItem()
 				.copy(),
 				(float) (itemEntity.getBoundingBox()


### PR DESCRIPTION
Previously you were able to duplicate blocks by using the replace method of the blockzapper on a chunk that was protected via FTBChunks by a different player.
This addresses those issues and adds a check if the player can actually place blocks at the given position.

I've also implemented the fix @Snownee has created for the 1.15 version of the game concerning item chutes

If there's better ways to accomplish what I've done please let me know and I'll be happy to change things!