### PR TITLE
Heat, Friction, Lubricant

### DIFF
--- a/src/generated/resources/assets/create/lang/en_us.json
+++ b/src/generated/resources/assets/create/lang/en_us.json
@@ -717,6 +717,8 @@
 	"create.generic.unit.rpm": "RPM",
 	"create.generic.unit.stress": "su",
 	"create.generic.unit.degrees": "°",
+	"create.generic.unit.heat": "°C",
+	"create.generic.unit.friction": "cμ",
 	"create.generic.unit.millibuckets": "%1$smB",
 	"create.generic.clockwise": "Clockwise",
 	"create.generic.counter_clockwise": "Counter-Clockwise",
@@ -830,6 +832,8 @@
 
 	"create.gui.goggles.generator_stats": "Generator Stats:",
 	"create.gui.goggles.kinetic_stats": "Kinetic Stats:",
+	"create.gui.goggles.heat_stats": "Heat Stats:",
+	"create.gui.goggles.friction_stats": "Friction Stats:",
 	"create.gui.goggles.at_current_speed": "at current speed",
 	"create.gui.goggles.pole_length": "Pole Length:",
 	"create.gui.goggles.fluid_container": "Fluid Container Info:",

--- a/src/main/java/com/simibubi/create/AllItems.java
+++ b/src/main/java/com/simibubi/create/AllItems.java
@@ -17,6 +17,7 @@ import com.simibubi.create.content.contraptions.components.structureMovement.mou
 import com.simibubi.create.content.contraptions.components.structureMovement.train.MinecartCouplingItem;
 import com.simibubi.create.content.contraptions.goggles.GogglesItem;
 import com.simibubi.create.content.contraptions.goggles.GogglesModel;
+import com.simibubi.create.content.contraptions.lubricant.LubricantItem;
 import com.simibubi.create.content.contraptions.processing.burner.BlazeBurnerBlockItem;
 import com.simibubi.create.content.contraptions.relays.belt.item.BeltConnectorItem;
 import com.simibubi.create.content.contraptions.relays.gearbox.VerticalGearboxItem;
@@ -272,6 +273,10 @@ public class AllItems {
 		.transform(CreateRegistrate.customRenderedItem(() -> ExtendoGripModel::new))
 		.model(AssetLookup.itemModelWithPartials())
 		.register();
+
+	public static final ItemEntry<LubricantItem> LUBRICANT = REGISTRATE.item("lubricant", LubricantItem::new)
+			.lang("Lubricant")
+			.register();
 
 	// Schematics
 

--- a/src/main/java/com/simibubi/create/content/contraptions/base/IFriction.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/base/IFriction.java
@@ -1,0 +1,37 @@
+package com.simibubi.create.content.contraptions.base;
+
+public interface IFriction {
+
+    /**
+     * Get Friction of Object ~Jayson.json
+     */
+    float getFriction();
+
+    /**
+     * Amount of how much Friction the Object generates,
+     * a Mixer might Produce more than a normal Gear, as example
+     * ~Jayson.json
+     */
+    float frictionGeneration();
+    void setFriction(float friction);
+
+    /**
+     * Checks if Object has Friction, moving Objects should have Friction if they have a Neighbour ~Jayson.json
+     */
+    default boolean hasFriction() {
+        return getFriction() > 0;
+    }
+
+    boolean frictionAble();
+
+    float getLubricantAmount();
+    void setLubricantAmount(float lubricant);
+
+    default void increaseLubricantAmount(float increament) {
+        setLubricantAmount(getLubricantAmount() + increament);
+    }
+
+    default void decreaseLubricantAmount(float decreament) {
+        increaseLubricantAmount(decreament / -1);
+    }
+}

--- a/src/main/java/com/simibubi/create/content/contraptions/base/IHeat.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/base/IHeat.java
@@ -1,0 +1,48 @@
+package com.simibubi.create.content.contraptions.base;
+
+import net.minecraft.util.text.TextFormatting;
+
+public interface IHeat {
+
+    /**
+     * Get Text Color based on Heat Amount,
+     * Over Half: {@link TextFormatting} DARK_RED
+     * Under Half: {@link TextFormatting} RED
+     * ~Jayson.json
+     */
+    default TextFormatting getHeatTextColor() {
+        return getHeat() > (getMaxHeat() / 2) ? TextFormatting.DARK_RED : TextFormatting.RED;
+    }
+
+    /**
+     * Checks if given Object has a heat value greater than 0
+     * ~Jayson.json
+     */
+    default boolean hasHeat() {
+        return getHeat() > 0;
+    }
+
+    /**
+     * If the given Object should even be heatable
+     * ~Jayson.json
+     */
+    boolean heatAble();
+
+    /**
+     * Returns the Heat value as a float (°C)
+     * ~Jayson.json
+     */
+    float getHeat();
+
+    /**
+     * Max heat of Object, before it breaks ~Jayson.json
+     */
+    float getMaxHeat();
+
+    /**
+     * Amount of how much Heat the Object generates,
+     * a Furnace might produce more than a Dirt Block as example
+     * ~Jayson.json
+     */
+    float heatGeneration();
+}

--- a/src/main/java/com/simibubi/create/content/contraptions/lubricant/LubricantItem.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/lubricant/LubricantItem.java
@@ -1,0 +1,30 @@
+package com.simibubi.create.content.contraptions.lubricant;
+
+import com.simibubi.create.content.contraptions.base.IFriction;
+import net.minecraft.block.BlockState;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemUseContext;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.ActionResultType;
+import net.minecraft.world.World;
+
+public class LubricantItem extends Item {
+
+    public LubricantItem(Properties properties) {
+        super(properties);
+    }
+
+    @Override
+    public ActionResultType onItemUse(ItemUseContext context) {
+        World world = context.getWorld();
+        BlockState state = world.getBlockState(context.getPos());
+        TileEntity tileEntity = state.hasTileEntity() ? world.getTileEntity(context.getPos()) : null;
+        if(tileEntity != null) {
+            if(tileEntity instanceof IFriction) {
+                IFriction frictionTE = (IFriction) tileEntity;
+                frictionTE.increaseLubricantAmount(0.1f);
+            }
+        }
+        return ActionResultType.PASS;
+    }
+}


### PR DESCRIPTION
First of to say, i didn't use Forge since the 1.12.2 and this was more of an experiment.

It's simple and needs _alot_ of improvement, but it gives away the way of adding heat, friction and lubricants.

As i said, it's the simple version. I didn't want to create a complex one, since i don't know if you guys like this idea.

At it's current state;
Heat is influenced by Friction and Speed.
Friction is influenced by Speed and Lubricant.
Lubricant is a liquid which you can add either using an Item or splash it into the machines using some sort of liquid gun. (on both ways, it will of course consume an amount of the liquid)

I didn't add Lubricants as liquids yet, but that's something that could be done. Each Lubricant is an own liquid (oil, as example) with an own Lubricant strength which decreases the Friction even more.
The speed of a Machine could also be influenced by a Lubricant, if a lubricant is extremly dense, the speed could slow down

The faster a Machine is, the more Heat and Friction it will generate but Lubricant also gets removed faster.
If it's raining, the removement of Lubricant is increased

Data such as Heat, Friction and Lubricants are hardcoded inside the TileEntity but could surely be replaced with Capabilities

Units:
°C - normal Celsius
cμ - Create Friction
mB - normal Millibuckets