### PR TITLE
Bumping registrate version to fix incompatibility with mojmap mods

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,7 +116,7 @@ configurations {
 dependencies {
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
 
-    def registrate = "com.tterrag.registrate:Registrate:MC1.16.2-${registrate_version}"
+    def registrate = "com.tterrag.registrate:Registrate:MC1.16.5-${registrate_version}"
     implementation fg.deobf(registrate)
     shade registrate
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ minecraft_version=1.16.5
 forge_version=36.0.42
 
 # dependency versions
-registrate_version=1.0.0-beta.33
+registrate_version=1.0.4
 jei_version=7.6.1.71
 
 # curseforge information


### PR DESCRIPTION
### Bumping registrate to newest build to fix incompatibility with mojmap.  

Developing mods with create compatibility is not possible with mojmaps at is current state.  
Create will crash due to a bug that was fixed in Registrate one week ago in version MC1.16.5-1.0.4:  
Fixed: https://github.com/tterrag1098/Registrate/pull/29
  
Error: https://gist.github.com/EwyBoy/543342c8d8ac2ebb43590f0745905ac0#file-error-log

This will help developers develop content and mod compatibility for Create as more people transition to mojmap.