### PR TITLE
Update obsidian.json

### DIFF
--- a/src/generated/resources/data/create/recipes/crushing/obsidian.json
+++ b/src/generated/resources/data/create/recipes/crushing/obsidian.json
@@ -10,7 +10,7 @@
       "item": "create:powdered_obsidian"
     },
     {
-      "item": "minecraft:obsidian",
+      "item": "create:powdered_obsidian",
       "chance": 0.75
     }
   ],


### PR DESCRIPTION
Seems odd that you'd have a 75% chance to get your input materials back. Possibly a copy/paste error? I assume this was intended to be an additional chance at powdered obsidian.