### PR TITLE
[Bugfix] Make omnidirectional entity crushing more consistent.

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/components/crusher/CrushingWheelControllerTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/crusher/CrushingWheelControllerTileEntity.java
@@ -20,6 +20,7 @@ import com.simibubi.create.foundation.utility.VecHelper;
 
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.item.ItemEntity;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.ItemStack;
@@ -199,12 +200,25 @@ public class CrushingWheelControllerTileEntity extends SmartTileEntity {
 			return;
 
 		if (!(processingEntity instanceof ItemEntity)) {
+			Vec3d entityOutPos = outPos.add(facing.getAxis() == Axis.X ? .5f * offset : 0f
+					, facing.getAxis() == Axis.Y ? .5f * offset : 0f
+					, facing.getAxis() == Axis.Z ? .5f * offset : 0f);
+			int crusherDamage = AllConfigs.SERVER.kinetics.crushingDamage.get();
+
+			if (processingEntity instanceof LivingEntity) {
+				if ((((LivingEntity) processingEntity).getHealth() - crusherDamage <= 0)	//Takes LivingEntity instances as exception, so it can move them before it would kill them.
+						&& (((LivingEntity) processingEntity).hurtTime <= 0)) {				//This way it can actually output the items to the right spot.
+					processingEntity.setPosition(entityOutPos.x
+							, entityOutPos.y
+							, entityOutPos.z);
+				}
+			}
 			processingEntity.attackEntityFrom(CrushingWheelTileEntity.damageSource,
-					AllConfigs.SERVER.kinetics.crushingDamage.get());
+					crusherDamage);
 			if (!processingEntity.isAlive()) {
-				processingEntity.setPosition(outPos.x + (facing.getAxis() == Axis.X ? .75f * offset : 0f)	//This is supposed to move the mobs to the output location
-						, outPos.y + (facing.getAxis() == Axis.Y ? .75f * offset : 0f)						//So the item drops end up on the other end
-						, outPos.z + (facing.getAxis() == Axis.Z ? .75f * offset : 0f));						//This, however, does not currently work consistently for non-downwards crushers.
+				processingEntity.setPosition(entityOutPos.x
+						, entityOutPos.y
+						, entityOutPos.z);
 			}
 			return;
 		}

--- a/src/main/java/com/simibubi/create/content/contraptions/components/crusher/CrushingWheelTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/crusher/CrushingWheelTileEntity.java
@@ -3,10 +3,13 @@ package com.simibubi.create.content.contraptions.components.crusher;
 import com.simibubi.create.content.contraptions.base.KineticTileEntity;
 import com.simibubi.create.foundation.utility.Iterate;
 
+import net.minecraft.entity.item.ItemEntity;
 import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.Direction;
 import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.util.math.Vec3d;
+import net.minecraftforge.event.entity.living.LivingDropsEvent;
 import net.minecraftforge.event.entity.living.LootingLevelEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
@@ -50,6 +53,16 @@ public class CrushingWheelTileEntity extends KineticTileEntity {
 		if (event.getDamageSource() != damageSource)
 			return;
 		event.setLootingLevel(2);		//This does not currently increase mob drops. It seems like this only works for damage done by an entity.
+	}
+
+	@SubscribeEvent
+	public static void handleCrushedMobDrops(LivingDropsEvent event) {
+		if (event.getSource() != CrushingWheelTileEntity.damageSource)
+			return;
+		Vec3d outSpeed = Vec3d.ZERO;
+		for (ItemEntity outputItem : event.getDrops()) {
+			outputItem.setMotion(outSpeed);
+		}
 	}
 
 }

--- a/src/main/java/com/simibubi/create/content/contraptions/components/crusher/CrushingWheelTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/crusher/CrushingWheelTileEntity.java
@@ -7,7 +7,6 @@ import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.Direction;
 import net.minecraft.util.math.AxisAlignedBB;
-import net.minecraftforge.event.entity.living.LivingDeathEvent;
 import net.minecraftforge.event.entity.living.LootingLevelEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
@@ -50,14 +49,7 @@ public class CrushingWheelTileEntity extends KineticTileEntity {
 	public static void crushingIsFortunate(LootingLevelEvent event) {
 		if (event.getDamageSource() != damageSource)
 			return;
-		event.setLootingLevel(2);
-	}
-
-	@SubscribeEvent
-	public static void crushingTeleportsEntities(LivingDeathEvent event) {
-		if (event.getSource() != damageSource)
-			return;
-		event.getEntity().setPos(event.getEntity().getX(), Math.floor(event.getEntity().getY()) - .5f, event.getEntity().getZ());
+		event.setLootingLevel(2);		//This does not currently increase mob drops. It seems like this only works for damage done by an entity.
 	}
 
 }


### PR DESCRIPTION
- Makes it so crushers check whether the next hit would kill a living entity so it can teleport them before actually killing them, so the mob drops end up in the output location significantly more reliably.
- Also removes velocity of items dropped by crushed entities so they neatly land on belts rather than exploding everywhere.