### PR TITLE
allow smart chute to transfer whole stacks

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/block/chute/ChuteTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/chute/ChuteTileEntity.java
@@ -72,6 +72,7 @@ public class ChuteTileEntity extends SmartTileEntity implements IHaveGoggleInfor
 	ChuteItemHandler itemHandler;
 	LazyOptional<IItemHandler> lazyHandler;
 	boolean canPickUpItems;
+	boolean canFilterItems;
 
 	float bottomPullDistance;
 	float beltBelowOffset;
@@ -90,6 +91,7 @@ public class ChuteTileEntity extends SmartTileEntity implements IHaveGoggleInfor
 		itemHandler = new ChuteItemHandler(this);
 		lazyHandler = LazyOptional.of(() -> itemHandler);
 		canPickUpItems = false;
+		canFilterItems = false;
 		capAbove = LazyOptional.empty();
 		capBelow = LazyOptional.empty();
 		bottomPullDistance = 0;
@@ -331,7 +333,7 @@ public class ChuteTileEntity extends SmartTileEntity implements IHaveGoggleInfor
 		IItemHandler inv = capAbove.orElse(null);
 		Predicate<ItemStack> canAccept = this::canAcceptItem;
 		if (count == 0) {
-			item = ItemHelper.extract(inv, canAccept, ExtractionCountMode.UPTO, 16, false);
+			item = ItemHelper.extract(inv, canAccept, ExtractionCountMode.UPTO, canFilterItems ? 64 : 16, false);
 			return;
 		}
 
@@ -351,7 +353,7 @@ public class ChuteTileEntity extends SmartTileEntity implements IHaveGoggleInfor
 		Predicate<ItemStack> canAccept = this::canAcceptItem;
 
 		if (count == 0) {
-			item = ItemHelper.extract(inv, canAccept, ExtractionCountMode.UPTO, 16, false);
+			item = ItemHelper.extract(inv, canAccept, ExtractionCountMode.UPTO, canFilterItems ? 64 : 16, false);
 			return;
 		}
 

--- a/src/main/java/com/simibubi/create/content/logistics/block/chute/SmartChuteTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/chute/SmartChuteTileEntity.java
@@ -17,6 +17,7 @@ public class SmartChuteTileEntity extends ChuteTileEntity {
 
 	public SmartChuteTileEntity(TileEntityType<?> tileEntityTypeIn) {
 		super(tileEntityTypeIn);
+		canFilterItems = true;
 	}
 
 	@Override


### PR DESCRIPTION
As new the smart chute takes over the responsibility of vertical brass funnel, it is supposed to transfer 64 items per operation when item count is set to [*]. Just like andesite funnel can transfer 1 item per operation but brass funnel can transfer 64 items. Analogous to that, normal chute transfers 16 items per operation and smart chute should be able to transfer 64 items per operation.

But this was not implemented in code and both normal chute and smart chute transferred same amount of items. This PR solves that.



https://user-images.githubusercontent.com/1235888/113484143-8fb05480-94c8-11eb-9cb7-dbe8d1b21b8e.mp4

