### PR TITLE
Repair renamed recipes

### DIFF
--- a/src/main/resources/data/create/recipes/compat/atmospheric/milling/hot_monkey_brush.json
+++ b/src/main/resources/data/create/recipes/compat/atmospheric/milling/hot_monkey_brush.json
@@ -8,7 +8,7 @@
   "type": "create:milling",
   "ingredients": [
     {
-      "item": "atmospheric:monkey_brush"
+      "item": "atmospheric:hot_monkey_brush"
     }
   ],
   "results": [

--- a/src/main/resources/data/create/recipes/compat/endergetic/cutting/poise_stem.json
+++ b/src/main/resources/data/create/recipes/compat/endergetic/cutting/poise_stem.json
@@ -13,7 +13,7 @@
     ],
 	"results": [
 		{
-			"item": "endergetic:poise_stem_stripped",
+			"item": "endergetic:stripped_poise_stem",
 			"count": 1
 		}
 	],

--- a/src/main/resources/data/create/recipes/compat/endergetic/cutting/stripped_poise_stem.json
+++ b/src/main/resources/data/create/recipes/compat/endergetic/cutting/stripped_poise_stem.json
@@ -8,7 +8,7 @@
     "type": "create:cutting",
     "ingredients": [
     	{
-    		"item": "endergetic:poise_stem_stripped"
+    		"item": "endergetic:stripped_poise_stem"
     	}
     ],
 	"results": [

--- a/src/main/resources/data/create/recipes/compat/upgrade_aquatic/cutting/driftwood_log.json
+++ b/src/main/resources/data/create/recipes/compat/upgrade_aquatic/cutting/driftwood_log.json
@@ -13,7 +13,7 @@
     ],
 	"results": [
 		{
-			"item": "upgrade_aquatic:driftwood_log_stripped",
+			"item": "upgrade_aquatic:stripped_driftwood_log",
 			"count": 1
 		}
 	],

--- a/src/main/resources/data/create/recipes/compat/upgrade_aquatic/cutting/stripped_driftwood_log.json
+++ b/src/main/resources/data/create/recipes/compat/upgrade_aquatic/cutting/stripped_driftwood_log.json
@@ -8,7 +8,7 @@
     "type": "create:cutting",
     "ingredients": [
     	{
-    		"item": "upgrade_aquatic:driftwood_log_stripped"
+    		"item": "upgrade_aquatic:stripped_driftwood_log"
     	}
     ],
 	"results": [

--- a/src/main/resources/data/create/recipes/compat/upgrade_aquatic/milling/pink_searocket.json
+++ b/src/main/resources/data/create/recipes/compat/upgrade_aquatic/milling/pink_searocket.json
@@ -8,7 +8,7 @@
   "type": "create:milling",
   "ingredients": [
     {
-      "item": "upgrade_aquatic:searocket_pink"
+      "item": "upgrade_aquatic:pink_searocket"
     }
   ],
   "results": [

--- a/src/main/resources/data/create/recipes/compat/upgrade_aquatic/milling/white_searocket.json
+++ b/src/main/resources/data/create/recipes/compat/upgrade_aquatic/milling/white_searocket.json
@@ -8,7 +8,7 @@
   "type": "create:milling",
   "ingredients": [
     {
-      "item": "upgrade_aquatic:searocket_white"
+      "item": "upgrade_aquatic:white_searocket"
     }
   ],
   "results": [


### PR DESCRIPTION
Fixes for #987 and parts of #1022 caused by some internal item name changes in Upgrade Aquatic, Endergetic, and Atmospheric between 1.15 and 1.16.