### PR TITLE
Cleanup and Refactoring

### DIFF
--- a/src/main/java/com/simibubi/create/AllBlocks.java
+++ b/src/main/java/com/simibubi/create/AllBlocks.java
@@ -203,7 +203,7 @@ import net.minecraftforge.common.ToolType;
 public class AllBlocks {
 
 	private static final CreateRegistrate REGISTRATE = Create.registrate()
-		.itemGroup(() -> Create.baseCreativeTab);
+		.itemGroup(() -> Create.BASE_CREATIVE_TAB);
 
 	// Schematics
 

--- a/src/main/java/com/simibubi/create/AllBlocks.java
+++ b/src/main/java/com/simibubi/create/AllBlocks.java
@@ -9,8 +9,6 @@ import static com.simibubi.create.foundation.data.CreateRegistrate.connectedText
 import static com.simibubi.create.foundation.data.ModelGen.customItemModel;
 import static com.simibubi.create.foundation.data.ModelGen.oxidizedItemModel;
 
-import java.util.Vector;
-
 import com.simibubi.create.AllTags.AllBlockTags;
 import com.simibubi.create.AllTags.AllItemTags;
 import com.simibubi.create.content.AllSections;
@@ -627,13 +625,12 @@ public class AllBlocks {
 			.transform(BuilderTransformers.valveHandle(null))
 			.register();
 
-	public static final Vector<BlockEntry<ValveHandleBlock>> DYED_VALVE_HANDLES =
-		new Vector<>(DyeColor.values().length);
+	public static final BlockEntry<?>[] DYED_VALVE_HANDLES = new BlockEntry<?>[DyeColor.values().length];
 
 	static {
 		for (DyeColor colour : DyeColor.values()) {
 			String colourName = colour.getString();
-			DYED_VALVE_HANDLES.add(REGISTRATE.block(colourName + "_valve_handle", ValveHandleBlock::dyed)
+			DYED_VALVE_HANDLES[colour.ordinal()] = REGISTRATE.block(colourName + "_valve_handle", ValveHandleBlock::dyed)
 				.transform(BuilderTransformers.valveHandle(colour))
 				.recipe((c, p) -> ShapedRecipeBuilder.shapedRecipe(c.get())
 					.patternLine("#")
@@ -642,7 +639,7 @@ public class AllBlocks {
 					.key('-', AllItemTags.VALVE_HANDLES.tag)
 					.addCriterion("has_valve", RegistrateRecipeProvider.hasItem(AllItemTags.VALVE_HANDLES.tag))
 					.build(p, Create.asResource("crafting/kinetics/" + c.getName() + "_from_other_valve_handle")))
-				.register());
+				.register();
 		}
 	}
 

--- a/src/main/java/com/simibubi/create/AllColorHandlers.java
+++ b/src/main/java/com/simibubi/create/AllColorHandlers.java
@@ -3,46 +3,38 @@ package com.simibubi.create;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.simibubi.create.foundation.block.IBlockVertexColor;
-import com.simibubi.create.foundation.block.render.ColoredVertexModel;
-
 import net.minecraft.block.Block;
-import net.minecraft.block.BlockState;
 import net.minecraft.block.RedstoneWireBlock;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.color.BlockColors;
 import net.minecraft.client.renderer.color.IBlockColor;
 import net.minecraft.client.renderer.color.IItemColor;
 import net.minecraft.client.renderer.color.ItemColors;
-import net.minecraft.item.ItemStack;
 import net.minecraft.state.properties.BlockStateProperties;
 import net.minecraft.util.IItemProvider;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.GrassColors;
-import net.minecraft.world.IBlockDisplayReader;
 import net.minecraft.world.biome.BiomeColors;
+import net.minecraftforge.client.event.ColorHandlerEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public class AllColorHandlers {
 
-	private final Map<Block, IBlockVertexColor> coloredVertexBlocks = new HashMap<>();
 	private final Map<Block, IBlockColor> coloredBlocks = new HashMap<>();
 	private final Map<IItemProvider, IItemColor> coloredItems = new HashMap<>();
 
 	//
 
 	public static IBlockColor getGrassyBlock() {
-		return new BlockColor(
-			(state, world, pos, layer) -> pos != null && world != null ? BiomeColors.getGrassColor(world, pos)
-				: GrassColors.get(0.5D, 1.0D));
+		return (state, world, pos, layer) -> pos != null && world != null ? BiomeColors.getGrassColor(world, pos)
+				: GrassColors.get(0.5D, 1.0D);
 	}
 
 	public static IItemColor getGrassyItem() {
-		return new ItemColor((stack, layer) -> GrassColors.get(0.5D, 1.0D));
+		return (stack, layer) -> GrassColors.get(0.5D, 1.0D);
 	}
 
 	public static IBlockColor getRedstonePower() {
-		return new BlockColor((state, world, pos, layer) -> RedstoneWireBlock
-			.getWireColor(pos != null && world != null ? state.get(BlockStateProperties.POWER_0_15) : 0));
+		return (state, world, pos, layer) -> RedstoneWireBlock
+			.getWireColor(pos != null && world != null ? state.get(BlockStateProperties.POWER_0_15) : 0);
 	}
 
 	//
@@ -51,66 +43,22 @@ public class AllColorHandlers {
 		coloredBlocks.put(block, color);
 	}
 
-	public void register(Block block, IBlockVertexColor color) {
-		coloredVertexBlocks.put(block, color);
-	}
-
 	public void register(IItemProvider item, IItemColor color) {
 		coloredItems.put(item, color);
 	}
 
-	public void init() {
-		BlockColors blockColors = Minecraft.getInstance()
-			.getBlockColors();
-		ItemColors itemColors = Minecraft.getInstance()
-			.getItemColors();
-
-		coloredBlocks.forEach((block, color) -> blockColors.register(color, block));
-		coloredItems.forEach((item, color) -> itemColors.register(color, item));
-		coloredVertexBlocks.forEach((block, color) -> CreateClient.getCustomBlockModels()
-			.register(() -> block, model -> new ColoredVertexModel(model, color)));
-	}
-
 	//
 
-	private static class ItemColor implements IItemColor {
-
-		private Function function;
-
-		@FunctionalInterface
-		interface Function {
-			int apply(ItemStack stack, int layer);
-		}
-
-		public ItemColor(Function function) {
-			this.function = function;
-		}
-
-		@Override
-		public int getColor(ItemStack stack, int layer) {
-			return function.apply(stack, layer);
-		}
-
+	@SubscribeEvent
+	public void registerBlockColors(ColorHandlerEvent.Block event) {
+		BlockColors blockColors = event.getBlockColors();
+		coloredBlocks.forEach((block, color) -> blockColors.register(color, block));
 	}
 
-	private static class BlockColor implements IBlockColor {
-
-		private Function function;
-
-		@FunctionalInterface
-		interface Function {
-			int apply(BlockState state, IBlockDisplayReader world, BlockPos pos, int layer);
-		}
-
-		public BlockColor(Function function) {
-			this.function = function;
-		}
-
-		@Override
-		public int getColor(BlockState state, IBlockDisplayReader world, BlockPos pos, int layer) {
-			return function.apply(state, world, pos, layer);
-		}
-
+	@SubscribeEvent
+	public void registerItemColors(ColorHandlerEvent.Item event) {
+		ItemColors itemColors = event.getItemColors();
+		coloredItems.forEach((item, color) -> itemColors.register(color, item));
 	}
 
 }

--- a/src/main/java/com/simibubi/create/AllContainerTypes.java
+++ b/src/main/java/com/simibubi/create/AllContainerTypes.java
@@ -10,61 +10,36 @@ import com.simibubi.create.content.schematics.block.SchematicTableContainer;
 import com.simibubi.create.content.schematics.block.SchematicTableScreen;
 import com.simibubi.create.content.schematics.block.SchematicannonContainer;
 import com.simibubi.create.content.schematics.block.SchematicannonScreen;
-import com.simibubi.create.foundation.utility.Lang;
+import com.tterrag.registrate.builders.ContainerBuilder.ForgeContainerFactory;
+import com.tterrag.registrate.builders.ContainerBuilder.ScreenFactory;
+import com.tterrag.registrate.util.entry.ContainerEntry;
+import com.tterrag.registrate.util.nullness.NonNullSupplier;
 
 import net.minecraft.client.gui.IHasContainer;
-import net.minecraft.client.gui.ScreenManager;
-import net.minecraft.client.gui.ScreenManager.IScreenFactory;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.inventory.container.Container;
-import net.minecraft.inventory.container.ContainerType;
-import net.minecraft.inventory.container.ContainerType.IFactory;
-import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
-import net.minecraftforge.event.RegistryEvent;
-import net.minecraftforge.fml.network.IContainerFactory;
 
-public enum AllContainerTypes {
+public class AllContainerTypes {
 
-	SCHEMATIC_TABLE(SchematicTableContainer::new),
-	SCHEMATICANNON(SchematicannonContainer::new),
-	FLEXCRATE(AdjustableCrateContainer::new),
-	FILTER(FilterContainer::new),
-	ATTRIBUTE_FILTER(AttributeFilterContainer::new),
+	public static final ContainerEntry<SchematicTableContainer> SCHEMATIC_TABLE =
+		register("schematic_table", SchematicTableContainer::new, () -> SchematicTableScreen::new);
 
-	;
+	public static final ContainerEntry<SchematicannonContainer> SCHEMATICANNON =
+		register("schematicannon", SchematicannonContainer::new, () -> SchematicannonScreen::new);
 
-	public ContainerType<? extends Container> type;
-	private IFactory<?> factory;
+	public static final ContainerEntry<AdjustableCrateContainer> FLEXCRATE =
+		register("flexcrate", AdjustableCrateContainer::new, () -> AdjustableCrateScreen::new);
 
-	private <C extends Container> AllContainerTypes(IContainerFactory<C> factory) {
-		this.factory = factory;
+	public static final ContainerEntry<FilterContainer> FILTER =
+		register("filter", FilterContainer::new, () -> FilterScreen::new);
+
+	public static final ContainerEntry<AttributeFilterContainer> ATTRIBUTE_FILTER =
+		register("attribute_filter", AttributeFilterContainer::new, () -> AttributeFilterScreen::new);
+
+	private static <C extends Container, S extends Screen & IHasContainer<C>> ContainerEntry<C> register(String name, ForgeContainerFactory<C> factory, NonNullSupplier<ScreenFactory<C, S>> screenFactory) {
+		return Create.registrate().container(name, factory, screenFactory).register();
 	}
 
-	public static void register(RegistryEvent.Register<ContainerType<?>> event) {
-		for (AllContainerTypes container : values()) {
-			container.type = new ContainerType<>(container.factory)
-				.setRegistryName(new ResourceLocation(Create.ID, Lang.asId(container.name())));
-			event.getRegistry()
-				.register(container.type);
-		}
-	}
-
-	@OnlyIn(Dist.CLIENT)
-	public static void registerScreenFactories() {
-		bind(SCHEMATIC_TABLE, SchematicTableScreen::new);
-		bind(SCHEMATICANNON, SchematicannonScreen::new);
-		bind(FLEXCRATE, AdjustableCrateScreen::new);
-		bind(FILTER, FilterScreen::new);
-		bind(ATTRIBUTE_FILTER, AttributeFilterScreen::new);
-	}
-
-	@OnlyIn(Dist.CLIENT)
-	@SuppressWarnings("unchecked")
-	private static <C extends Container, S extends Screen & IHasContainer<C>> void bind(AllContainerTypes c,
-		IScreenFactory<C, S> factory) {
-		ScreenManager.registerFactory((ContainerType<C>) c.type, factory);
-	}
+	public static void register() {}
 
 }

--- a/src/main/java/com/simibubi/create/AllEntityTypes.java
+++ b/src/main/java/com/simibubi/create/AllEntityTypes.java
@@ -10,43 +10,47 @@ import com.simibubi.create.content.contraptions.components.structureMovement.gan
 import com.simibubi.create.content.contraptions.components.structureMovement.glue.SuperGlueEntity;
 import com.simibubi.create.content.contraptions.components.structureMovement.glue.SuperGlueRenderer;
 import com.simibubi.create.foundation.utility.Lang;
-import com.tterrag.registrate.util.entry.RegistryEntry;
+import com.tterrag.registrate.util.entry.EntityEntry;
 import com.tterrag.registrate.util.nullness.NonNullConsumer;
+import com.tterrag.registrate.util.nullness.NonNullSupplier;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityClassification;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.EntityType.IFactory;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
-import net.minecraftforge.fml.client.registry.RenderingRegistry;
+import net.minecraftforge.fml.client.registry.IRenderFactory;
 
 public class AllEntityTypes {
 
-	public static final RegistryEntry<EntityType<OrientedContraptionEntity>> ORIENTED_CONTRAPTION =
-		contraption("contraption", OrientedContraptionEntity::new, 5, 3, true);
-	public static final RegistryEntry<EntityType<ControlledContraptionEntity>> CONTROLLED_CONTRAPTION =
-		contraption("stationary_contraption", ControlledContraptionEntity::new, 20, 40, false);
-	public static final RegistryEntry<EntityType<GantryContraptionEntity>> GANTRY_CONTRAPTION =
-		contraption("gantry_contraption", GantryContraptionEntity::new, 10, 40, false);
+	public static final EntityEntry<OrientedContraptionEntity> ORIENTED_CONTRAPTION =
+		contraption("contraption", OrientedContraptionEntity::new, () -> OrientedContraptionEntityRenderer::new,
+			5, 3, true);
+	public static final EntityEntry<ControlledContraptionEntity> CONTROLLED_CONTRAPTION =
+		contraption("stationary_contraption", ControlledContraptionEntity::new, () -> ContraptionEntityRenderer::new,
+			20, 40, false);
+	public static final EntityEntry<GantryContraptionEntity> GANTRY_CONTRAPTION =
+		contraption("gantry_contraption", GantryContraptionEntity::new, () -> ContraptionEntityRenderer::new,
+			10, 40, false);
 
-	public static final RegistryEntry<EntityType<SuperGlueEntity>> SUPER_GLUE = register("super_glue",
-		SuperGlueEntity::new, EntityClassification.MISC, 10, Integer.MAX_VALUE, false, true, SuperGlueEntity::build);
-	public static final RegistryEntry<EntityType<SeatEntity>> SEAT = register("seat", SeatEntity::new,
-		EntityClassification.MISC, 0, Integer.MAX_VALUE, false, true, SeatEntity::build);
+	public static final EntityEntry<SuperGlueEntity> SUPER_GLUE =
+		register("super_glue", SuperGlueEntity::new, () -> SuperGlueRenderer::new,
+			EntityClassification.MISC, 10, Integer.MAX_VALUE, false, true, SuperGlueEntity::build);
+	public static final EntityEntry<SeatEntity> SEAT =
+		register("seat", SeatEntity::new, () -> SeatEntity.Render::new,
+			EntityClassification.MISC, 0, Integer.MAX_VALUE, false, true, SeatEntity::build);
 
 	//
 
-	public static void register() {}
-
-	private static <T extends Entity> RegistryEntry<EntityType<T>> contraption(String name, IFactory<T> factory,
-		int range, int updateFrequency, boolean sendVelocity) {
-		return register(name, factory, EntityClassification.MISC, range, updateFrequency, sendVelocity, true,
-			AbstractContraptionEntity::build);
+	private static <T extends Entity> EntityEntry<T> contraption(String name, IFactory<T> factory,
+		NonNullSupplier<IRenderFactory<? super T>> renderer, int range, int updateFrequency,
+		boolean sendVelocity) {
+		return register(name, factory, renderer, EntityClassification.MISC, range, updateFrequency,
+			sendVelocity, true, AbstractContraptionEntity::build);
 	}
 
-	private static <T extends Entity> RegistryEntry<EntityType<T>> register(String name, IFactory<T> factory,
-		EntityClassification group, int range, int updateFrequency, boolean sendVelocity, boolean immuneToFire,
+	private static <T extends Entity> EntityEntry<T> register(String name, IFactory<T> factory,
+		NonNullSupplier<IRenderFactory<? super T>> renderer, EntityClassification group, int range,
+		int updateFrequency, boolean sendVelocity, boolean immuneToFire,
 		NonNullConsumer<EntityType.Builder<T>> propertyBuilder) {
 		String id = Lang.asId(name);
 		return Create.registrate()
@@ -59,16 +63,9 @@ public class AllEntityTypes {
 				if (immuneToFire)
 					b.immuneToFire();
 			})
+			.renderer(renderer)
 			.register();
 	}
 
-	@OnlyIn(value = Dist.CLIENT)
-	public static void registerRenderers() {
-		RenderingRegistry.registerEntityRenderingHandler(CONTROLLED_CONTRAPTION.get(), ContraptionEntityRenderer::new);
-		RenderingRegistry.registerEntityRenderingHandler(ORIENTED_CONTRAPTION.get(),
-			OrientedContraptionEntityRenderer::new);
-		RenderingRegistry.registerEntityRenderingHandler(GANTRY_CONTRAPTION.get(), ContraptionEntityRenderer::new);
-		RenderingRegistry.registerEntityRenderingHandler(SUPER_GLUE.get(), SuperGlueRenderer::new);
-		RenderingRegistry.registerEntityRenderingHandler(SEAT.get(), SeatEntity.Render::new);
-	}
+	public static void register() {}
 }

--- a/src/main/java/com/simibubi/create/AllFluids.java
+++ b/src/main/java/com/simibubi/create/AllFluids.java
@@ -7,7 +7,7 @@ import com.simibubi.create.content.contraptions.fluids.potion.PotionFluid;
 import com.simibubi.create.content.contraptions.fluids.potion.PotionFluid.PotionFluidAttributes;
 import com.simibubi.create.content.palettes.AllPaletteBlocks;
 import com.simibubi.create.foundation.data.CreateRegistrate;
-import com.tterrag.registrate.util.entry.RegistryEntry;
+import com.tterrag.registrate.util.entry.FluidEntry;
 
 import net.minecraft.block.BlockState;
 import net.minecraft.client.renderer.RenderType;
@@ -25,22 +25,22 @@ public class AllFluids {
 
 	private static final CreateRegistrate REGISTRATE = Create.registrate();
 
-	public static RegistryEntry<PotionFluid> POTION =
+	public static FluidEntry<PotionFluid> POTION =
 		REGISTRATE.virtualFluid("potion", PotionFluidAttributes::new, PotionFluid::new)
 			.lang(f -> "fluid.create.potion", "Potion")
 			.register();
 
-	public static RegistryEntry<VirtualFluid> TEA = REGISTRATE.virtualFluid("tea")
+	public static FluidEntry<VirtualFluid> TEA = REGISTRATE.virtualFluid("tea")
 		.lang(f -> "fluid.create.tea", "Builder's Tea")
 		.tag(AllTags.forgeFluidTag("tea"))
 		.register();
 
-	public static RegistryEntry<VirtualFluid> MILK = REGISTRATE.virtualFluid("milk")
+	public static FluidEntry<VirtualFluid> MILK = REGISTRATE.virtualFluid("milk")
 		.lang(f -> "fluid.create.milk", "Milk")
 		.tag(AllTags.forgeFluidTag("milk"))
 		.register();
 
-	public static RegistryEntry<ForgeFlowingFluid.Flowing> HONEY =
+	public static FluidEntry<ForgeFlowingFluid.Flowing> HONEY =
 		REGISTRATE.standardFluid("honey", NoColorFluidAttributes::new)
 			.lang(f -> "fluid.create.honey", "Honey")
 			.attributes(b -> b.viscosity(500)
@@ -55,7 +55,7 @@ public class AllFluids {
 			.build()
 			.register();
 
-	public static RegistryEntry<ForgeFlowingFluid.Flowing> CHOCOLATE =
+	public static FluidEntry<ForgeFlowingFluid.Flowing> CHOCOLATE =
 		REGISTRATE.standardFluid("chocolate", NoColorFluidAttributes::new)
 			.lang(f -> "fluid.create.chocolate", "Chocolate")
 			.tag(AllTags.forgeFluidTag("chocolate"))
@@ -78,7 +78,7 @@ public class AllFluids {
 	public static void assignRenderLayers() {}
 
 	@OnlyIn(Dist.CLIENT)
-	private static void makeTranslucent(RegistryEntry<? extends ForgeFlowingFluid> entry) {
+	private static void makeTranslucent(FluidEntry<?> entry) {
 		ForgeFlowingFluid fluid = entry.get();
 		RenderTypeLookup.setRenderLayer(fluid, RenderType.getTranslucent());
 		RenderTypeLookup.setRenderLayer(fluid.getStillFluid(), RenderType.getTranslucent());

--- a/src/main/java/com/simibubi/create/AllItems.java
+++ b/src/main/java/com/simibubi/create/AllItems.java
@@ -61,7 +61,7 @@ import net.minecraft.util.ResourceLocation;
 public class AllItems {
 
 	private static final CreateRegistrate REGISTRATE = Create.registrate()
-		.itemGroup(() -> Create.baseCreativeTab);
+		.itemGroup(() -> Create.BASE_CREATIVE_TAB);
 
 	// Schematics
 

--- a/src/main/java/com/simibubi/create/AllKeys.java
+++ b/src/main/java/com/simibubi/create/AllKeys.java
@@ -9,7 +9,8 @@ import net.minecraftforge.fml.client.registry.ClientRegistry;
 
 public enum AllKeys {
 
-	TOOL_MENU("toolmenu", GLFW.GLFW_KEY_LEFT_ALT), ACTIVATE_TOOL("", GLFW.GLFW_KEY_LEFT_CONTROL),
+	TOOL_MENU("toolmenu", GLFW.GLFW_KEY_LEFT_ALT),
+	ACTIVATE_TOOL("", GLFW.GLFW_KEY_LEFT_CONTROL),
 
 	;
 

--- a/src/main/java/com/simibubi/create/AllMovementBehaviours.java
+++ b/src/main/java/com/simibubi/create/AllMovementBehaviours.java
@@ -17,12 +17,12 @@ import net.minecraft.block.Blocks;
 import net.minecraft.util.ResourceLocation;
 
 public class AllMovementBehaviours {
-	private static final HashMap<ResourceLocation, MovementBehaviour> movementBehaviours = new HashMap<>();
+	private static final HashMap<ResourceLocation, MovementBehaviour> MOVEMENT_BEHAVIOURS = new HashMap<>();
 
 	public static void addMovementBehaviour(ResourceLocation resourceLocation, MovementBehaviour movementBehaviour) {
-		if (movementBehaviours.containsKey(resourceLocation))
-			Create.logger.warn("Movement behaviour for " + resourceLocation.toString() + " was overridden");
-		movementBehaviours.put(resourceLocation, movementBehaviour);
+		if (MOVEMENT_BEHAVIOURS.containsKey(resourceLocation))
+			Create.LOGGER.warn("Movement behaviour for " + resourceLocation.toString() + " was overridden");
+		MOVEMENT_BEHAVIOURS.put(resourceLocation, movementBehaviour);
 	}
 
 	public static void addMovementBehaviour(Block block, MovementBehaviour movementBehaviour) {
@@ -31,7 +31,7 @@ public class AllMovementBehaviours {
 
 	@Nullable
 	public static MovementBehaviour of(ResourceLocation resourceLocation) {
-		return movementBehaviours.getOrDefault(resourceLocation, null);
+		return MOVEMENT_BEHAVIOURS.getOrDefault(resourceLocation, null);
 	}
 
 	@Nullable
@@ -45,7 +45,7 @@ public class AllMovementBehaviours {
 	}
 
 	public static boolean contains(Block block) {
-		return movementBehaviours.containsKey(block.getRegistryName());
+		return MOVEMENT_BEHAVIOURS.containsKey(block.getRegistryName());
 	}
 
 	public static <B extends Block> NonNullConsumer<? super B> addMovementBehaviour(

--- a/src/main/java/com/simibubi/create/AllSpecialTextures.java
+++ b/src/main/java/com/simibubi/create/AllSpecialTextures.java
@@ -2,10 +2,7 @@ package com.simibubi.create;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 
-@EventBusSubscriber(value = Dist.CLIENT)
 public enum AllSpecialTextures {
 
 	BLANK("blank.png"),

--- a/src/main/java/com/simibubi/create/AllTags.java
+++ b/src/main/java/com/simibubi/create/AllTags.java
@@ -31,7 +31,7 @@ import net.minecraftforge.fml.ModList;
 
 public class AllTags {
 	private static final CreateRegistrate REGISTRATE = Create.registrate()
-		.itemGroup(() -> Create.baseCreativeTab);
+		.itemGroup(() -> Create.BASE_CREATIVE_TAB);
 
 	public static <T extends Block, P> NonNullFunction<BlockBuilder<T, P>, ItemBuilder<BlockItem, BlockBuilder<T, P>>> tagBlockAndItem(
 		String tagName) {

--- a/src/main/java/com/simibubi/create/AllTileEntities.java
+++ b/src/main/java/com/simibubi/create/AllTileEntities.java
@@ -157,7 +157,6 @@ import com.simibubi.create.content.schematics.block.SchematicannonInstance;
 import com.simibubi.create.content.schematics.block.SchematicannonRenderer;
 import com.simibubi.create.content.schematics.block.SchematicannonTileEntity;
 import com.simibubi.create.foundation.tileEntity.renderer.SmartTileEntityRenderer;
-import com.tterrag.registrate.util.entry.BlockEntry;
 import com.tterrag.registrate.util.entry.TileEntityEntry;
 
 public class AllTileEntities {
@@ -249,7 +248,7 @@ public class AllTileEntities {
 		.tileEntity("hand_crank", HandCrankTileEntity::new)
 		.instance(() -> HandCrankInstance::new)
 		.validBlocks(AllBlocks.HAND_CRANK, AllBlocks.COPPER_VALVE_HANDLE)
-		.validBlocks(AllBlocks.DYED_VALVE_HANDLES.toArray(new BlockEntry<?>[AllBlocks.DYED_VALVE_HANDLES.size()]))
+		.validBlocks(AllBlocks.DYED_VALVE_HANDLES)
 		.renderer(() -> HandCrankRenderer::new)
 		.register();
 

--- a/src/main/java/com/simibubi/create/Create.java
+++ b/src/main/java/com/simibubi/create/Create.java
@@ -31,7 +31,6 @@ import com.simibubi.create.foundation.worldgen.AllWorldFeatures;
 import com.tterrag.registrate.util.NonNullLazyValue;
 
 import net.minecraft.data.DataGenerator;
-import net.minecraft.inventory.container.ContainerType;
 import net.minecraft.item.ItemGroup;
 import net.minecraft.item.crafting.IRecipeSerializer;
 import net.minecraft.particles.ParticleType;
@@ -57,52 +56,52 @@ public class Create {
 	public static final String NAME = "Create";
 	public static final String VERSION = "0.3.1c";
 
-	public static Logger logger = LogManager.getLogger();
-	public static ItemGroup baseCreativeTab = new CreateItemGroup();
-	public static ItemGroup palettesCreativeTab = new PalettesItemGroup();
+	public static final Logger LOGGER = LogManager.getLogger();
 
-	public static Gson GSON = new GsonBuilder().setPrettyPrinting()
+	public static final Gson GSON = new GsonBuilder().setPrettyPrinting()
 		.disableHtmlEscaping()
 		.create();
 
-	public static ServerSchematicLoader schematicReceiver;
-	public static RedstoneLinkNetworkHandler redstoneLinkNetworkHandler;
-	public static TorquePropagator torquePropagator;
-	public static ServerLagger lagger;
-	public static ChunkUtil chunkUtil;
-	public static Random random;
+	public static final ItemGroup BASE_CREATIVE_TAB = new CreateItemGroup();
+	public static final ItemGroup PALETTES_CREATIVE_TAB = new PalettesItemGroup();
 
-	private static final NonNullLazyValue<CreateRegistrate> registrate = CreateRegistrate.lazy(ID);
+	public static final ServerSchematicLoader SCHEMATIC_RECEIVER = new ServerSchematicLoader();
+	public static final RedstoneLinkNetworkHandler REDSTONE_LINK_NETWORK_HANDLER = new RedstoneLinkNetworkHandler();
+	public static final TorquePropagator TORQUE_PROPAGATOR = new TorquePropagator();
+	public static final ServerLagger LAGGER = new ServerLagger();
+	public static final ChunkUtil CHUNK_UTIL = new ChunkUtil();
+	public static final Random RANDOM = new Random();
+
+	private static final NonNullLazyValue<CreateRegistrate> REGISTRATE = CreateRegistrate.lazy(ID);
 
 	public Create() {
-		IEventBus modEventBus = FMLJavaModLoadingContext.get()
-			.getModEventBus();
-
 		AllSoundEvents.prepare();
 		AllBlocks.register();
 		AllItems.register();
 		AllFluids.register();
 		AllTags.register();
 		AllPaletteBlocks.register();
+		AllContainerTypes.register();
 		AllEntityTypes.register();
 		AllTileEntities.register();
 		AllMovementBehaviours.register();
 		AllWorldFeatures.register();
+		AllConfigs.register();
+
+		IEventBus modEventBus = FMLJavaModLoadingContext.get()
+			.getModEventBus();
+		IEventBus forgeEventBus = MinecraftForge.EVENT_BUS;
 
 		modEventBus.addListener(Create::init);
-		MinecraftForge.EVENT_BUS.addListener(EventPriority.HIGH, Create::onBiomeLoad);
 		modEventBus.addGenericListener(Feature.class, AllWorldFeatures::registerOreFeatures);
 		modEventBus.addGenericListener(Placement.class, AllWorldFeatures::registerDecoratorFeatures);
 		modEventBus.addGenericListener(IRecipeSerializer.class, AllRecipeTypes::register);
-		modEventBus.addGenericListener(ContainerType.class, AllContainerTypes::register);
 		modEventBus.addGenericListener(ParticleType.class, AllParticleTypes::register);
 		modEventBus.addGenericListener(SoundEvent.class, AllSoundEvents::register);
 		modEventBus.addListener(AllConfigs::onLoad);
 		modEventBus.addListener(AllConfigs::onReload);
 		modEventBus.addListener(EventPriority.LOWEST, this::gatherData);
-
-		AllConfigs.register();
-		random = new Random();
+		forgeEventBus.addListener(EventPriority.HIGH, Create::onBiomeLoad);
 
 		DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> CreateClient.addClientListeners(modEventBus));
 	}
@@ -110,14 +109,9 @@ public class Create {
 	public static void init(final FMLCommonSetupEvent event) {
 		CapabilityMinecartController.register();
 		SchematicInstances.register();
-		schematicReceiver = new ServerSchematicLoader();
-		redstoneLinkNetworkHandler = new RedstoneLinkNetworkHandler();
-		torquePropagator = new TorquePropagator();
-		lagger = new ServerLagger();
 
-		chunkUtil = new ChunkUtil();
-		chunkUtil.init();
-		MinecraftForge.EVENT_BUS.register(chunkUtil);
+		CHUNK_UTIL.init();
+		MinecraftForge.EVENT_BUS.register(CHUNK_UTIL);
 
 		AllPackets.registerPackets();
 		AllTriggers.register();
@@ -128,18 +122,6 @@ public class Create {
 		});
 	}
 
-	public static void onBiomeLoad(BiomeLoadingEvent event) {
-		AllWorldFeatures.reload(event);
-	}
-
-	public static CreateRegistrate registrate() {
-		return registrate.get();
-	}
-
-	public static ResourceLocation asResource(String path) {
-		return new ResourceLocation(ID, path);
-	}
-
 	public void gatherData(GatherDataEvent event) {
 		DataGenerator gen = event.getGenerator();
 		gen.addProvider(new AllAdvancements(gen));
@@ -148,6 +130,18 @@ public class Create {
 		gen.addProvider(new StandardRecipeGen(gen));
 		gen.addProvider(new MechanicalCraftingRecipeGen(gen));
 		ProcessingRecipeGen.registerAll(gen);
+	}
+
+	public static void onBiomeLoad(BiomeLoadingEvent event) {
+		AllWorldFeatures.reload(event);
+	}
+
+	public static CreateRegistrate registrate() {
+		return REGISTRATE.get();
+	}
+
+	public static ResourceLocation asResource(String path) {
+		return new ResourceLocation(ID, path);
 	}
 
 }

--- a/src/main/java/com/simibubi/create/content/contraptions/KineticDebugger.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/KineticDebugger.java
@@ -28,7 +28,7 @@ public class KineticDebugger {
 		if (!isActive()) {
 			if (KineticTileEntityRenderer.rainbowMode) {
 				KineticTileEntityRenderer.rainbowMode = false;
-				CreateClient.bufferCache.invalidate();
+				CreateClient.BUFFER_CACHE.invalidate();
 			}			
 			return;
 		}
@@ -44,7 +44,7 @@ public class KineticDebugger {
 			.getRenderShape(world, toOutline);
 
 		if (te.getTheoreticalSpeed() != 0 && !shape.isEmpty())
-			CreateClient.outliner.chaseAABB("kineticSource", shape.getBoundingBox()
+			CreateClient.OUTLINER.chaseAABB("kineticSource", shape.getBoundingBox()
 				.offset(toOutline))
 				.lineWidth(1 / 16f)
 				.colored(te.hasSource() ? ColorHelper.colorFromLong(te.network) : 0xffcc00);
@@ -54,7 +54,7 @@ public class KineticDebugger {
 			Vector3d vec = Vector3d.of(Direction.getFacingFromAxis(AxisDirection.POSITIVE, axis)
 				.getDirectionVec());
 			Vector3d center = VecHelper.getCenterOf(te.getPos());
-			CreateClient.outliner.showLine("rotationAxis", center.add(vec), center.subtract(vec))
+			CreateClient.OUTLINER.showLine("rotationAxis", center.add(vec), center.subtract(vec))
 				.lineWidth(1 / 16f);
 		}
 

--- a/src/main/java/com/simibubi/create/content/contraptions/TorquePropagator.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/TorquePropagator.java
@@ -15,12 +15,12 @@ public class TorquePropagator {
 
 	public void onLoadWorld(IWorld world) {
 		networks.put(world, new HashMap<>());
-		Create.logger.debug("Prepared Kinetic Network Space for " + WorldHelper.getDimensionID(world));
+		Create.LOGGER.debug("Prepared Kinetic Network Space for " + WorldHelper.getDimensionID(world));
 	}
 
 	public void onUnloadWorld(IWorld world) {
 		networks.remove(world);
-		Create.logger.debug("Removed Kinetic Network Space for " + WorldHelper.getDimensionID(world));
+		Create.LOGGER.debug("Removed Kinetic Network Space for " + WorldHelper.getDimensionID(world));
 	}
 
 	public KineticNetwork getOrCreateNetworkFor(KineticTileEntity te) {

--- a/src/main/java/com/simibubi/create/content/contraptions/base/KineticTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/base/KineticTileEntity.java
@@ -329,7 +329,7 @@ public abstract class KineticTileEntity extends SmartTileEntity
 	}
 
 	public KineticNetwork getOrCreateNetwork() {
-		return Create.torquePropagator.getOrCreateNetworkFor(this);
+		return Create.TORQUE_PROPAGATOR.getOrCreateNetworkFor(this);
 	}
 
 	public boolean hasNetwork() {

--- a/src/main/java/com/simibubi/create/content/contraptions/base/KineticTileEntityRenderer.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/base/KineticTileEntityRenderer.java
@@ -48,7 +48,7 @@ public class KineticTileEntityRenderer extends SafeTileEntityRenderer<KineticTil
 
 	public static void renderRotatingKineticBlock(KineticTileEntity te, BlockState renderedState, MatrixStack ms,
 		IVertexBuilder buffer, int light) {
-		SuperByteBuffer superByteBuffer = CreateClient.bufferCache.renderBlockIn(KINETIC_TILE, renderedState);
+		SuperByteBuffer superByteBuffer = CreateClient.BUFFER_CACHE.renderBlockIn(KINETIC_TILE, renderedState);
 		renderRotatingBuffer(te, superByteBuffer, ms, buffer, light);
 	}
 
@@ -120,7 +120,7 @@ public class KineticTileEntityRenderer extends SafeTileEntityRenderer<KineticTil
 	}
 
 	protected SuperByteBuffer getRotatedModel(KineticTileEntity te) {
-		return CreateClient.bufferCache.renderBlockIn(KINETIC_TILE, getRenderedBlockState(te));
+		return CreateClient.BUFFER_CACHE.renderBlockIn(KINETIC_TILE, getRenderedBlockState(te));
 	}
 
 }

--- a/src/main/java/com/simibubi/create/content/contraptions/components/crank/ValveHandleBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/crank/ValveHandleBlock.java
@@ -48,7 +48,7 @@ public class ValveHandleBlock extends HandCrankBlock {
 			if (worldIn.isRemote)
 				return ActionResultType.SUCCESS;
 
-			BlockState newState = AllBlocks.DYED_VALVE_HANDLES.get(color.ordinal())
+			BlockState newState = AllBlocks.DYED_VALVE_HANDLES[color.ordinal()]
 				.getDefaultState()
 				.with(FACING, state.get(FACING));
 			if (newState != state)

--- a/src/main/java/com/simibubi/create/content/contraptions/components/deployer/BeltDeployerCallbacks.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/deployer/BeltDeployerCallbacks.java
@@ -89,7 +89,7 @@ public class BeltDeployerCallbacks {
 					boolean centered = BeltHelper.isItemUpright(stack);
 					copy.stack = stack;
 					copy.locked = true;
-					copy.angle = centered ? 180 : Create.random.nextInt(360);
+					copy.angle = centered ? 180 : Create.RANDOM.nextInt(360);
 					return copy;
 				})
 				.collect(Collectors.toList());

--- a/src/main/java/com/simibubi/create/content/contraptions/components/millstone/MillstoneRenderer.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/millstone/MillstoneRenderer.java
@@ -16,7 +16,7 @@ public class MillstoneRenderer extends KineticTileEntityRenderer {
 
 	@Override
 	protected SuperByteBuffer getRotatedModel(KineticTileEntity te) {
-		return CreateClient.bufferCache.renderPartial(AllBlockPartials.MILLSTONE_COG, te.getBlockState());
+		return CreateClient.BUFFER_CACHE.renderPartial(AllBlockPartials.MILLSTONE_COG, te.getBlockState());
 	}
 
 }

--- a/src/main/java/com/simibubi/create/content/contraptions/components/press/BeltPressingCallbacks.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/press/BeltPressingCallbacks.java
@@ -62,7 +62,7 @@ public class BeltPressingCallbacks {
 				boolean centered = BeltHelper.isItemUpright(stack);
 				copy.stack = stack;
 				copy.locked = true;
-				copy.angle = centered ? 180 : Create.random.nextInt(360);
+				copy.angle = centered ? 180 : Create.RANDOM.nextInt(360);
 				return copy;
 			})
 			.collect(Collectors.toList());

--- a/src/main/java/com/simibubi/create/content/contraptions/components/press/MechanicalPressTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/press/MechanicalPressTileEntity.java
@@ -260,7 +260,7 @@ public class MechanicalPressTileEntity extends BasinOperatingTileEntity {
 					ItemEntity created =
 						new ItemEntity(world, itemEntity.getX(), itemEntity.getY(), itemEntity.getZ(), result);
 					created.setDefaultPickupDelay();
-					created.setMotion(VecHelper.offsetRandomly(Vector3d.ZERO, Create.random, .05f));
+					created.setMotion(VecHelper.offsetRandomly(Vector3d.ZERO, Create.RANDOM, .05f));
 					world.addEntity(created);
 				}
 				item.shrink(1);

--- a/src/main/java/com/simibubi/create/content/contraptions/components/saw/SawRenderer.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/saw/SawRenderer.java
@@ -143,7 +143,7 @@ public class SawRenderer extends SafeTileEntityRenderer<SawTileEntity> {
 		BlockState state = te.getBlockState();
 		if (state.get(FACING).getAxis().isHorizontal())
 			return PartialBufferer.getFacing(AllBlockPartials.SHAFT_HALF, state.rotate(te.getWorld(), te.getPos(), Rotation.CLOCKWISE_180));
-		return CreateClient.bufferCache.renderBlockIn(KineticTileEntityRenderer.KINETIC_TILE,
+		return CreateClient.BUFFER_CACHE.renderBlockIn(KineticTileEntityRenderer.KINETIC_TILE,
 				getRenderedBlockState(te));
 	}
 

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/AbstractContraptionEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/AbstractContraptionEntity.java
@@ -391,7 +391,7 @@ public abstract class AbstractContraptionEntity extends Entity implements IEntit
 			byte[] byteArray = dataOutput.toByteArray();
 			int estimatedPacketSize = byteArray.length;
 			if (estimatedPacketSize > 2_000_000) {
-				Create.logger.warn("Could not send Contraption Spawn Data (Packet too big): "
+				Create.LOGGER.warn("Could not send Contraption Spawn Data (Packet too big): "
 					+ getContraption().getType().id + " @" + getPositionVec() + " (" + getUniqueID().toString() + ")");
 				buffer.writeCompoundTag(new CompoundNBT());
 				return;

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/BlockMovementChecks.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/BlockMovementChecks.java
@@ -1,5 +1,8 @@
 package com.simibubi.create.content.contraptions.components.structureMovement;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.simibubi.create.AllBlocks;
 import com.simibubi.create.AllTags.AllBlockTags;
 import com.simibubi.create.content.contraptions.components.actors.AttachedActorBlock;
@@ -53,15 +56,118 @@ import net.minecraft.state.properties.AttachFace;
 import net.minecraft.state.properties.BedPart;
 import net.minecraft.state.properties.BellAttachment;
 import net.minecraft.state.properties.BlockStateProperties;
+import net.minecraft.state.properties.DoubleBlockHalf;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
 
-public class BlockMovementTraits {
+public class BlockMovementChecks {
 
-	public static boolean movementNecessary(BlockState state, World world, BlockPos pos) {
+	private static final List<MovementNecessaryCheck> MOVEMENT_NECESSARY_CHECKS = new ArrayList<>();
+	private static final List<MovementAllowedCheck> MOVEMENT_ALLOWED_CHECKS = new ArrayList<>();
+	private static final List<BrittleCheck> BRITTLE_CHECKS = new ArrayList<>();
+	private static final List<AttachedCheck> ATTACHED_CHECKS = new ArrayList<>();
+	private static final List<NotSupportiveCheck> NOT_SUPPORTIVE_CHECKS = new ArrayList<>();
+
+	// Registration
+	// Add new checks to the front instead of the end
+
+	public static void registerMovementNecessaryCheck(MovementNecessaryCheck check) {
+		MOVEMENT_NECESSARY_CHECKS.add(0, check);
+	}
+
+	public static void registerMovementAllowedCheck(MovementAllowedCheck check) {
+		MOVEMENT_ALLOWED_CHECKS.add(0, check);
+	}
+
+	public static void registerBrittleCheck(BrittleCheck check) {
+		BRITTLE_CHECKS.add(0, check);
+	}
+
+	public static void registerAttachedCheck(AttachedCheck check) {
+		ATTACHED_CHECKS.add(0, check);
+	}
+
+	public static void registerNotSupportiveCheck(NotSupportiveCheck check) {
+		NOT_SUPPORTIVE_CHECKS.add(0, check);
+	}
+
+	public static void registerAllChecks(AllChecks checks) {
+		registerMovementNecessaryCheck(checks);
+		registerMovementAllowedCheck(checks);
+		registerBrittleCheck(checks);
+		registerAttachedCheck(checks);
+		registerNotSupportiveCheck(checks);
+	}
+
+	// Actual check methods
+
+	public static boolean isMovementNecessary(BlockState state, World world, BlockPos pos) {
+		for (MovementNecessaryCheck check : MOVEMENT_NECESSARY_CHECKS) {
+			CheckResult result = check.isMovementNecessary(state, world, pos);
+			if (result != CheckResult.PASS) {
+				return result.toBoolean();
+			}
+		}
+		return isMovementNecessaryFallback(state, world, pos);
+	}
+
+	public static boolean isMovementAllowed(BlockState state, World world, BlockPos pos) {
+		for (MovementAllowedCheck check : MOVEMENT_ALLOWED_CHECKS) {
+			CheckResult result = check.isMovementAllowed(state, world, pos);
+			if (result != CheckResult.PASS) {
+				return result.toBoolean();
+			}
+		}
+		return isMovementAllowedFallback(state, world, pos);
+	}
+
+	/**
+	 * Brittle blocks will be collected first, as they may break when other blocks
+	 * are removed before them
+	 */
+	public static boolean isBrittle(BlockState state) {
+		for (BrittleCheck check : BRITTLE_CHECKS) {
+			CheckResult result = check.isBrittle(state);
+			if (result != CheckResult.PASS) {
+				return result.toBoolean();
+			}
+		}
+		return isBrittleFallback(state);
+	}
+
+	/**
+	 * Attached blocks will move if blocks they are attached to are moved
+	 */
+	public static boolean isBlockAttachedTowards(BlockState state, World world, BlockPos pos,
+		Direction direction) {
+		for (AttachedCheck check : ATTACHED_CHECKS) {
+			CheckResult result = check.isBlockAttachedTowards(state, world, pos, direction);
+			if (result != CheckResult.PASS) {
+				return result.toBoolean();
+			}
+		}
+		return isBlockAttachedTowardsFallback(state, world, pos, direction);
+	}
+
+	/**
+	 * Non-Supportive blocks will not continue a chain of blocks picked up by e.g. a
+	 * piston
+	 */
+	public static boolean isNotSupportive(BlockState state, Direction facing) {
+		for (NotSupportiveCheck check : NOT_SUPPORTIVE_CHECKS) {
+			CheckResult result = check.isNotSupportive(state, facing);
+			if (result != CheckResult.PASS) {
+				return result.toBoolean();
+			}
+		}
+		return isNotSupportiveFallback(state, facing);
+	}
+
+	// Fallback checks
+
+	private static boolean isMovementNecessaryFallback(BlockState state, World world, BlockPos pos) {
 		if (isBrittle(state))
 			return true;
 		if (state.getBlock() instanceof FenceGateBlock)
@@ -75,7 +181,7 @@ public class BlockMovementTraits {
 		return true;
 	}
 
-	public static boolean movementAllowed(BlockState state, World world, BlockPos pos) {
+	private static boolean isMovementAllowedFallback(BlockState state, World world, BlockPos pos) {
 		Block block = state.getBlock();
 		if (block instanceof AbstractChassisBlock)
 			return true;
@@ -115,11 +221,7 @@ public class BlockMovementTraits {
 		return state.getPushReaction() != PushReaction.BLOCK;
 	}
 
-	/**
-	 * Brittle blocks will be collected first, as they may break when other blocks
-	 * are removed before them
-	 */
-	public static boolean isBrittle(BlockState state) {
+	private static boolean isBrittleFallback(BlockState state) {
 		Block block = state.getBlock();
 		if (state.contains(BlockStateProperties.HANGING))
 			return true;
@@ -147,10 +249,7 @@ public class BlockMovementTraits {
 		return AllBlockTags.BRITTLE.tag.contains(block);
 	}
 
-	/**
-	 * Attached blocks will move if blocks they are attached to are moved
-	 */
-	public static boolean isBlockAttachedTowards(IBlockReader world, BlockPos pos, BlockState state,
+	private static boolean isBlockAttachedTowardsFallback(BlockState state, World world, BlockPos pos,
 		Direction direction) {
 		Block block = state.getBlock();
 		if (block instanceof LadderBlock)
@@ -163,13 +262,15 @@ public class BlockMovementTraits {
 			return direction == Direction.DOWN;
 		if (block instanceof AbstractPressurePlateBlock)
 			return direction == Direction.DOWN;
-		if (block instanceof DoorBlock)
+		if (block instanceof DoorBlock) {
+			if (state.get(DoorBlock.HALF) == DoubleBlockHalf.LOWER && direction == Direction.UP)
+				return true;
 			return direction == Direction.DOWN;
+		}
 		if (block instanceof BedBlock) {
 			Direction facing = state.get(BedBlock.HORIZONTAL_FACING);
-			if (state.get(BedBlock.PART) == BedPart.HEAD) {
+			if (state.get(BedBlock.PART) == BedPart.HEAD)
 				facing = facing.getOpposite();
-			}
 			return direction == facing;
 		}
 		if (block instanceof RedstoneLinkBlock)
@@ -226,16 +327,12 @@ public class BlockMovementTraits {
 			return FluidTankConnectivityHandler.isConnected(world, pos, pos.offset(direction));
 		if (AllBlocks.STICKER.has(state) && state.get(StickerBlock.EXTENDED)) {
 			return direction == state.get(StickerBlock.FACING)
-				&& !notSupportive(world.getBlockState(pos.offset(direction)), direction.getOpposite());
+				&& !isNotSupportive(world.getBlockState(pos.offset(direction)), direction.getOpposite());
 		}
 		return false;
 	}
 
-	/**
-	 * Non-Supportive blocks will not continue a chain of blocks picked up by e.g. a
-	 * piston
-	 */
-	public static boolean notSupportive(BlockState state, Direction facing) {
+	private static boolean isNotSupportiveFallback(BlockState state, Direction facing) {
 		if (AllBlocks.MECHANICAL_DRILL.has(state))
 			return state.get(BlockStateProperties.FACING) == facing;
 		if (AllBlocks.MECHANICAL_BEARING.has(state))
@@ -264,6 +361,60 @@ public class BlockMovementTraits {
 		if (AllBlocks.STICKER.has(state) && !state.get(StickerBlock.EXTENDED))
 			return facing == state.get(StickerBlock.FACING);
 		return isBrittle(state);
+	}
+
+	// Check classes
+
+	public static interface MovementNecessaryCheck {
+		public CheckResult isMovementNecessary(BlockState state, World world, BlockPos pos);
+	}
+
+	public static interface MovementAllowedCheck {
+		public CheckResult isMovementAllowed(BlockState state, World world, BlockPos pos);
+	}
+
+	public static interface BrittleCheck {
+		/**
+		 * Brittle blocks will be collected first, as they may break when other blocks
+		 * are removed before them
+		 */
+		public CheckResult isBrittle(BlockState state);
+	}
+
+	public static interface AttachedCheck {
+		/**
+		 * Attached blocks will move if blocks they are attached to are moved
+		 */
+		public CheckResult isBlockAttachedTowards(BlockState state, World world, BlockPos pos, Direction direction);
+	}
+
+	public static interface NotSupportiveCheck {
+		/**
+		 * Non-Supportive blocks will not continue a chain of blocks picked up by e.g. a
+		 * piston
+		 */
+		public CheckResult isNotSupportive(BlockState state, Direction direction);
+	}
+
+	public static interface AllChecks extends MovementNecessaryCheck, MovementAllowedCheck, BrittleCheck, AttachedCheck, NotSupportiveCheck {
+	}
+
+	public static enum CheckResult {
+		SUCCESS,
+		FAIL,
+		PASS;
+
+		public Boolean toBoolean() {
+			return this == PASS ? null : (this == SUCCESS ? true : false);
+		}
+
+		public static CheckResult of(boolean b) {
+			return b ? SUCCESS : FAIL;
+		}
+
+		public static CheckResult of(Boolean b) {
+			return b == null ? PASS : (b ? SUCCESS : FAIL);
+		}
 	}
 
 }

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/Contraption.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/Contraption.java
@@ -73,7 +73,6 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.ChestBlock;
-import net.minecraft.block.DoorBlock;
 import net.minecraft.block.IWaterLoggable;
 import net.minecraft.block.PressurePlateBlock;
 import net.minecraft.block.material.PushReaction;
@@ -87,7 +86,6 @@ import net.minecraft.nbt.ListNBT;
 import net.minecraft.nbt.NBTUtil;
 import net.minecraft.state.properties.BlockStateProperties;
 import net.minecraft.state.properties.ChestType;
-import net.minecraft.state.properties.DoubleBlockHalf;
 import net.minecraft.state.properties.PistonType;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
@@ -212,7 +210,7 @@ public abstract class Contraption {
 		if (bounds == null)
 			bounds = new AxisAlignedBB(BlockPos.ZERO);
 
-		if (!BlockMovementTraits.isBrittle(world.getBlockState(pos)))
+		if (!BlockMovementChecks.isBrittle(world.getBlockState(pos)))
 			frontier.add(pos);
 		if (!addToInitialFrontier(world, pos, forcedDirection, frontier))
 			return false;
@@ -312,7 +310,7 @@ public abstract class Contraption {
 		if (isAnchoringBlockAt(pos))
 			return true;
 		BlockState state = world.getBlockState(pos);
-		if (!BlockMovementTraits.movementNecessary(state, world, pos))
+		if (!BlockMovementChecks.isMovementNecessary(state, world, pos))
 			return true;
 		if (!movementAllowed(state, world, pos))
 			throw AssemblyException.unmovableBlock(pos, state);
@@ -336,7 +334,7 @@ public abstract class Contraption {
 			Direction offset = state.get(StickerBlock.FACING);
 			BlockPos attached = pos.offset(offset);
 			if (!visited.contains(attached)
-				&& !BlockMovementTraits.notSupportive(world.getBlockState(attached), offset.getOpposite()))
+				&& !BlockMovementChecks.isNotSupportive(world.getBlockState(attached), offset.getOpposite()))
 				frontier.add(attached);
 		}
 
@@ -365,13 +363,6 @@ public abstract class Contraption {
 		if (isPistonHead(state))
 			movePistonHead(world, pos, frontier, visited, state);
 
-		// Doors try to stay whole
-		if (state.getBlock() instanceof DoorBlock) {
-			BlockPos otherPartPos = pos.up(state.get(DoorBlock.HALF) == DoubleBlockHalf.LOWER ? 1 : -1);
-			if (!visited.contains(otherPartPos))
-				frontier.add(otherPartPos);
-		}
-
 		// Cart assemblers attach themselves
 		BlockPos posDown = pos.down();
 		BlockState stateBelow = world.getBlockState(posDown);
@@ -395,24 +386,24 @@ public abstract class Contraption {
 			boolean wasVisited = visited.contains(offsetPos);
 			boolean faceHasGlue = superglue.containsKey(offset);
 			boolean blockAttachedTowardsFace =
-				BlockMovementTraits.isBlockAttachedTowards(world, offsetPos, blockState, offset.getOpposite());
-			boolean brittle = BlockMovementTraits.isBrittle(blockState);
+				BlockMovementChecks.isBlockAttachedTowards(blockState, world, offsetPos, offset.getOpposite());
+			boolean brittle = BlockMovementChecks.isBrittle(blockState);
 			boolean canStick = !brittle && state.canStickTo(blockState) && blockState.canStickTo(state);
 			if (canStick) {
 				if (state.getPushReaction() == PushReaction.PUSH_ONLY
 					|| blockState.getPushReaction() == PushReaction.PUSH_ONLY) {
 					canStick = false;
 				}
-				if (BlockMovementTraits.notSupportive(state, offset)) {
+				if (BlockMovementChecks.isNotSupportive(state, offset)) {
 					canStick = false;
 				}
-				if (BlockMovementTraits.notSupportive(blockState, offset.getOpposite())) {
+				if (BlockMovementChecks.isNotSupportive(blockState, offset.getOpposite())) {
 					canStick = false;
 				}
 			}
 
 			if (!wasVisited && (canStick || blockAttachedTowardsFace || faceHasGlue
-				|| (offset == forcedDirection && !BlockMovementTraits.notSupportive(state, forcedDirection))))
+				|| (offset == forcedDirection && !BlockMovementChecks.isNotSupportive(state, forcedDirection))))
 				frontier.add(offsetPos);
 			if (faceHasGlue)
 				addGlue(superglue.get(offset));
@@ -674,7 +665,7 @@ public abstract class Contraption {
 	}
 
 	protected boolean movementAllowed(BlockState state, World world, BlockPos pos) {
-		return BlockMovementTraits.movementAllowed(state, world, pos);
+		return BlockMovementChecks.isMovementAllowed(state, world, pos);
 	}
 
 	protected boolean isAnchoringBlockAt(BlockPos pos) {
@@ -944,7 +935,7 @@ public abstract class Contraption {
 			for (Iterator<BlockInfo> iterator = blocks.values()
 				.iterator(); iterator.hasNext();) {
 				BlockInfo block = iterator.next();
-				if (brittles != BlockMovementTraits.isBrittle(block.state))
+				if (brittles != BlockMovementChecks.isBrittle(block.state))
 					continue;
 
 				BlockPos add = block.pos.add(anchor)
@@ -981,7 +972,7 @@ public abstract class Contraption {
 	public void addBlocksToWorld(World world, StructureTransform transform) {
 		for (boolean nonBrittles : Iterate.trueAndFalse) {
 			for (BlockInfo block : blocks.values()) {
-				if (nonBrittles == BlockMovementTraits.isBrittle(block.state))
+				if (nonBrittles == BlockMovementChecks.isBrittle(block.state))
 					continue;
 
 				BlockPos targetPos = transform.apply(block.pos);

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/Contraption.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/Contraption.java
@@ -61,7 +61,7 @@ import com.simibubi.create.foundation.render.backend.light.EmptyLighter;
 import com.simibubi.create.foundation.render.backend.light.GridAlignedBB;
 import com.simibubi.create.foundation.tileEntity.behaviour.filtering.FilteringBehaviour;
 import com.simibubi.create.foundation.utility.BlockFace;
-import com.simibubi.create.foundation.utility.Coordinate;
+import com.simibubi.create.foundation.utility.ICoordinate;
 import com.simibubi.create.foundation.utility.Iterate;
 import com.simibubi.create.foundation.utility.NBTHelper;
 import com.simibubi.create.foundation.utility.NBTProcessors;
@@ -974,10 +974,7 @@ public abstract class Contraption {
 //				continue;
 			int flags = BlockFlags.IS_MOVING | BlockFlags.DEFAULT;
 			world.notifyBlockUpdate(add, block.state, Blocks.AIR.getDefaultState(), flags);
-			world.markAndNotifyBlock(add, world.getChunkAt(add), block.state, Blocks.AIR.getDefaultState(), flags, 512);
 			block.state.updateDiagonalNeighbors(world, add, flags & -2);
-//			world.markAndNotifyBlock(add, null, block.state, Blocks.AIR.getDefaultState(),
-//				BlockFlags.IS_MOVING | BlockFlags.DEFAULT); this method did strange logspamming with POI-related blocks
 		}
 	}
 
@@ -1235,7 +1232,7 @@ public abstract class Contraption {
 		throw new IllegalStateException("Impossible axis");
 	}
 
-	public static float getMaxDistSqr(Set<BlockPos> blocks, Coordinate one, Coordinate other) {
+	public static float getMaxDistSqr(Set<BlockPos> blocks, ICoordinate one, ICoordinate other) {
 		float maxDistSq = -1;
 		for (BlockPos pos : blocks) {
 			float a = one.get(pos);

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/chassis/ChassisRangeDisplay.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/chassis/ChassisRangeDisplay.java
@@ -35,7 +35,7 @@ public class ChassisRangeDisplay {
 		public Entry(ChassisTileEntity te) {
 			this.te = te;
 			timer = DISPLAY_TIME;
-			CreateClient.outliner.showCluster(getOutlineKey(), createSelection(te))
+			CreateClient.OUTLINER.showCluster(getOutlineKey(), createSelection(te))
 				.colored(0xFFFFFF)
 				.disableNormals()
 				.lineWidth(1 / 16f)
@@ -97,7 +97,7 @@ public class ChassisRangeDisplay {
 			Entry entry = entries.get(pos);
 			if (tickEntry(entry, hasWrench))
 				iterator.remove();
-			CreateClient.outliner.keep(entry.getOutlineKey());
+			CreateClient.OUTLINER.keep(entry.getOutlineKey());
 		}
 
 		for (Iterator<GroupEntry> iterator = groupEntries.iterator(); iterator.hasNext();) {
@@ -107,7 +107,7 @@ public class ChassisRangeDisplay {
 				if (group == lastHoveredGroup)
 					lastHoveredGroup = null;
 			}
-			CreateClient.outliner.keep(group.getOutlineKey());
+			CreateClient.OUTLINER.keep(group.getOutlineKey());
 		}
 
 		if (!hasWrench)
@@ -173,9 +173,9 @@ public class ChassisRangeDisplay {
 			GroupEntry hoveredGroup = new GroupEntry(chassis);
 
 			for (ChassisTileEntity included : hoveredGroup.includedTEs)
-				CreateClient.outliner.remove(included.getPos());
+				CreateClient.OUTLINER.remove(included.getPos());
 
-			groupEntries.forEach(entry -> CreateClient.outliner.remove(entry.getOutlineKey()));
+			groupEntries.forEach(entry -> CreateClient.OUTLINER.remove(entry.getOutlineKey()));
 			groupEntries.clear();
 			entries.clear();
 			groupEntries.add(hoveredGroup);
@@ -186,7 +186,7 @@ public class ChassisRangeDisplay {
 		BlockPos pos = chassis.getPos();
 		GroupEntry entry = getExistingGroupForPos(pos);
 		if (entry != null)
-			CreateClient.outliner.remove(entry.getOutlineKey());
+			CreateClient.OUTLINER.remove(entry.getOutlineKey());
 
 		groupEntries.clear();
 		entries.clear();

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/chassis/ChassisTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/chassis/ChassisTileEntity.java
@@ -11,7 +11,7 @@ import java.util.Queue;
 import java.util.Set;
 
 import com.simibubi.create.AllBlocks;
-import com.simibubi.create.content.contraptions.components.structureMovement.BlockMovementTraits;
+import com.simibubi.create.content.contraptions.components.structureMovement.BlockMovementChecks;
 import com.simibubi.create.foundation.config.AllConfigs;
 import com.simibubi.create.foundation.tileEntity.SmartTileEntity;
 import com.simibubi.create.foundation.tileEntity.TileEntityBehaviour;
@@ -165,14 +165,14 @@ public class ChassisTileEntity extends SmartTileEntity {
 					break;
 
 				// Ignore replaceable Blocks and Air-like
-				if (!BlockMovementTraits.movementNecessary(currentState, world, current))
+				if (!BlockMovementChecks.isMovementNecessary(currentState, world, current))
 					break;
-				if (BlockMovementTraits.isBrittle(currentState))
+				if (BlockMovementChecks.isBrittle(currentState))
 					break;
 
 				positions.add(current);
 
-				if (BlockMovementTraits.notSupportive(currentState, facing))
+				if (BlockMovementChecks.isNotSupportive(currentState, facing))
 					break;
 			}
 		}
@@ -206,9 +206,9 @@ public class ChassisTileEntity extends SmartTileEntity {
 					continue;
 				if (!searchPos.withinDistance(pos, chassisRange + .5f))
 					continue;
-				if (!BlockMovementTraits.movementNecessary(searchedState, world, searchPos))
+				if (!BlockMovementChecks.isMovementNecessary(searchedState, world, searchPos))
 					continue;
-				if (BlockMovementTraits.isBrittle(searchedState))
+				if (BlockMovementChecks.isBrittle(searchedState))
 					continue;
 
 				localVisited.add(searchPos);
@@ -220,7 +220,7 @@ public class ChassisTileEntity extends SmartTileEntity {
 						continue;
 					if (searchPos.equals(pos) && offset != facing)
 						continue;
-					if (BlockMovementTraits.notSupportive(searchedState, offset))
+					if (BlockMovementChecks.isNotSupportive(searchedState, offset))
 						continue;
 
 					localFrontier.add(searchPos.offset(offset));

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/glue/SuperGlueEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/glue/SuperGlueEntity.java
@@ -9,7 +9,7 @@ import com.simibubi.create.AllEntityTypes;
 import com.simibubi.create.AllItems;
 import com.simibubi.create.AllSoundEvents;
 import com.simibubi.create.content.contraptions.base.DirectionalKineticBlock;
-import com.simibubi.create.content.contraptions.components.structureMovement.BlockMovementTraits;
+import com.simibubi.create.content.contraptions.components.structureMovement.BlockMovementChecks;
 import com.simibubi.create.content.contraptions.components.structureMovement.bearing.BearingBlock;
 import com.simibubi.create.content.contraptions.components.structureMovement.chassis.AbstractChassisBlock;
 import com.simibubi.create.content.schematics.ISpecialEntityItemRequirement;
@@ -195,11 +195,11 @@ public class SuperGlueEntity extends Entity implements IEntityAdditionalSpawnDat
 
 	public static boolean isValidFace(World world, BlockPos pos, Direction direction) {
 		BlockState state = world.getBlockState(pos);
-		if (BlockMovementTraits.isBlockAttachedTowards(world, pos, state, direction))
+		if (BlockMovementChecks.isBlockAttachedTowards(state, world, pos, direction))
 			return true;
-		if (!BlockMovementTraits.movementNecessary(state, world, pos))
+		if (!BlockMovementChecks.isMovementNecessary(state, world, pos))
 			return false;
-		if (BlockMovementTraits.notSupportive(state, direction))
+		if (BlockMovementChecks.isNotSupportive(state, direction))
 			return false;
 		return true;
 	}

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/piston/PistonContraption.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/piston/PistonContraption.java
@@ -15,7 +15,7 @@ import java.util.Queue;
 import org.apache.commons.lang3.tuple.Pair;
 
 import com.simibubi.create.content.contraptions.components.structureMovement.AssemblyException;
-import com.simibubi.create.content.contraptions.components.structureMovement.BlockMovementTraits;
+import com.simibubi.create.content.contraptions.components.structureMovement.BlockMovementChecks;
 import com.simibubi.create.content.contraptions.components.structureMovement.ContraptionLighter;
 import com.simibubi.create.content.contraptions.components.structureMovement.ContraptionType;
 import com.simibubi.create.content.contraptions.components.structureMovement.TranslatingContraption;
@@ -169,13 +169,13 @@ public class PistonContraption extends TranslatingContraption {
 			if (!world.isBlockPresent(currentPos))
 				throw AssemblyException.unloadedChunk(currentPos);
 			BlockState state = world.getBlockState(currentPos);
-			if (!BlockMovementTraits.movementNecessary(state, world, currentPos))
+			if (!BlockMovementChecks.isMovementNecessary(state, world, currentPos))
 				return true;
-			if (BlockMovementTraits.isBrittle(state) && !(state.getBlock() instanceof CarpetBlock))
+			if (BlockMovementChecks.isBrittle(state) && !(state.getBlock() instanceof CarpetBlock))
 				return true;
 			if (isPistonHead(state) && state.get(FACING) == direction.getOpposite())
 				return true;
-			if (!BlockMovementTraits.movementAllowed(state, world, currentPos))
+			if (!BlockMovementChecks.isMovementAllowed(state, world, currentPos))
 				if (retracting)
 					return true;
 				else
@@ -183,7 +183,7 @@ public class PistonContraption extends TranslatingContraption {
 			if (retracting && state.getPushReaction() == PushReaction.PUSH_ONLY)
 				return true;
 			frontier.add(currentPos);
-			if (BlockMovementTraits.notSupportive(state, orientation))
+			if (BlockMovementChecks.isNotSupportive(state, orientation))
 				return true;
 		}
 		return true;

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/pulley/PulleyRenderer.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/pulley/PulleyRenderer.java
@@ -31,12 +31,12 @@ public class PulleyRenderer extends AbstractPulleyRenderer {
 
 	@Override
 	protected SuperByteBuffer renderRope(KineticTileEntity te) {
-		return CreateClient.bufferCache.renderBlock(AllBlocks.ROPE.getDefaultState());
+		return CreateClient.BUFFER_CACHE.renderBlock(AllBlocks.ROPE.getDefaultState());
 	}
 
 	@Override
 	protected SuperByteBuffer renderMagnet(KineticTileEntity te) {
-		return CreateClient.bufferCache.renderBlock(AllBlocks.PULLEY_MAGNET.getDefaultState());
+		return CreateClient.BUFFER_CACHE.renderBlock(AllBlocks.PULLEY_MAGNET.getDefaultState());
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/pulley/PulleyTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/pulley/PulleyTileEntity.java
@@ -2,7 +2,7 @@ package com.simibubi.create.content.contraptions.components.structureMovement.pu
 
 import com.simibubi.create.AllBlocks;
 import com.simibubi.create.content.contraptions.components.structureMovement.AssemblyException;
-import com.simibubi.create.content.contraptions.components.structureMovement.BlockMovementTraits;
+import com.simibubi.create.content.contraptions.components.structureMovement.BlockMovementChecks;
 import com.simibubi.create.content.contraptions.components.structureMovement.ContraptionCollider;
 import com.simibubi.create.content.contraptions.components.structureMovement.ControlledContraptionEntity;
 import com.simibubi.create.content.contraptions.components.structureMovement.piston.LinearActuatorTileEntity;
@@ -186,9 +186,9 @@ public class PulleyTileEntity extends LinearActuatorTileEntity {
 
 		BlockPos posBelow = pos.down((int) (offset + getMovementSpeed()) + 1);
 		BlockState state = world.getBlockState(posBelow);
-		if (!BlockMovementTraits.movementNecessary(state, world, posBelow))
+		if (!BlockMovementChecks.isMovementNecessary(state, world, posBelow))
 			return;
-		if (BlockMovementTraits.isBrittle(state))
+		if (BlockMovementChecks.isBrittle(state))
 			return;
 
 		disassemble();

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/render/ContraptionRenderDispatcher.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/render/ContraptionRenderDispatcher.java
@@ -124,7 +124,7 @@ public class ContraptionRenderDispatcher {
 
 	public static void renderStructure(World world, Contraption c, MatrixStack ms, MatrixStack msLocal,
 									   IRenderTypeBuffer buffer) {
-		SuperByteBufferCache bufferCache = CreateClient.bufferCache;
+		SuperByteBufferCache bufferCache = CreateClient.BUFFER_CACHE;
 		List<RenderType> blockLayers = RenderType.getBlockLayers();
 
 		buffer.getBuffer(RenderType.getSolid());

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/train/CouplingHandler.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/train/CouplingHandler.java
@@ -124,7 +124,7 @@ public class CouplingHandler {
 
 			while (true) {
 				if (safetyCount-- <= 0) {
-					Create.logger.warn("Infinite loop in coupling iteration");
+					Create.LOGGER.warn("Infinite loop in coupling iteration");
 					return false;
 				}
 

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/train/CouplingRenderer.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/train/CouplingRenderer.java
@@ -228,13 +228,13 @@ public class CouplingRenderer {
 		int color = ColorHelper.mixColors(0xabf0e9, 0xee8572, (float) MathHelper
 			.clamp(Math.abs(first.getCouplingLength(true) - connectedCenter.distanceTo(mainCenter)) * 8, 0, 1));
 
-		CreateClient.outliner.showLine(mainCart.getEntityId() + "", mainCenter, connectedCenter)
+		CreateClient.OUTLINER.showLine(mainCart.getEntityId() + "", mainCenter, connectedCenter)
 			.colored(color)
 			.lineWidth(1 / 8f);
 
 		Vector3d point = mainCart.getPositionVec()
 			.add(0, yOffset, 0);
-		CreateClient.outliner.showLine(mainCart.getEntityId() + "_dot", point, point.add(0, 1 / 128f, 0))
+		CreateClient.OUTLINER.showLine(mainCart.getEntityId() + "_dot", point, point.add(0, 1 / 128f, 0))
 			.colored(0xffffff)
 			.lineWidth(1 / 4f);
 	}

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/train/capability/MinecartController.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/train/capability/MinecartController.java
@@ -197,7 +197,7 @@ public class MinecartController implements INBTSerializable<CompoundNBT> {
 
 			while (true) {
 				if (safetyCount-- <= 0) {
-					Create.logger.warn("Infinite loop in coupling iteration");
+					Create.LOGGER.warn("Infinite loop in coupling iteration");
 					return;
 				}
 				cartsToFlip.add(current);

--- a/src/main/java/com/simibubi/create/content/contraptions/fluids/pipes/FluidPipeBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/fluids/pipes/FluidPipeBlock.java
@@ -148,7 +148,7 @@ public class FluidPipeBlock extends SixWayBlock implements IWaterLoggable, IWren
 		FluidTransportBehaviour transport = TileEntityBehaviour.get(world, neighbourPos, FluidTransportBehaviour.TYPE);
 		BracketedTileEntityBehaviour bracket = TileEntityBehaviour.get(world, neighbourPos, BracketedTileEntityBehaviour.TYPE);
 		if (isPipe(neighbour))
-			return bracket == null || !bracket.isBacketPresent()
+			return bracket == null || !bracket.isBracketPresent()
 				|| FluidPropagator.getStraightPipeAxis(neighbour) == direction.getAxis();
 		if (transport == null)
 			return false;
@@ -228,7 +228,7 @@ public class FluidPipeBlock extends SixWayBlock implements IWaterLoggable, IWren
 		IBlockDisplayReader world, BlockPos pos) {
 
 		BracketedTileEntityBehaviour bracket = TileEntityBehaviour.get(world, pos, BracketedTileEntityBehaviour.TYPE);
-		if (bracket != null && bracket.isBacketPresent())
+		if (bracket != null && bracket.isBracketPresent())
 			return state;
 
 		// Update sides that are not ignored

--- a/src/main/java/com/simibubi/create/content/contraptions/goggles/GoggleOverlayRenderer.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/goggles/GoggleOverlayRenderer.java
@@ -42,7 +42,7 @@ import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 @EventBusSubscriber(value = Dist.CLIENT)
 public class GoggleOverlayRenderer {
 
-	private static final Map<Object, OutlineEntry> outlines = CreateClient.outliner.getOutlines();
+	private static final Map<Object, OutlineEntry> outlines = CreateClient.OUTLINER.getOutlines();
 
 	@SubscribeEvent
 	public static void lookingAtBlocksThroughGogglesShowsTooltip(RenderGameOverlayEvent.Post event) {

--- a/src/main/java/com/simibubi/create/content/contraptions/particle/AirFlowParticle.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/particle/AirFlowParticle.java
@@ -35,7 +35,7 @@ public class AirFlowParticle extends SimpleAnimatedParticle {
 		this.maxAge = 40;
 		canCollide = false;
 		selectSprite(7);
-		Vector3d offset = VecHelper.offsetRandomly(Vector3d.ZERO, Create.random, .25f);
+		Vector3d offset = VecHelper.offsetRandomly(Vector3d.ZERO, Create.RANDOM, .25f);
 		this.setPosition(posX + offset.x, posY + offset.y, posZ + offset.z);
 		this.prevPosX = posX;
 		this.prevPosY = posY;

--- a/src/main/java/com/simibubi/create/content/contraptions/particle/AirParticle.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/particle/AirParticle.java
@@ -39,9 +39,9 @@ public class AirParticle extends SimpleAnimatedParticle {
 		targetZ = (float) (z + dz);
 		drag = data.drag;
 
-		twirlRadius = Create.random.nextFloat() / 6;
-		twirlAngleOffset = Create.random.nextFloat() * 360;
-		twirlAxis = Create.random.nextBoolean() ? Axis.X : Axis.Z;
+		twirlRadius = Create.RANDOM.nextFloat() / 6;
+		twirlAngleOffset = Create.RANDOM.nextFloat() * 360;
+		twirlAxis = Create.RANDOM.nextBoolean() ? Axis.X : Axis.Z;
 
 		// speed in m/ticks
 		maxAge = Math.min((int) (new Vector3d(dx, dy, dz).length() / data.speed), 60);

--- a/src/main/java/com/simibubi/create/content/contraptions/processing/BasinBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/processing/BasinBlock.java
@@ -126,7 +126,7 @@ public class BasinBlock extends Block implements ITE<BasinTileEntity>, IWrenchab
 			}
 			if (success)
 				worldIn.playSound(null, pos, SoundEvents.ENTITY_ITEM_PICKUP, SoundCategory.PLAYERS, .2f,
-					1f + Create.random.nextFloat());
+					1f + Create.RANDOM.nextFloat());
 			te.onEmptied();
 		} catch (TileEntityException e) {
 		}

--- a/src/main/java/com/simibubi/create/content/contraptions/processing/HeatCondition.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/processing/HeatCondition.java
@@ -46,7 +46,7 @@ public enum HeatCondition {
 			if (heatCondition.serialize()
 				.equals(name))
 				return heatCondition;
-		Create.logger.warn("Tried to deserialize invalid heat condition: \"" + name + "\"");
+		Create.LOGGER.warn("Tried to deserialize invalid heat condition: \"" + name + "\"");
 		return NONE;
 	}
 

--- a/src/main/java/com/simibubi/create/content/contraptions/processing/ProcessingRecipe.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/processing/ProcessingRecipe.java
@@ -85,7 +85,7 @@ public abstract class ProcessingRecipe<T extends IInventory> implements IRecipe<
 
 	private void validate(String recipeTypeName) {
 		String messageHeader = "Your custom " + recipeTypeName + " recipe (" + id.toString() + ")";
-		Logger logger = Create.logger;
+		Logger logger = Create.LOGGER;
 		int ingredientCount = ingredients.size();
 		int outputCount = results.size();
 

--- a/src/main/java/com/simibubi/create/content/contraptions/relays/advanced/SpeedControllerRenderer.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/relays/advanced/SpeedControllerRenderer.java
@@ -53,7 +53,7 @@ public class SpeedControllerRenderer extends SmartTileEntityRenderer<SpeedContro
 	}
 
 	private SuperByteBuffer getRotatedModel(SpeedControllerTileEntity te) {
-		return CreateClient.bufferCache.renderBlockIn(KineticTileEntityRenderer.KINETIC_TILE,
+		return CreateClient.BUFFER_CACHE.renderBlockIn(KineticTileEntityRenderer.KINETIC_TILE,
 			KineticTileEntityRenderer.shaft(KineticTileEntityRenderer.getRotationAxisOf(te)));
 	}
 

--- a/src/main/java/com/simibubi/create/content/contraptions/relays/belt/BeltBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/relays/belt/BeltBlock.java
@@ -274,7 +274,7 @@ public class BeltBlock extends HorizontalKineticBlock implements ITE<BeltTileEnt
 				});
 			if (success.isTrue())
 				world.playSound(null, pos, SoundEvents.ENTITY_ITEM_PICKUP, SoundCategory.PLAYERS, .2f,
-					1f + Create.random.nextFloat());
+					1f + Create.RANDOM.nextFloat());
 		}
 
 		if (isShaft) {

--- a/src/main/java/com/simibubi/create/content/contraptions/relays/belt/BeltRenderer.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/relays/belt/BeltRenderer.java
@@ -143,7 +143,7 @@ public class BeltRenderer extends SafeTileEntityRenderer<BeltTileEntity> {
 					return stack;
 				};
 
-				SuperByteBuffer superBuffer = CreateClient.bufferCache.renderDirectionalPartial(AllBlockPartials.BELT_PULLEY, blockState, dir, matrixStackSupplier);
+				SuperByteBuffer superBuffer = CreateClient.BUFFER_CACHE.renderDirectionalPartial(AllBlockPartials.BELT_PULLEY, blockState, dir, matrixStackSupplier);
 				KineticTileEntityRenderer.standardKineticRotationTransform(superBuffer, te, light).renderInto(ms, vb);
 			}
 		}

--- a/src/main/java/com/simibubi/create/content/contraptions/relays/belt/item/BeltConnectorItem.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/relays/belt/item/BeltConnectorItem.java
@@ -47,7 +47,7 @@ public class BeltConnectorItem extends BlockItem {
 
 	@Override
 	public void fillItemGroup(ItemGroup p_150895_1_, NonNullList<ItemStack> p_150895_2_) {
-		if (p_150895_1_ == Create.baseCreativeTab)
+		if (p_150895_1_ == Create.BASE_CREATIVE_TAB)
 			return;
 		super.fillItemGroup(p_150895_1_, p_150895_2_);
 	}

--- a/src/main/java/com/simibubi/create/content/contraptions/relays/elementary/BracketedKineticBlockModel.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/relays/elementary/BracketedKineticBlockModel.java
@@ -21,7 +21,7 @@ import net.minecraftforge.client.model.data.ModelProperty;
 
 public class BracketedKineticBlockModel extends BakedModelWrapper<IBakedModel> {
 
-	private static ModelProperty<BracketedModelData> BRACKET_PROPERTY = new ModelProperty<>();
+	private static final ModelProperty<BracketedModelData> BRACKET_PROPERTY = new ModelProperty<>();
 
 	public BracketedKineticBlockModel(IBakedModel template) {
 		super(template);

--- a/src/main/java/com/simibubi/create/content/contraptions/relays/elementary/BracketedTileEntityBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/relays/elementary/BracketedTileEntityBehaviour.java
@@ -73,7 +73,7 @@ public class BracketedTileEntityBehaviour extends TileEntityBehaviour {
 			tileEntity.notifyUpdate();
 	}
 
-	public boolean isBacketPresent() {
+	public boolean isBracketPresent() {
 		return getBracket() != Blocks.AIR.getDefaultState();
 	}
 

--- a/src/main/java/com/simibubi/create/content/contraptions/wrench/IWrenchable.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/wrench/IWrenchable.java
@@ -71,11 +71,11 @@ public interface IWrenchable {
 	}
 
 	default void playRemoveSound(World world, BlockPos pos) {
-		AllSoundEvents.WRENCH_REMOVE.playOnServer(world, pos, 1, Create.random.nextFloat() * .5f + .5f);
+		AllSoundEvents.WRENCH_REMOVE.playOnServer(world, pos, 1, Create.RANDOM.nextFloat() * .5f + .5f);
 	}
 
 	default void playRotateSound(World world, BlockPos pos) {
-		AllSoundEvents.WRENCH_ROTATE.playOnServer(world, pos, 1, Create.random.nextFloat() + .5f);
+		AllSoundEvents.WRENCH_ROTATE.playOnServer(world, pos, 1, Create.RANDOM.nextFloat() + .5f);
 	}
 
 	default BlockState getRotatedBlockState(BlockState originalState, Direction targetedFace) {

--- a/src/main/java/com/simibubi/create/content/curiosities/armor/CopperBacktankArmorLayer.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/armor/CopperBacktankArmorLayer.java
@@ -62,9 +62,9 @@ public class CopperBacktankArmorLayer<T extends LivingEntity, M extends EntityMo
 			.with(CopperBacktankBlock.HORIZONTAL_FACING, Direction.SOUTH);
 		RenderType renderType = RenderType.getCutout();
 
-		SuperByteBuffer backtank = CreateClient.bufferCache.renderBlock(renderedState);
+		SuperByteBuffer backtank = CreateClient.BUFFER_CACHE.renderBlock(renderedState);
 		SuperByteBuffer cogs =
-			CreateClient.bufferCache.renderPartial(AllBlockPartials.COPPER_BACKTANK_COGS, renderedState);
+			CreateClient.BUFFER_CACHE.renderPartial(AllBlockPartials.COPPER_BACKTANK_COGS, renderedState);
 
 		model.bipedBody.rotate(ms);
 		ms.translate(-1 / 2f, 10 / 16f, 1f);

--- a/src/main/java/com/simibubi/create/content/curiosities/armor/CopperBacktankRenderer.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/armor/CopperBacktankRenderer.java
@@ -27,7 +27,7 @@ public class CopperBacktankRenderer extends KineticTileEntityRenderer {
 		super.renderSafe(te, partialTicks, ms, buffer, light, overlay);
 
 		SuperByteBuffer cogs =
-			CreateClient.bufferCache.renderPartial(AllBlockPartials.COPPER_BACKTANK_COGS, te.getBlockState());
+			CreateClient.BUFFER_CACHE.renderPartial(AllBlockPartials.COPPER_BACKTANK_COGS, te.getBlockState());
 		cogs.matrixStacker()
 			.centre()
 			.rotateY(180 + AngleHelper.horizontalAngle(te.getBlockState()

--- a/src/main/java/com/simibubi/create/content/curiosities/armor/CopperBacktankTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/armor/CopperBacktankTileEntity.java
@@ -42,7 +42,7 @@ public class CopperBacktankTileEntity extends KineticTileEntity implements IName
 		int max = getMaxAir();
 		if (world.isRemote) {
 			Vector3d centerOf = VecHelper.getCenterOf(pos);
-			Vector3d v = VecHelper.offsetRandomly(centerOf, Create.random, .65f);
+			Vector3d v = VecHelper.offsetRandomly(centerOf, Create.RANDOM, .65f);
 			Vector3d m = centerOf.subtract(v);
 			if (airLevel != max)
 				world.addParticle(new AirParticleData(1, .05f), v.x, v.y, v.z, m.x, m.y, m.z);

--- a/src/main/java/com/simibubi/create/content/curiosities/zapper/ZapperRenderHandler.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/zapper/ZapperRenderHandler.java
@@ -90,7 +90,7 @@ public class ZapperRenderHandler {
 			return;
 
 		cachedBeams.forEach(beam -> {
-			CreateClient.outliner.endChasingLine(beam, beam.start, beam.end, 1 - beam.itensity)
+			CreateClient.OUTLINER.endChasingLine(beam, beam.start, beam.end, 1 - beam.itensity)
 				.disableNormals()
 				.colored(0xffffff)
 				.lineWidth(beam.itensity * 1 / 8f);

--- a/src/main/java/com/simibubi/create/content/curiosities/zapper/terrainzapper/WorldshaperRenderHandler.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/zapper/terrainzapper/WorldshaperRenderHandler.java
@@ -31,7 +31,7 @@ public class WorldshaperRenderHandler {
 		if (renderedPositions == null)
 			return;
 
-		CreateClient.outliner.showCluster("terrainZapper", renderedPositions.get())
+		CreateClient.OUTLINER.showCluster("terrainZapper", renderedPositions.get())
 			.colored(0xbfbfbf)
 			.disableNormals()
 			.lineWidth(1 / 32f)

--- a/src/main/java/com/simibubi/create/content/logistics/RedstoneLinkNetworkHandler.java
+++ b/src/main/java/com/simibubi/create/content/logistics/RedstoneLinkNetworkHandler.java
@@ -67,12 +67,12 @@ public class RedstoneLinkNetworkHandler {
 
 	public void onLoadWorld(IWorld world) {
 		connections.put(world, new HashMap<>());
-		Create.logger.debug("Prepared Redstone Network Space for " + WorldHelper.getDimensionID(world));
+		Create.LOGGER.debug("Prepared Redstone Network Space for " + WorldHelper.getDimensionID(world));
 	}
 
 	public void onUnloadWorld(IWorld world) {
 		connections.remove(world);
-		Create.logger.debug("Removed Redstone Network Space for " + WorldHelper.getDimensionID(world));
+		Create.LOGGER.debug("Removed Redstone Network Space for " + WorldHelper.getDimensionID(world));
 	}
 
 	public Set<LinkBehaviour> getNetworkOf(LinkBehaviour actor) {
@@ -144,7 +144,7 @@ public class RedstoneLinkNetworkHandler {
 
 	public Map<Pair<Frequency, Frequency>, Set<LinkBehaviour>> networksIn(IWorld world) {
 		if (!connections.containsKey(world)) {
-			Create.logger.warn(
+			Create.LOGGER.warn(
 					"Tried to Access unprepared network space of " + WorldHelper.getDimensionID(world));
 			return new HashMap<>();
 		}

--- a/src/main/java/com/simibubi/create/content/logistics/block/chute/ChuteTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/chute/ChuteTileEntity.java
@@ -313,12 +313,12 @@ public class ChuteTileEntity extends SmartTileEntity implements IHaveGoggleInfor
 			return;
 		AirParticleData airParticleData = new AirParticleData(drag, motion);
 		Vector3d origin = Vector3d.of(pos);
-		float xOff = Create.random.nextFloat() * .5f + .25f;
-		float zOff = Create.random.nextFloat() * .5f + .25f;
+		float xOff = Create.RANDOM.nextFloat() * .5f + .25f;
+		float zOff = Create.RANDOM.nextFloat() * .5f + .25f;
 		Vector3d v = origin.add(xOff, verticalStart, zOff);
 		Vector3d d = origin.add(xOff, verticalEnd, zOff)
 			.subtract(v);
-		if (Create.random.nextFloat() < 2 * motion)
+		if (Create.RANDOM.nextFloat() < 2 * motion)
 			world.addOptionalParticle(airParticleData, v.x, v.y, v.z, d.x, d.y, d.z);
 	}
 

--- a/src/main/java/com/simibubi/create/content/logistics/block/depot/EjectorTargetHandler.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/depot/EjectorTargetHandler.java
@@ -210,7 +210,7 @@ public class EjectorTargetHandler {
 		ClientWorld world = mc.world;
 
 		AxisAlignedBB bb = new AxisAlignedBB(0, 0, 0, 1, 0, 1).offset(currentSelection.add(-validX, -yDiff, -validZ));
-		CreateClient.outliner.chaseAABB("valid", bb)
+		CreateClient.OUTLINER.chaseAABB("valid", bb)
 			.colored(intColor)
 			.lineWidth(1 / 16f);
 
@@ -260,7 +260,7 @@ public class EjectorTargetHandler {
 		BlockState state = world.getBlockState(pos);
 		VoxelShape shape = state.getShape(world, pos);
 		AxisAlignedBB boundingBox = shape.isEmpty() ? new AxisAlignedBB(BlockPos.ZERO) : shape.getBoundingBox();
-		CreateClient.outliner.showAABB("target", boundingBox.offset(pos))
+		CreateClient.OUTLINER.showAABB("target", boundingBox.offset(pos))
 			.colored(0xffcb74)
 			.lineWidth(1 / 16f);
 	}

--- a/src/main/java/com/simibubi/create/content/logistics/block/depot/SharedDepotBlockMethods.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/depot/SharedDepotBlockMethods.java
@@ -53,7 +53,7 @@ public class SharedDepotBlockMethods {
 			player.inventory.placeItemBackInInventory(world, mainItemStack);
 			behaviour.removeHeldItem();
 			world.playSound(null, pos, SoundEvents.ENTITY_ITEM_PICKUP, SoundCategory.PLAYERS, .2f,
-				1f + Create.random.nextFloat());
+				1f + Create.RANDOM.nextFloat());
 		}
 		ItemStackHandler outputs = behaviour.processingOutputBuffer;
 		for (int i = 0; i < outputs.getSlots(); i++)

--- a/src/main/java/com/simibubi/create/content/logistics/block/inventories/AdjustableCrateContainer.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/inventories/AdjustableCrateContainer.java
@@ -7,6 +7,7 @@ import net.minecraft.client.world.ClientWorld;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.inventory.container.Container;
+import net.minecraft.inventory.container.ContainerType;
 import net.minecraft.inventory.container.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.PacketBuffer;
@@ -19,8 +20,8 @@ public class AdjustableCrateContainer extends Container {
 	public PlayerInventory playerInventory;
 	public boolean doubleCrate;
 
-	public AdjustableCrateContainer(int id, PlayerInventory inv, PacketBuffer extraData) {
-		super(AllContainerTypes.FLEXCRATE.type, id);
+	public AdjustableCrateContainer(ContainerType<?> type, int id, PlayerInventory inv, PacketBuffer extraData) {
+		super(type, id);
 		ClientWorld world = Minecraft.getInstance().world;
 		TileEntity tileEntity = world.getTileEntity(extraData.readBlockPos());
 		this.playerInventory = inv;
@@ -31,11 +32,15 @@ public class AdjustableCrateContainer extends Container {
 		}
 	}
 
-	public AdjustableCrateContainer(int id, PlayerInventory inv, AdjustableCrateTileEntity te) {
-		super(AllContainerTypes.FLEXCRATE.type, id);
+	public AdjustableCrateContainer(ContainerType<?> type, int id, PlayerInventory inv, AdjustableCrateTileEntity te) {
+		super(type, id);
 		this.te = te;
 		this.playerInventory = inv;
 		init();
+	}
+
+	public static AdjustableCrateContainer create(int id, PlayerInventory inv, AdjustableCrateTileEntity te) {
+		return new AdjustableCrateContainer(AllContainerTypes.FLEXCRATE.get(), id, inv, te);
 	}
 
 	private void init() {

--- a/src/main/java/com/simibubi/create/content/logistics/block/inventories/AdjustableCrateTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/inventories/AdjustableCrateTileEntity.java
@@ -72,7 +72,7 @@ public class AdjustableCrateTileEntity extends CrateTileEntity implements INamed
 
 	@Override
 	public Container createMenu(int id, PlayerInventory inventory, PlayerEntity player) {
-		return new AdjustableCrateContainer(id, inventory, this);
+		return AdjustableCrateContainer.create(id, inventory, this);
 	}
 
 	public AdjustableCrateTileEntity getOtherCrate() {

--- a/src/main/java/com/simibubi/create/content/logistics/block/mechanicalArm/ArmInteractionPointHandler.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/mechanicalArm/ArmInteractionPointHandler.java
@@ -195,7 +195,7 @@ public class ArmInteractionPointHandler {
 				continue;
 
 			int color = point.mode == Mode.DEPOSIT ? 0xffcb74 : 0x4f8a8b;
-			CreateClient.outliner.showAABB(point, shape.getBoundingBox()
+			CreateClient.OUTLINER.showAABB(point, shape.getBoundingBox()
 				.offset(pos))
 				.colored(color)
 				.lineWidth(1 / 16f);

--- a/src/main/java/com/simibubi/create/content/logistics/block/mechanicalArm/ArmTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/mechanicalArm/ArmTileEntity.java
@@ -352,7 +352,7 @@ public class ArmTileEntity extends KineticTileEntity {
 
 				if (!prevHeld.isItemEqual(heldItem))
 					world.playSound(null, pos, SoundEvents.ENTITY_ITEM_PICKUP, SoundCategory.BLOCKS, .125f,
-						.5f + Create.random.nextFloat() * .25f);
+						.5f + Create.RANDOM.nextFloat() * .25f);
 				return;
 			}
 

--- a/src/main/java/com/simibubi/create/content/logistics/item/filter/AttributeFilterContainer.java
+++ b/src/main/java/com/simibubi/create/content/logistics/item/filter/AttributeFilterContainer.java
@@ -9,6 +9,7 @@ import com.simibubi.create.foundation.utility.Pair;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.inventory.container.ClickType;
+import net.minecraft.inventory.container.ContainerType;
 import net.minecraft.inventory.container.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
@@ -30,12 +31,16 @@ public class AttributeFilterContainer extends AbstractFilterContainer {
 	WhitelistMode whitelistMode;
 	List<Pair<ItemAttribute, Boolean>> selectedAttributes;
 
-	public AttributeFilterContainer(int id, PlayerInventory inv, PacketBuffer extraData) {
-		super(AllContainerTypes.ATTRIBUTE_FILTER.type, id, inv, extraData);
+	public AttributeFilterContainer(ContainerType<?> type, int id, PlayerInventory inv, PacketBuffer extraData) {
+		super(type, id, inv, extraData);
 	}
 
-	public AttributeFilterContainer(int id, PlayerInventory inv, ItemStack stack) {
-		super(AllContainerTypes.ATTRIBUTE_FILTER.type, id, inv, stack);
+	public AttributeFilterContainer(ContainerType<?> type, int id, PlayerInventory inv, ItemStack stack) {
+		super(type, id, inv, stack);
+	}
+
+	public static AttributeFilterContainer create(int id, PlayerInventory inv, ItemStack stack) {
+		return new AttributeFilterContainer(AllContainerTypes.ATTRIBUTE_FILTER.get(), id, inv, stack);
 	}
 
 	public void appendSelectedAttribute(ItemAttribute itemAttribute, boolean inverted) {

--- a/src/main/java/com/simibubi/create/content/logistics/item/filter/FilterContainer.java
+++ b/src/main/java/com/simibubi/create/content/logistics/item/filter/FilterContainer.java
@@ -3,6 +3,7 @@ package com.simibubi.create.content.logistics.item.filter;
 import com.simibubi.create.AllContainerTypes;
 
 import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.inventory.container.ContainerType;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.network.PacketBuffer;
@@ -14,12 +15,16 @@ public class FilterContainer extends AbstractFilterContainer {
 	boolean respectNBT;
 	boolean blacklist;
 
-	public FilterContainer(int id, PlayerInventory inv, PacketBuffer extraData) {
-		super(AllContainerTypes.FILTER.type, id, inv, extraData);
+	public FilterContainer(ContainerType<?> type, int id, PlayerInventory inv, PacketBuffer extraData) {
+		super(type, id, inv, extraData);
 	}
 
-	public FilterContainer(int id, PlayerInventory inv, ItemStack stack) {
-		super(AllContainerTypes.FILTER.type, id, inv, stack);
+	public FilterContainer(ContainerType<?> type, int id, PlayerInventory inv, ItemStack stack) {
+		super(type, id, inv, stack);
+	}
+
+	public static FilterContainer create(int id, PlayerInventory inv, ItemStack stack) {
+		return new FilterContainer(AllContainerTypes.FILTER.get(), id, inv, stack);
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/logistics/item/filter/FilterItem.java
+++ b/src/main/java/com/simibubi/create/content/logistics/item/filter/FilterItem.java
@@ -157,9 +157,9 @@ public class FilterItem extends Item implements INamedContainerProvider {
 	public Container createMenu(int id, PlayerInventory inv, PlayerEntity player) {
 		ItemStack heldItem = player.getHeldItemMainhand();
 		if (type == FilterType.REGULAR)
-			return new FilterContainer(id, inv, heldItem);
+			return FilterContainer.create(id, inv, heldItem);
 		if (type == FilterType.ATTRIBUTE)
-			return new AttributeFilterContainer(id, inv, heldItem);
+			return AttributeFilterContainer.create(id, inv, heldItem);
 		return null;
 	}
 

--- a/src/main/java/com/simibubi/create/content/palettes/AllPaletteBlocks.java
+++ b/src/main/java/com/simibubi/create/content/palettes/AllPaletteBlocks.java
@@ -36,7 +36,7 @@ import net.minecraftforge.common.Tags;
 public class AllPaletteBlocks {
 
 	private static final CreateRegistrate REGISTRATE = Create.registrate()
-		.itemGroup(() -> Create.palettesCreativeTab)
+		.itemGroup(() -> Create.PALETTES_CREATIVE_TAB)
 		.startSection(AllSections.PALETTES);
 
 	// Windows and Glass

--- a/src/main/java/com/simibubi/create/content/schematics/ClientSchematicLoader.java
+++ b/src/main/java/com/simibubi/create/content/schematics/ClientSchematicLoader.java
@@ -59,7 +59,7 @@ public class ClientSchematicLoader {
 		Path path = Paths.get("schematics", schematic);
 
 		if (!Files.exists(path)) {
-			Create.logger.fatal("Missing Schematic file: " + path.toString());
+			Create.LOGGER.fatal("Missing Schematic file: " + path.toString());
 			return;
 		}
 

--- a/src/main/java/com/simibubi/create/content/schematics/SchematicWorld.java
+++ b/src/main/java/com/simibubi/create/content/schematics/SchematicWorld.java
@@ -104,7 +104,7 @@ public class SchematicWorld extends WrappedWorld implements IServerWorld {
 				}
 				return tileEntity;
 			} catch (Exception e) {
-				Create.logger.debug("Could not create TE of block " + blockState + ": " + e);
+				Create.LOGGER.debug("Could not create TE of block " + blockState + ": " + e);
 			}
 		}
 		return null;

--- a/src/main/java/com/simibubi/create/content/schematics/ServerSchematicLoader.java
+++ b/src/main/java/com/simibubi/create/content/schematics/ServerSchematicLoader.java
@@ -72,7 +72,7 @@ public class ServerSchematicLoader {
 			SchematicUploadEntry entry = activeUploads.get(upload);
 
 			if (entry.idleTime++ > getConfig().schematicIdleTimeout.get()) {
-				Create.logger.warn("Schematic Upload timed out: " + upload);
+				Create.LOGGER.warn("Schematic Upload timed out: " + upload);
 				deadEntries.add(upload);
 			}
 
@@ -94,7 +94,7 @@ public class ServerSchematicLoader {
 
 		// Unsupported Format
 		if (!schematic.endsWith(".nbt")) {
-			Create.logger.warn("Attempted Schematic Upload with non-supported Format: " + playerSchematicId);
+			Create.LOGGER.warn("Attempted Schematic Upload with non-supported Format: " + playerSchematicId);
 			return;
 		}
 
@@ -102,7 +102,7 @@ public class ServerSchematicLoader {
 
 		Path uploadPath = playerSchematicsPath.resolve(schematic).normalize();
 		if (!uploadPath.startsWith(playerSchematicsPath)) {
-			Create.logger.warn("Attempted Schematic Upload with directory escape: {}", playerSchematicId);
+			Create.LOGGER.warn("Attempted Schematic Upload with directory escape: {}", playerSchematicId);
 			return;
 		}
 
@@ -148,7 +148,7 @@ public class ServerSchematicLoader {
 			table.startUpload(schematic);
 
 		} catch (IOException e) {
-			Create.logger.error("Exception Thrown when starting Upload: " + playerSchematicId);
+			Create.LOGGER.error("Exception Thrown when starting Upload: " + playerSchematicId);
 			e.printStackTrace();
 		}
 	}
@@ -178,13 +178,13 @@ public class ServerSchematicLoader {
 
 			// Size Validations
 			if (data.length > getConfig().maxSchematicPacketSize.get()) {
-				Create.logger.warn("Oversized Upload Packet received: " + playerSchematicId);
+				Create.LOGGER.warn("Oversized Upload Packet received: " + playerSchematicId);
 				cancelUpload(playerSchematicId);
 				return;
 			}
 
 			if (entry.bytesUploaded > entry.totalBytes) {
-				Create.logger.warn("Received more data than Expected: " + playerSchematicId);
+				Create.LOGGER.warn("Received more data than Expected: " + playerSchematicId);
 				cancelUpload(playerSchematicId);
 				return;
 			}
@@ -200,7 +200,7 @@ public class ServerSchematicLoader {
 				table.sendUpdate = true;
 
 			} catch (IOException e) {
-				Create.logger.error("Exception Thrown when uploading Schematic: " + playerSchematicId);
+				Create.LOGGER.error("Exception Thrown when uploading Schematic: " + playerSchematicId);
 				e.printStackTrace();
 				cancelUpload(playerSchematicId);
 			}
@@ -215,10 +215,10 @@ public class ServerSchematicLoader {
 		try {
 			entry.stream.close();
 			Files.deleteIfExists(Paths.get(getSchematicPath(), playerSchematicId));
-			Create.logger.warn("Cancelled Schematic Upload: " + playerSchematicId);
+			Create.LOGGER.warn("Cancelled Schematic Upload: " + playerSchematicId);
 
 		} catch (IOException e) {
-			Create.logger.error("Exception Thrown when cancelling Upload: " + playerSchematicId);
+			Create.LOGGER.error("Exception Thrown when cancelling Upload: " + playerSchematicId);
 			e.printStackTrace();
 		}
 
@@ -249,7 +249,7 @@ public class ServerSchematicLoader {
 				World world = removed.world;
 				BlockPos pos = removed.tablePos;
 
-				Create.logger.info("New Schematic Uploaded: " + playerSchematicId);
+				Create.LOGGER.info("New Schematic Uploaded: " + playerSchematicId);
 				if (pos == null)
 					return;
 
@@ -264,7 +264,7 @@ public class ServerSchematicLoader {
 				table.inventory.setStackInSlot(1, SchematicItem.create(schematic, player.getGameProfile().getName()));
 
 			} catch (IOException e) {
-				Create.logger.error("Exception Thrown when finishing Upload: " + playerSchematicId);
+				Create.LOGGER.error("Exception Thrown when finishing Upload: " + playerSchematicId);
 				e.printStackTrace();
 			}
 		}
@@ -278,7 +278,7 @@ public class ServerSchematicLoader {
 
 		// Unsupported Format
 		if (!schematic.endsWith(".nbt")) {
-			Create.logger.warn("Attempted Schematic Upload with non-supported Format: {}", playerSchematicId);
+			Create.LOGGER.warn("Attempted Schematic Upload with non-supported Format: {}", playerSchematicId);
 			return;
 		}
 
@@ -286,7 +286,7 @@ public class ServerSchematicLoader {
 
 		Path path = schematicPath.resolve(playerSchematicId).normalize();
 		if (!path.startsWith(schematicPath)) {
-			Create.logger.warn("Attempted Schematic Upload with directory escape: {}", playerSchematicId);
+			Create.LOGGER.warn("Attempted Schematic Upload with directory escape: {}", playerSchematicId);
 			return;
 		}
 
@@ -326,7 +326,7 @@ public class ServerSchematicLoader {
 				e.printStackTrace();
 			}
 		} catch (IOException e) {
-			Create.logger.error("Exception Thrown in direct Schematic Upload: " + playerSchematicId);
+			Create.LOGGER.error("Exception Thrown in direct Schematic Upload: " + playerSchematicId);
 			e.printStackTrace();
 		}
 	}

--- a/src/main/java/com/simibubi/create/content/schematics/block/SchematicTableContainer.java
+++ b/src/main/java/com/simibubi/create/content/schematics/block/SchematicTableContainer.java
@@ -8,6 +8,7 @@ import net.minecraft.client.world.ClientWorld;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.inventory.container.Container;
+import net.minecraft.inventory.container.ContainerType;
 import net.minecraft.inventory.container.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.PacketBuffer;
@@ -21,8 +22,8 @@ public class SchematicTableContainer extends Container {
 	private Slot outputSlot;
 	private PlayerEntity player;
 
-	public SchematicTableContainer(int id, PlayerInventory inv, PacketBuffer extraData) {
-		super(AllContainerTypes.SCHEMATIC_TABLE.type, id);
+	public SchematicTableContainer(ContainerType<?> type, int id, PlayerInventory inv, PacketBuffer extraData) {
+		super(type, id);
 		player = inv.player;
 		ClientWorld world = Minecraft.getInstance().world;
 		TileEntity tileEntity = world.getTileEntity(extraData.readBlockPos());
@@ -33,11 +34,15 @@ public class SchematicTableContainer extends Container {
 		}
 	}
 
-	public SchematicTableContainer(int id, PlayerInventory inv, SchematicTableTileEntity te) {
-		super(AllContainerTypes.SCHEMATIC_TABLE.type, id);
+	public SchematicTableContainer(ContainerType<?> type, int id, PlayerInventory inv, SchematicTableTileEntity te) {
+		super(type, id);
 		this.player = inv.player;
 		this.te = te;
 		init();
+	}
+
+	public static SchematicTableContainer create(int id, PlayerInventory inv, SchematicTableTileEntity te) {
+		return new SchematicTableContainer(AllContainerTypes.SCHEMATIC_TABLE.get(), id, inv, te);
 	}
 
 	protected void init() {

--- a/src/main/java/com/simibubi/create/content/schematics/block/SchematicTableScreen.java
+++ b/src/main/java/com/simibubi/create/content/schematics/block/SchematicTableScreen.java
@@ -68,8 +68,8 @@ public class SchematicTableScreen extends AbstractSimiContainerScreen<SchematicT
 		int mainLeft = guiLeft - 56;
 		int mainTop = guiTop - 16;
 
-		CreateClient.schematicSender.refresh();
-		List<ITextComponent> availableSchematics = CreateClient.schematicSender.getAvailableSchematics();
+		CreateClient.SCHEMATIC_SENDER.refresh();
+		List<ITextComponent> availableSchematics = CreateClient.SCHEMATIC_SENDER.getAvailableSchematics();
 
 		schematicsLabel = new Label(mainLeft + 49, mainTop + 26, StringTextComponent.EMPTY).withShadow();
 		schematicsLabel.text = StringTextComponent.EMPTY;
@@ -176,7 +176,7 @@ public class SchematicTableScreen extends AbstractSimiContainerScreen<SchematicT
 
 	@Override
 	public boolean mouseClicked(double p_mouseClicked_1_, double p_mouseClicked_3_, int p_mouseClicked_5_) {
-		ClientSchematicLoader schematicSender = CreateClient.schematicSender;
+		ClientSchematicLoader schematicSender = CreateClient.SCHEMATIC_SENDER;
 
 		if (confirmButton.active && confirmButton.isHovered() && ((SchematicTableContainer) container).canWrite()
 			&& schematicsArea != null) {

--- a/src/main/java/com/simibubi/create/content/schematics/block/SchematicTableTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/schematics/block/SchematicTableTileEntity.java
@@ -110,8 +110,8 @@ public class SchematicTableTileEntity extends SyncedTileEntity implements ITicka
 	}
 
 	@Override
-	public Container createMenu(int p_createMenu_1_, PlayerInventory p_createMenu_2_, PlayerEntity p_createMenu_3_) {
-		return new SchematicTableContainer(p_createMenu_1_, p_createMenu_2_, this);
+	public Container createMenu(int id, PlayerInventory inv, PlayerEntity player) {
+		return SchematicTableContainer.create(id, inv, this);
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/schematics/block/SchematicannonContainer.java
+++ b/src/main/java/com/simibubi/create/content/schematics/block/SchematicannonContainer.java
@@ -7,6 +7,7 @@ import net.minecraft.client.world.ClientWorld;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.inventory.container.Container;
+import net.minecraft.inventory.container.ContainerType;
 import net.minecraft.inventory.container.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.PacketBuffer;
@@ -18,8 +19,8 @@ public class SchematicannonContainer extends Container {
 	private SchematicannonTileEntity te;
 	private PlayerEntity player;
 
-	public SchematicannonContainer(int id, PlayerInventory inv, PacketBuffer buffer) {
-		super(AllContainerTypes.SCHEMATICANNON.type, id);
+	public SchematicannonContainer(ContainerType<?> type, int id, PlayerInventory inv, PacketBuffer buffer) {
+		super(type, id);
 		player = inv.player;
 		ClientWorld world = Minecraft.getInstance().world;
 		TileEntity tileEntity = world.getTileEntity(buffer.readBlockPos());
@@ -30,11 +31,15 @@ public class SchematicannonContainer extends Container {
 		}
 	}
 
-	public SchematicannonContainer(int id, PlayerInventory inv, SchematicannonTileEntity te) {
-		super(AllContainerTypes.SCHEMATICANNON.type, id);
+	public SchematicannonContainer(ContainerType<?> type, int id, PlayerInventory inv, SchematicannonTileEntity te) {
+		super(type, id);
 		player = inv.player;
 		this.te = te;
 		init();
+	}
+
+	public static SchematicannonContainer create(int id, PlayerInventory inv, SchematicannonTileEntity te) {
+		return new SchematicannonContainer(AllContainerTypes.SCHEMATICANNON.get(), id, inv, te);
 	}
 
 	protected void init() {

--- a/src/main/java/com/simibubi/create/content/schematics/block/SchematicannonTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/schematics/block/SchematicannonTileEntity.java
@@ -28,8 +28,6 @@ import com.simibubi.create.foundation.item.ItemHelper.ExtractionCountMode;
 import com.simibubi.create.foundation.render.backend.instancing.IInstanceRendered;
 import com.simibubi.create.foundation.tileEntity.SmartTileEntity;
 import com.simibubi.create.foundation.tileEntity.TileEntityBehaviour;
-import com.simibubi.create.foundation.tileEntity.behaviour.BehaviourType;
-import com.simibubi.create.foundation.tileEntity.behaviour.filtering.FilteringBehaviour;
 import com.simibubi.create.foundation.utility.BlockHelper;
 import com.simibubi.create.foundation.utility.IPartialSafeNBT;
 import com.simibubi.create.foundation.utility.Iterate;
@@ -934,7 +932,7 @@ public class SchematicannonTileEntity extends SmartTileEntity implements INamedC
 
 	@Override
 	public Container createMenu(int id, PlayerInventory inv, PlayerEntity player) {
-		return new SchematicannonContainer(id, inv, this);
+		return SchematicannonContainer.create(id, inv, this);
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/schematics/client/SchematicAndQuillHandler.java
+++ b/src/main/java/com/simibubi/create/content/schematics/client/SchematicAndQuillHandler.java
@@ -239,7 +239,7 @@ public class SchematicAndQuillHandler {
 		if (!convertImmediately)
 			return;
 		if (!Files.exists(path)) {
-			Create.logger.fatal("Missing Schematic file: " + path.toString());
+			Create.LOGGER.fatal("Missing Schematic file: " + path.toString());
 			return;
 		}
 		try {
@@ -248,14 +248,14 @@ public class SchematicAndQuillHandler {
 			AllPackets.channel.sendToServer(new InstantSchematicPacket(filename, origin, bounds));
 
 		} catch (IOException e) {
-			Create.logger.fatal("Error finding Schematic file: " + path.toString());
+			Create.LOGGER.fatal("Error finding Schematic file: " + path.toString());
 			e.printStackTrace();
 			return;
 		}
 	}
 
 	private Outliner outliner() {
-		return CreateClient.outliner;
+		return CreateClient.OUTLINER;
 	}
 
 }

--- a/src/main/java/com/simibubi/create/content/schematics/client/SchematicEditScreen.java
+++ b/src/main/java/com/simibubi/create/content/schematics/client/SchematicEditScreen.java
@@ -50,7 +50,7 @@ public class SchematicEditScreen extends AbstractSimiScreen {
 		setWindowSize(background.width + 50, background.height);
 		int x = guiLeft;
 		int y = guiTop;
-		handler = CreateClient.schematicHandler;
+		handler = CreateClient.SCHEMATIC_HANDLER;
 
 		xInput = new TextFieldWidget(textRenderer, x + 50, y + 26, 34, 10, StringTextComponent.EMPTY);
 		yInput = new TextFieldWidget(textRenderer, x + 90, y + 26, 34, 10, StringTextComponent.EMPTY);

--- a/src/main/java/com/simibubi/create/content/schematics/client/SchematicPromptScreen.java
+++ b/src/main/java/com/simibubi/create/content/schematics/client/SchematicPromptScreen.java
@@ -90,7 +90,7 @@ public class SchematicPromptScreen extends AbstractSimiScreen {
 			return true;
 		}
 		if (abort.isHovered()) {
-			CreateClient.schematicAndQuillHandler.discard();
+			CreateClient.SCHEMATIC_AND_QUILL_HANDLER.discard();
 			Minecraft.getInstance().player.closeScreen();
 			return true;
 		}
@@ -102,7 +102,7 @@ public class SchematicPromptScreen extends AbstractSimiScreen {
 	}
 
 	private void confirm(boolean convertImmediately) {
-		CreateClient.schematicAndQuillHandler.saveSchematic(nameField.getText(), convertImmediately);
+		CreateClient.SCHEMATIC_AND_QUILL_HANDLER.saveSchematic(nameField.getText(), convertImmediately);
 		Minecraft.getInstance().player.closeScreen();
 	}
 

--- a/src/main/java/com/simibubi/create/content/schematics/client/tools/SchematicToolBase.java
+++ b/src/main/java/com/simibubi/create/content/schematics/client/tools/SchematicToolBase.java
@@ -45,7 +45,7 @@ public abstract class SchematicToolBase implements ISchematicTool {
 
 	@Override
 	public void init() {
-		schematicHandler = CreateClient.schematicHandler;
+		schematicHandler = CreateClient.SCHEMATIC_HANDLER;
 		selectedPos = null;
 		selectedFace = null;
 		schematicSelected = false;

--- a/src/main/java/com/simibubi/create/content/schematics/packet/InstantSchematicPacket.java
+++ b/src/main/java/com/simibubi/create/content/schematics/packet/InstantSchematicPacket.java
@@ -43,7 +43,7 @@ public class InstantSchematicPacket extends SimplePacketBase {
 					.getSender();
 				if (player == null)
 					return;
-				Create.schematicReceiver.handleInstantSchematic(player, name, player.world, origin, bounds);
+				Create.SCHEMATIC_RECEIVER.handleInstantSchematic(player, name, player.world, origin, bounds);
 			});
 		context.get()
 			.setPacketHandled(true);

--- a/src/main/java/com/simibubi/create/content/schematics/packet/SchematicUploadPacket.java
+++ b/src/main/java/com/simibubi/create/content/schematics/packet/SchematicUploadPacket.java
@@ -73,12 +73,12 @@ public class SchematicUploadPacket extends SimplePacketBase {
 				if (code == BEGIN) {
 					BlockPos pos = ((SchematicTableContainer) player.openContainer).getTileEntity()
 						.getPos();
-					Create.schematicReceiver.handleNewUpload(player, schematic, size, pos);
+					Create.SCHEMATIC_RECEIVER.handleNewUpload(player, schematic, size, pos);
 				}
 				if (code == WRITE) 
-					Create.schematicReceiver.handleWriteRequest(player, schematic, data);
+					Create.SCHEMATIC_RECEIVER.handleWriteRequest(player, schematic, data);
 				if (code == FINISH) 
-					Create.schematicReceiver.handleFinishedUpload(player, schematic);
+					Create.SCHEMATIC_RECEIVER.handleFinishedUpload(player, schematic);
 			});
 		context.get()
 			.setPacketHandled(true);

--- a/src/main/java/com/simibubi/create/events/ClientEvents.java
+++ b/src/main/java/com/simibubi/create/events/ClientEvents.java
@@ -110,9 +110,9 @@ public class ClientEvents {
 		FastRenderDispatcher.tick();
 		ScrollValueHandler.tick();
 
-		CreateClient.schematicSender.tick();
-		CreateClient.schematicAndQuillHandler.tick();
-		CreateClient.schematicHandler.tick();
+		CreateClient.SCHEMATIC_SENDER.tick();
+		CreateClient.SCHEMATIC_AND_QUILL_HANDLER.tick();
+		CreateClient.SCHEMATIC_HANDLER.tick();
 
 		ContraptionHandler.tick(world);
 		CapabilityMinecartController.tick(world);
@@ -137,8 +137,8 @@ public class ClientEvents {
 		ArmInteractionPointHandler.tick();
 		EjectorTargetHandler.tick();
 		PlacementHelpers.tick();
-		CreateClient.outliner.tickOutlines();
-		CreateClient.ghostBlocks.tickGhosts();
+		CreateClient.OUTLINER.tickOutlines();
+		CreateClient.GHOST_BLOCKS.tickGhosts();
 		ContraptionRenderDispatcher.tick();
 	}
 
@@ -153,7 +153,7 @@ public class ClientEvents {
 		if (world.isRemote() && world instanceof ClientWorld && !(world instanceof WrappedClientWorld)) {
 			CreateClient.invalidateRenderers(world);
 			AnimationTickHolder.reset();
-			KineticRenderer renderer = CreateClient.kineticRenderer.get(world);
+			KineticRenderer renderer = CreateClient.KINETIC_RENDERER.get(world);
 			renderer.invalidate();
 			((ClientWorld) world).loadedTileEntityList.forEach(renderer::add);
 		}
@@ -187,10 +187,10 @@ public class ClientEvents {
 		SuperRenderTypeBuffer buffer = SuperRenderTypeBuffer.getInstance();
 
 		CouplingRenderer.renderAll(ms, buffer);
-		CreateClient.schematicHandler.render(ms, buffer);
-		CreateClient.ghostBlocks.renderAll(ms, buffer);
+		CreateClient.SCHEMATIC_HANDLER.render(ms, buffer);
+		CreateClient.GHOST_BLOCKS.renderAll(ms, buffer);
 
-		CreateClient.outliner.renderOutlines(ms, buffer, pt);
+		CreateClient.OUTLINER.renderOutlines(ms, buffer, pt);
 		// LightVolumeDebugger.render(ms, buffer);
 		buffer.draw();
 		RenderSystem.enableCull();
@@ -220,7 +220,7 @@ public class ClientEvents {
 
 	public static void onRenderHotbar(MatrixStack ms, IRenderTypeBuffer buffer, int light, int overlay,
 		float partialTicks) {
-		CreateClient.schematicHandler.renderOverlay(ms, buffer, light, overlay, partialTicks);
+		CreateClient.SCHEMATIC_HANDLER.renderOverlay(ms, buffer, light, overlay, partialTicks);
 	}
 
 	@SubscribeEvent

--- a/src/main/java/com/simibubi/create/events/CommonEvents.java
+++ b/src/main/java/com/simibubi/create/events/CommonEvents.java
@@ -10,7 +10,6 @@ import com.simibubi.create.content.contraptions.fluids.recipe.PotionMixingRecipe
 import com.simibubi.create.content.contraptions.wrench.WrenchItem;
 import com.simibubi.create.content.curiosities.zapper.ZapperInteractionHandler;
 import com.simibubi.create.content.curiosities.zapper.ZapperItem;
-import com.simibubi.create.content.schematics.ServerSchematicLoader;
 import com.simibubi.create.foundation.command.AllCommands;
 import com.simibubi.create.foundation.fluid.FluidHelper;
 import com.simibubi.create.foundation.utility.Iterate;
@@ -54,10 +53,8 @@ public class CommonEvents {
 	public static void onServerTick(ServerTickEvent event) {
 		if (event.phase == Phase.START)
 			return;
-		if (Create.schematicReceiver == null)
-			Create.schematicReceiver = new ServerSchematicLoader();
-		Create.schematicReceiver.tick();
-		Create.lagger.tick();
+		Create.SCHEMATIC_RECEIVER.tick();
+		Create.LAGGER.tick();
 		ServerSpeedProvider.serverTick();
 	}
 
@@ -133,21 +130,21 @@ public class CommonEvents {
 
 	@SubscribeEvent
 	public static void serverStopped(FMLServerStoppingEvent event) {
-		Create.schematicReceiver.shutdown();
+		Create.SCHEMATIC_RECEIVER.shutdown();
 	}
 
 	@SubscribeEvent
 	public static void onLoadWorld(WorldEvent.Load event) {
 		IWorld world = event.getWorld();
-		Create.redstoneLinkNetworkHandler.onLoadWorld(world);
-		Create.torquePropagator.onLoadWorld(world);
+		Create.REDSTONE_LINK_NETWORK_HANDLER.onLoadWorld(world);
+		Create.TORQUE_PROPAGATOR.onLoadWorld(world);
 	}
 
 	@SubscribeEvent
 	public static void onUnloadWorld(WorldEvent.Unload event) {
 		IWorld world = event.getWorld();
-		Create.redstoneLinkNetworkHandler.onUnloadWorld(world);
-		Create.torquePropagator.onUnloadWorld(world);
+		Create.REDSTONE_LINK_NETWORK_HANDLER.onUnloadWorld(world);
+		Create.TORQUE_PROPAGATOR.onUnloadWorld(world);
 		WorldAttached.invalidateWorld(world);
 	}
 

--- a/src/main/java/com/simibubi/create/events/InputEvents.java
+++ b/src/main/java/com/simibubi/create/events/InputEvents.java
@@ -23,7 +23,7 @@ public class InputEvents {
 		if (Minecraft.getInstance().currentScreen != null)
 			return;
 
-		CreateClient.schematicHandler.onKeyInput(key, pressed);
+		CreateClient.SCHEMATIC_HANDLER.onKeyInput(key, pressed);
 	}
 
 	@SubscribeEvent
@@ -33,8 +33,8 @@ public class InputEvents {
 
 		double delta = event.getScrollDelta();
 //		CollisionDebugger.onScroll(delta);
-		boolean cancelled = CreateClient.schematicHandler.mouseScrolled(delta)
-			|| CreateClient.schematicAndQuillHandler.mouseScrolled(delta) || FilteringHandler.onScroll(delta)
+		boolean cancelled = CreateClient.SCHEMATIC_HANDLER.mouseScrolled(delta)
+			|| CreateClient.SCHEMATIC_AND_QUILL_HANDLER.mouseScrolled(delta) || FilteringHandler.onScroll(delta)
 			|| ScrollValueHandler.onScroll(delta);
 		event.setCanceled(cancelled);
 	}
@@ -47,8 +47,8 @@ public class InputEvents {
 		int button = event.getButton();
 		boolean pressed = !(event.getAction() == 0);
 
-		CreateClient.schematicHandler.onMouseInput(button, pressed);
-		CreateClient.schematicAndQuillHandler.onMouseInput(button, pressed);
+		CreateClient.SCHEMATIC_HANDLER.onMouseInput(button, pressed);
+		CreateClient.SCHEMATIC_AND_QUILL_HANDLER.onMouseInput(button, pressed);
 	}
 
 }

--- a/src/main/java/com/simibubi/create/foundation/block/ITE.java
+++ b/src/main/java/com/simibubi/create/foundation/block/ITE.java
@@ -97,7 +97,7 @@ public interface ITE<T extends TileEntity> {
 
 	static void report(TileEntityException e) {
 		if (AllConfigs.COMMON.logTeErrors.get())
-			Create.logger.debug("TileEntityException thrown!", e);
+			Create.LOGGER.debug("TileEntityException thrown!", e);
 	}
 
 }

--- a/src/main/java/com/simibubi/create/foundation/command/ChunkUtilCommand.java
+++ b/src/main/java/com/simibubi/create/foundation/command/ChunkUtilCommand.java
@@ -26,7 +26,7 @@ public class ChunkUtilCommand {
 							.getWorld()
 							.getChunkProvider();
 
-						boolean success = Create.chunkUtil.reloadChunk(chunkProvider, chunkPos);
+						boolean success = Create.CHUNK_UTIL.reloadChunk(chunkProvider, chunkPos);
 
 						if (success) {
 							ctx.getSource()
@@ -52,7 +52,7 @@ public class ChunkUtilCommand {
 							.getWorld()
 							.getChunkProvider();
 
-						boolean success = Create.chunkUtil.unloadChunk(chunkProvider, chunkPos);
+						boolean success = Create.CHUNK_UTIL.unloadChunk(chunkProvider, chunkPos);
 						ctx.getSource()
 							.sendFeedback(
 								new StringTextComponent("added chunk " + chunkPos.toString() + " to unload list"),
@@ -75,7 +75,7 @@ public class ChunkUtilCommand {
 			.then(Commands.literal("clear")
 				.executes(ctx -> {
 					// chunk clear
-					int count = Create.chunkUtil.clear(ctx.getSource()
+					int count = Create.CHUNK_UTIL.clear(ctx.getSource()
 						.getWorld()
 						.getChunkProvider());
 					ctx.getSource()

--- a/src/main/java/com/simibubi/create/foundation/command/HighlightPacket.java
+++ b/src/main/java/com/simibubi/create/foundation/command/HighlightPacket.java
@@ -48,7 +48,7 @@ public class HighlightPacket extends SimplePacketBase {
 		if (Minecraft.getInstance().world == null || !Minecraft.getInstance().world.isBlockPresent(pos))
 			return;
 
-		CreateClient.outliner.showAABB("highlightCommand", VoxelShapes.fullCube()
+		CreateClient.OUTLINER.showAABB("highlightCommand", VoxelShapes.fullCube()
 			.getBoundingBox()
 			.offset(pos), 200)
 			.lineWidth(1 / 32f)

--- a/src/main/java/com/simibubi/create/foundation/command/KillTPSCommand.java
+++ b/src/main/java/com/simibubi/create/foundation/command/KillTPSCommand.java
@@ -17,8 +17,8 @@ public class KillTPSCommand {
 				// killtps no arguments
 				ctx.getSource()
 					.sendFeedback(Lang.createTranslationTextComponent("command.killTPSCommand.status.slowed_by.0",
-						Create.lagger.isLagging() ? Create.lagger.getTickTime() : 0), true);
-				if (Create.lagger.isLagging())
+						Create.LAGGER.isLagging() ? Create.LAGGER.getTickTime() : 0), true);
+				if (Create.LAGGER.isLagging())
 					ctx.getSource()
 						.sendFeedback(Lang.createTranslationTextComponent("command.killTPSCommand.status.usage.0"),
 							true);
@@ -32,9 +32,9 @@ public class KillTPSCommand {
 			.then(Commands.literal("start")
 				.executes(ctx -> {
 					// killtps start no time
-					int tickTime = Create.lagger.getTickTime();
+					int tickTime = Create.LAGGER.getTickTime();
 					if (tickTime > 0) {
-						Create.lagger.setLagging(true);
+						Create.LAGGER.setLagging(true);
 						ctx.getSource()
 							.sendFeedback((Lang
 								.createTranslationTextComponent("command.killTPSCommand.status.slowed_by.1", tickTime)),
@@ -57,8 +57,8 @@ public class KillTPSCommand {
 						int tickTime = IntegerArgumentType.getInteger(ctx,
 							Lang.translate("command.killTPSCommand.argument.tickTime")
 								.getUnformattedComponentText());
-						Create.lagger.setTickTime(tickTime);
-						Create.lagger.setLagging(true);
+						Create.LAGGER.setTickTime(tickTime);
+						Create.LAGGER.setLagging(true);
 						ctx.getSource()
 							.sendFeedback((Lang
 								.createTranslationTextComponent("command.killTPSCommand.status.slowed_by.1", tickTime)),
@@ -72,7 +72,7 @@ public class KillTPSCommand {
 			.then(Commands.literal("stop")
 				.executes(ctx -> {
 					// killtps stop
-					Create.lagger.setLagging(false);
+					Create.LAGGER.setLagging(false);
 					ctx.getSource()
 						.sendFeedback(Lang.createTranslationTextComponent("command.killTPSCommand.status.slowed_by.2"),
 							false);

--- a/src/main/java/com/simibubi/create/foundation/command/SConfigureConfigPacket.java
+++ b/src/main/java/com/simibubi/create/foundation/command/SConfigureConfigPacket.java
@@ -170,7 +170,7 @@ public class SConfigureConfigPacket extends SimplePacketBase {
 
 			ResourceLocation id = new ResourceLocation(value);
 			if (!PonderRegistry.all.containsKey(id)) {
-				Create.logger.error("Could not find ponder scenes for item: " + id);
+				Create.LOGGER.error("Could not find ponder scenes for item: " + id);
 				return;
 			}
 

--- a/src/main/java/com/simibubi/create/foundation/data/CreateRegistrate.java
+++ b/src/main/java/com/simibubi/create/foundation/data/CreateRegistrate.java
@@ -17,6 +17,7 @@ import com.simibubi.create.content.contraptions.relays.encased.CasingConnectivit
 import com.simibubi.create.foundation.block.IBlockVertexColor;
 import com.simibubi.create.foundation.block.connected.CTModel;
 import com.simibubi.create.foundation.block.connected.ConnectedTextureBehaviour;
+import com.simibubi.create.foundation.block.render.ColoredVertexModel;
 import com.simibubi.create.foundation.block.render.CustomRenderedItemModel;
 import com.tterrag.registrate.AbstractRegistrate;
 import com.tterrag.registrate.builders.BlockBuilder;
@@ -223,6 +224,12 @@ public class CreateRegistrate extends AbstractRegistrate<CreateRegistrate> {
 	}
 
 	@OnlyIn(Dist.CLIENT)
+	private static void registerBlockVertexColor(Block entry, IBlockVertexColor colorFunc) {
+		CreateClient.getCustomBlockModels()
+			.register(entry.delegate, model -> new ColoredVertexModel(model, colorFunc));
+	}
+
+	@OnlyIn(Dist.CLIENT)
 	private static void registerBlockModel(Block entry,
 		Supplier<NonNullFunction<IBakedModel, ? extends IBakedModel>> func) {
 		CreateClient.getCustomBlockModels()
@@ -248,12 +255,6 @@ public class CreateRegistrate extends AbstractRegistrate<CreateRegistrate> {
 		CreateClient.getColorHandler()
 			.register(entry, colorFunc.get()
 				.get());
-	}
-
-	@OnlyIn(Dist.CLIENT)
-	private static void registerBlockVertexColor(Block entry, IBlockVertexColor colorFunc) {
-		CreateClient.getColorHandler()
-			.register(entry, colorFunc);
 	}
 
 	@OnlyIn(Dist.CLIENT)

--- a/src/main/java/com/simibubi/create/foundation/data/LangMerger.java
+++ b/src/main/java/com/simibubi/create/foundation/data/LangMerger.java
@@ -119,7 +119,7 @@ public class LangMerger implements IDataProvider {
 
 	private void collectExistingEntries(Path path) throws IOException {
 		if (!Files.exists(path)) {
-			Create.logger.warn("Nothing to merge! It appears no lang was generated before me.");
+			Create.LOGGER.warn("Nothing to merge! It appears no lang was generated before me.");
 			return;
 		}
 
@@ -237,7 +237,7 @@ public class LangMerger implements IDataProvider {
 			Files.createDirectories(target.getParent());
 
 			try (BufferedWriter bufferedwriter = Files.newBufferedWriter(target)) {
-				Create.logger.info(message);
+				Create.LOGGER.info(message);
 				bufferedwriter.write(data);
 				bufferedwriter.close();
 			}

--- a/src/main/java/com/simibubi/create/foundation/data/recipe/CreateRecipeProvider.java
+++ b/src/main/java/com/simibubi/create/foundation/data/recipe/CreateRecipeProvider.java
@@ -29,7 +29,7 @@ public abstract class CreateRecipeProvider extends RecipeProvider {
 	@Override
 	protected void registerRecipes(Consumer<IFinishedRecipe> p_200404_1_) {
 		all.forEach(c -> c.register(p_200404_1_));
-		Create.logger.info(getName() + " registered " + all.size() + " recipe" + (all.size() == 1 ? "" : "s"));
+		Create.LOGGER.info(getName() + " registered " + all.size() + " recipe" + (all.size() == 1 ? "" : "s"));
 	}
 
 	@FunctionalInterface

--- a/src/main/java/com/simibubi/create/foundation/mixin/LightUpdateMixin.java
+++ b/src/main/java/com/simibubi/create/foundation/mixin/LightUpdateMixin.java
@@ -46,7 +46,7 @@ public abstract class LightUpdateMixin extends AbstractChunkProvider {
 					.getY()) == sectionY)
 				.map(Map.Entry::getValue)
 				.forEach(tile -> {
-					CreateClient.kineticRenderer.get(world)
+					CreateClient.KINETIC_RENDERER.get(world)
 						.onLightUpdate(tile);
 				});
 		}

--- a/src/main/java/com/simibubi/create/foundation/mixin/NetworkLightUpdateMixin.java
+++ b/src/main/java/com/simibubi/create/foundation/mixin/NetworkLightUpdateMixin.java
@@ -36,7 +36,7 @@ public class NetworkLightUpdateMixin {
 				chunk.getTileEntityMap()
 					.values()
 					.forEach(tile -> {
-						CreateClient.kineticRenderer.get(world)
+						CreateClient.KINETIC_RENDERER.get(world)
 							.onLightUpdate(tile);
 					});
 			}

--- a/src/main/java/com/simibubi/create/foundation/mixin/RenderHooksMixin.java
+++ b/src/main/java/com/simibubi/create/foundation/mixin/RenderHooksMixin.java
@@ -67,14 +67,14 @@ public class RenderHooksMixin {
 		double camY = cameraPos.getY();
 		double camZ = cameraPos.getZ();
 
-		CreateClient.kineticRenderer.get(world)
+		CreateClient.KINETIC_RENDERER.get(world)
 			.beginFrame(info, camX, camY, camZ);
 		ContraptionRenderDispatcher.beginFrame(info, camX, camY, camZ);
 	}
 
 	@Inject(at = @At("TAIL"), method = "scheduleBlockRerenderIfNeeded")
 	private void checkUpdate(BlockPos pos, BlockState lastState, BlockState newState, CallbackInfo ci) {
-		CreateClient.kineticRenderer.get(world)
+		CreateClient.KINETIC_RENDERER.get(world)
 			.update(world.getTileEntity(pos));
 	}
 
@@ -85,7 +85,7 @@ public class RenderHooksMixin {
 		Backend.refresh();
 
 		if (Backend.canUseInstancing() && world != null) {
-			KineticRenderer kineticRenderer = CreateClient.kineticRenderer.get(world);
+			KineticRenderer kineticRenderer = CreateClient.KINETIC_RENDERER.get(world);
 			kineticRenderer.invalidate();
 			world.loadedTileEntityList.forEach(kineticRenderer::add);
 		}

--- a/src/main/java/com/simibubi/create/foundation/mixin/TileRemoveMixin.java
+++ b/src/main/java/com/simibubi/create/foundation/mixin/TileRemoveMixin.java
@@ -24,7 +24,7 @@ public class TileRemoveMixin {
 	@Inject(at = @At("TAIL"), method = "remove")
 	private void onRemove(CallbackInfo ci) {
 		if (world instanceof ClientWorld)
-			CreateClient.kineticRenderer.get(this.world)
+			CreateClient.KINETIC_RENDERER.get(this.world)
 				.remove((TileEntity) (Object) this);
 	}
 }

--- a/src/main/java/com/simibubi/create/foundation/mixin/TileWorldHookMixin.java
+++ b/src/main/java/com/simibubi/create/foundation/mixin/TileWorldHookMixin.java
@@ -35,7 +35,7 @@ public class TileWorldHookMixin {
 	@Inject(at = @At("TAIL"), method = "addTileEntity")
 	private void onAddTile(TileEntity te, CallbackInfoReturnable<Boolean> cir) {
 		if (isRemote) {
-			CreateClient.kineticRenderer.get(self)
+			CreateClient.KINETIC_RENDERER.get(self)
 				.queueAdd(te);
 		}
 	}
@@ -46,7 +46,7 @@ public class TileWorldHookMixin {
 	@Inject(at = @At(value = "INVOKE", target = "Ljava/util/Set;clear()V", ordinal = 0), method = "tickBlockEntities")
 	private void onChunkUnload(CallbackInfo ci) {
 		if (isRemote) {
-			KineticRenderer kineticRenderer = CreateClient.kineticRenderer.get(self);
+			KineticRenderer kineticRenderer = CreateClient.KINETIC_RENDERER.get(self);
 			for (TileEntity tile : tileEntitiesToBeRemoved) {
 				kineticRenderer.remove(tile);
 			}

--- a/src/main/java/com/simibubi/create/foundation/ponder/PonderRegistry.java
+++ b/src/main/java/com/simibubi/create/foundation/ponder/PonderRegistry.java
@@ -113,7 +113,7 @@ public class PonderRegistry {
 		InputStream resourceAsStream = Create.class.getClassLoader()
 			.getResourceAsStream(filepath);
 		if (resourceAsStream == null) {
-			Create.logger.error("Ponder schematic missing: " + path);
+			Create.LOGGER.error("Ponder schematic missing: " + path);
 			return t;
 		}
 		try (DataInputStream stream =
@@ -121,7 +121,7 @@ public class PonderRegistry {
 			CompoundNBT nbt = CompressedStreamTools.read(stream, new NBTSizeTracker(0x20000000L));
 			t.read(nbt);
 		} catch (IOException e) {
-			Create.logger.warn("Failed to read ponder schematic", e);
+			Create.LOGGER.warn("Failed to read ponder schematic", e);
 		}
 		return t;
 	}

--- a/src/main/java/com/simibubi/create/foundation/ponder/content/KineticsScenes.java
+++ b/src/main/java/com/simibubi/create/foundation/ponder/content/KineticsScenes.java
@@ -631,7 +631,7 @@ public class KineticsScenes {
 		scene.overlay.showControls(new InputWindowElement(centerOf, Pointing.DOWN).rightClick()
 			.withItem(new ItemStack(Items.BLUE_DYE)), 40);
 		scene.idle(7);
-		scene.world.modifyBlock(util.grid.at(2, 2, 2), s -> AllBlocks.DYED_VALVE_HANDLES.get(11).getDefaultState()
+		scene.world.modifyBlock(util.grid.at(2, 2, 2), s -> AllBlocks.DYED_VALVE_HANDLES[11].getDefaultState()
 			.with(ValveHandleBlock.FACING, Direction.UP), true);
 		scene.idle(10);
 		scene.overlay.showText(70)

--- a/src/main/java/com/simibubi/create/foundation/ponder/elements/ParrotElement.java
+++ b/src/main/java/com/simibubi/create/foundation/ponder/elements/ParrotElement.java
@@ -143,7 +143,7 @@ public class ParrotElement extends AnimatedSceneElement {
 
 		ParrotEntity create(PonderWorld world) {
 			ParrotEntity entity = new ParrotEntity(EntityType.PARROT, world);
-			int nextInt = Create.random.nextInt(5);
+			int nextInt = Create.RANDOM.nextInt(5);
 			entity.setVariant(nextInt == 1 ? 0 : nextInt); // blue parrots are kinda hard to see
 			return entity;
 		}

--- a/src/main/java/com/simibubi/create/foundation/ponder/elements/WorldSectionElement.java
+++ b/src/main/java/com/simibubi/create/foundation/ponder/elements/WorldSectionElement.java
@@ -329,7 +329,7 @@ public class WorldSectionElement extends AnimatedSceneElement {
 
 	protected void renderStructure(PonderWorld world, MatrixStack ms, IRenderTypeBuffer buffer, RenderType type,
 		float fade) {
-		SuperByteBufferCache bufferCache = CreateClient.bufferCache;
+		SuperByteBufferCache bufferCache = CreateClient.BUFFER_CACHE;
 		int code = hashCode() ^ world.hashCode();
 
 		Pair<Integer, Integer> key = Pair.of(code, RenderType.getBlockLayers()

--- a/src/main/java/com/simibubi/create/foundation/ponder/instructions/EmitParticlesInstruction.java
+++ b/src/main/java/com/simibubi/create/foundation/ponder/instructions/EmitParticlesInstruction.java
@@ -23,8 +23,8 @@ public class EmitParticlesInstruction extends TickingInstruction {
 		}
 
 		public static <T extends IParticleData> Emitter withinBlockSpace(T data, Vector3d motion) {
-			return (w, x, y, z) -> w.addParticle(data, Math.floor(x) + Create.random.nextFloat(),
-				Math.floor(y) + Create.random.nextFloat(), Math.floor(z) + Create.random.nextFloat(), motion.x,
+			return (w, x, y, z) -> w.addParticle(data, Math.floor(x) + Create.RANDOM.nextFloat(),
+				Math.floor(y) + Create.RANDOM.nextFloat(), Math.floor(z) + Create.RANDOM.nextFloat(), motion.x,
 				motion.y, motion.z);
 		}
 
@@ -47,7 +47,7 @@ public class EmitParticlesInstruction extends TickingInstruction {
 	public void tick(PonderScene scene) {
 		super.tick(scene);
 		int runs = (int) runsPerTick;
-		if (Create.random.nextFloat() < (runsPerTick - runs))
+		if (Create.RANDOM.nextFloat() < (runsPerTick - runs))
 			runs++;
 		for (int i = 0; i < runs; i++)
 			emitter.create(scene.getWorld(), anchor.x, anchor.y, anchor.z);

--- a/src/main/java/com/simibubi/create/foundation/render/PartialBufferer.java
+++ b/src/main/java/com/simibubi/create/foundation/render/PartialBufferer.java
@@ -16,7 +16,7 @@ import net.minecraft.util.Direction;
 public class PartialBufferer {
 
 	public static SuperByteBuffer get(PartialModel partial, BlockState referenceState) {
-		return CreateClient.bufferCache.renderPartial(partial, referenceState);
+		return CreateClient.BUFFER_CACHE.renderPartial(partial, referenceState);
 	}
 
 	public static SuperByteBuffer getFacing(PartialModel partial, BlockState referenceState) {
@@ -25,7 +25,7 @@ public class PartialBufferer {
 	}
 
 	public static SuperByteBuffer getFacing(PartialModel partial, BlockState referenceState, Direction facing) {
-		return CreateClient.bufferCache.renderDirectionalPartial(partial, referenceState, facing, rotateToFace(facing));
+		return CreateClient.BUFFER_CACHE.renderDirectionalPartial(partial, referenceState, facing, rotateToFace(facing));
 	}
 
 	public static Supplier<MatrixStack> rotateToFace(Direction facing) {

--- a/src/main/java/com/simibubi/create/foundation/render/TileEntityRenderHelper.java
+++ b/src/main/java/com/simibubi/create/foundation/render/TileEntityRenderHelper.java
@@ -73,9 +73,9 @@ public class TileEntityRenderHelper {
 					.getRegistryName()
 					.toString() + " didn't want to render while moved.\n";
 				if (AllConfigs.CLIENT.explainRenderErrors.get())
-					Create.logger.error(message, e);
+					Create.LOGGER.error(message, e);
 				else
-					Create.logger.error(message);
+					Create.LOGGER.error(message);
 			}
 
 			ms.pop();

--- a/src/main/java/com/simibubi/create/foundation/render/backend/FastRenderDispatcher.java
+++ b/src/main/java/com/simibubi/create/foundation/render/backend/FastRenderDispatcher.java
@@ -27,7 +27,7 @@ public class FastRenderDispatcher {
 		Minecraft mc = Minecraft.getInstance();
 		ClientWorld world = mc.world;
 
-		KineticRenderer kineticRenderer = CreateClient.kineticRenderer.get(world);
+		KineticRenderer kineticRenderer = CreateClient.KINETIC_RENDERER.get(world);
 
 		Entity renderViewEntity = mc.renderViewEntity;
 		kineticRenderer.tick(renderViewEntity.getX(), renderViewEntity.getY(), renderViewEntity.getZ());
@@ -61,7 +61,7 @@ public class FastRenderDispatcher {
 		if (!Backend.canUseInstancing()) return;
 
 		ClientWorld world = Minecraft.getInstance().world;
-		KineticRenderer kineticRenderer = CreateClient.kineticRenderer.get(world);
+		KineticRenderer kineticRenderer = CreateClient.KINETIC_RENDERER.get(world);
 
 		layer.startDrawing();
 

--- a/src/main/java/com/simibubi/create/foundation/tileEntity/behaviour/edgeInteraction/EdgeInteractionRenderer.java
+++ b/src/main/java/com/simibubi/create/foundation/tileEntity/behaviour/edgeInteraction/EdgeInteractionRenderer.java
@@ -84,7 +84,7 @@ public class EdgeInteractionRenderer {
 			.withColors(0x7A6A2C, 0xB79D64)
 			.passive(!hit);
 
-		CreateClient.outliner.showValueBox("edge", box)
+		CreateClient.OUTLINER.showValueBox("edge", box)
 			.lineWidth(1 / 64f)
 			.withFaceTexture(hit ? AllSpecialTextures.THIN_CHECKERED : null)
 			.highlightFace(face);

--- a/src/main/java/com/simibubi/create/foundation/tileEntity/behaviour/filtering/FilteringRenderer.java
+++ b/src/main/java/com/simibubi/create/foundation/tileEntity/behaviour/filtering/FilteringRenderer.java
@@ -80,7 +80,7 @@ public class FilteringRenderer {
 			.scrollTooltip(showCount && !isFilterSlotted ? new StringTextComponent("[").append(Lang.translate("action.scroll")).append("]") : StringTextComponent.EMPTY)
 			.passive(!hit);
 
-		CreateClient.outliner.showValueBox(Pair.of("filter", pos), box.transform(behaviour.slotPositioning))
+		CreateClient.OUTLINER.showValueBox(Pair.of("filter", pos), box.transform(behaviour.slotPositioning))
 			.lineWidth(1 / 64f)
 			.withFaceTexture(hit ? AllSpecialTextures.THIN_CHECKERED : null)
 			.highlightFace(result.getFace());

--- a/src/main/java/com/simibubi/create/foundation/tileEntity/behaviour/linked/LinkBehaviour.java
+++ b/src/main/java/com/simibubi/create/foundation/tileEntity/behaviour/linked/LinkBehaviour.java
@@ -91,7 +91,7 @@ public class LinkBehaviour extends TileEntityBehaviour {
 	}
 
 	public void notifySignalChange() {
-		Create.redstoneLinkNetworkHandler.updateNetworkOf(this);
+		Create.REDSTONE_LINK_NETWORK_HANDLER.updateNetworkOf(this);
 	}
 
 	@Override
@@ -169,7 +169,7 @@ public class LinkBehaviour extends TileEntityBehaviour {
 	}
 
 	private RedstoneLinkNetworkHandler getHandler() {
-		return Create.redstoneLinkNetworkHandler;
+		return Create.REDSTONE_LINK_NETWORK_HANDLER;
 	}
 
 	public static class SlotPositioning {

--- a/src/main/java/com/simibubi/create/foundation/tileEntity/behaviour/linked/LinkRenderer.java
+++ b/src/main/java/com/simibubi/create/foundation/tileEntity/behaviour/linked/LinkRenderer.java
@@ -51,7 +51,7 @@ public class LinkRenderer {
 			ValueBox box = new ValueBox(label, bb, pos).withColors(0x601F18, 0xB73C2D)
 				.offsetLabel(behaviour.textShift)
 				.passive(!hit);
-			CreateClient.outliner.showValueBox(Pair.of(Boolean.valueOf(first), pos), box.transform(transform))
+			CreateClient.OUTLINER.showValueBox(Pair.of(Boolean.valueOf(first), pos), box.transform(transform))
 				.lineWidth(1 / 64f)
 				.withFaceTexture(hit ? AllSpecialTextures.THIN_CHECKERED : null)
 				.highlightFace(result.getFace());

--- a/src/main/java/com/simibubi/create/foundation/tileEntity/behaviour/scrollvalue/ScrollValueRenderer.java
+++ b/src/main/java/com/simibubi/create/foundation/tileEntity/behaviour/scrollvalue/ScrollValueRenderer.java
@@ -75,7 +75,7 @@ public class ScrollValueRenderer {
 			.withColors(0x5A5D5A, 0xB5B7B6)
 			.passive(!highlight);
 
-		CreateClient.outliner.showValueBox(pos, box.transform(behaviour.slotPositioning))
+		CreateClient.OUTLINER.showValueBox(pos, box.transform(behaviour.slotPositioning))
 			.lineWidth(1 / 64f)
 			.highlightFace(face);
 	}

--- a/src/main/java/com/simibubi/create/foundation/utility/FilesHelper.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/FilesHelper.java
@@ -23,7 +23,7 @@ public class FilesHelper {
 		try {
 			Files.createDirectories(Paths.get(name));
 		} catch (IOException e) {
-			Create.logger.warn("Could not create Folder: {}", name);
+			Create.LOGGER.warn("Could not create Folder: {}", name);
 		}
 	}
 

--- a/src/main/java/com/simibubi/create/foundation/utility/ICoordinate.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/ICoordinate.java
@@ -3,6 +3,6 @@ package com.simibubi.create.foundation.utility;
 import net.minecraft.util.math.BlockPos;
 
 @FunctionalInterface
-public interface Coordinate {
+public interface ICoordinate {
 	float get(BlockPos from);
 }

--- a/src/main/java/com/simibubi/create/foundation/utility/RemapHelper.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/RemapHelper.java
@@ -200,10 +200,10 @@ public class RemapHelper {
 		for (RegistryEvent.MissingMappings.Mapping<Block> mapping : mappings) {
 			if (reMap.containsKey(mapping.key.getPath())) {
 				try {
-					Create.logger.warn("Remapping block '{}' to '{}'", mapping.key, reMap.get(mapping.key.getPath()));
+					Create.LOGGER.warn("Remapping block '{}' to '{}'", mapping.key, reMap.get(mapping.key.getPath()));
 					mapping.remap(ForgeRegistries.BLOCKS.getValue(reMap.get(mapping.key.getPath())));
 				} catch (Throwable t) {
-					Create.logger.warn("Remapping block '{}' to '{}' failed: {}", mapping.key,
+					Create.LOGGER.warn("Remapping block '{}' to '{}' failed: {}", mapping.key,
 						reMap.get(mapping.key.getPath()), t);
 				}
 			}
@@ -223,10 +223,10 @@ public class RemapHelper {
 		for (RegistryEvent.MissingMappings.Mapping<Item> mapping : mappings) {
 			if (reMap.containsKey(mapping.key.getPath())) {
 				try {
-					Create.logger.warn("Remapping item '{}' to '{}'", mapping.key, reMap.get(mapping.key.getPath()));
+					Create.LOGGER.warn("Remapping item '{}' to '{}'", mapping.key, reMap.get(mapping.key.getPath()));
 					mapping.remap(ForgeRegistries.ITEMS.getValue(reMap.get(mapping.key.getPath())));
 				} catch (Throwable t) {
-					Create.logger.warn("Remapping item '{}' to '{}' failed: {}", mapping.key,
+					Create.LOGGER.warn("Remapping item '{}' to '{}' failed: {}", mapping.key,
 						reMap.get(mapping.key.getPath()), t);
 				}
 			}

--- a/src/main/java/com/simibubi/create/foundation/utility/placement/IPlacementHelper.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/placement/IPlacementHelper.java
@@ -96,15 +96,15 @@ public interface IPlacementHelper {
 		Vector3d offsetB = facing.crossProduct(direction).normalize().scale(.25);
 		Vector3d endA = center.add(direction.scale(.75)).add(offsetA);
 		Vector3d endB = center.add(direction.scale(.75)).add(offsetB);
-		CreateClient.outliner.showLine("placementArrowA" + center + target, start.add(offset), endA.add(offset)).lineWidth(1/16f);
-		CreateClient.outliner.showLine("placementArrowB" + center + target, start.add(offset), endB.add(offset)).lineWidth(1/16f);
+		CreateClient.OUTLINER.showLine("placementArrowA" + center + target, start.add(offset), endA.add(offset)).lineWidth(1/16f);
+		CreateClient.OUTLINER.showLine("placementArrowB" + center + target, start.add(offset), endB.add(offset)).lineWidth(1/16f);
 	}
 
 	default void displayGhost(PlacementOffset offset) {
 		if (!offset.hasGhostState())
 			return;
 
-		CreateClient.ghostBlocks.showGhostState(this, offset.getTransform().apply(offset.getGhostState()))
+		CreateClient.GHOST_BLOCKS.showGhostState(this, offset.getTransform().apply(offset.getGhostState()))
 				.at(offset.getBlockPos())
 				.breathingAlpha();
 	}

--- a/src/main/resources/create.mixins.json
+++ b/src/main/resources/create.mixins.json
@@ -13,14 +13,14 @@
     "FogColorTrackerMixin",
     "HeavyBootsOnPlayerMixin",
     "LightUpdateMixin",
+    "ModelDataRefreshMixin",
     "NetworkLightUpdateMixin",
     "RenderHooksMixin",
     "ShaderCloseMixin",
     "StoreProjectionMatrixMixin",
     "TileRemoveMixin",
     "TileWorldHookMixin",
-    "WindowResizeMixin",
-    "ModelDataRefreshMixin"
+    "WindowResizeMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,6 +1,6 @@
 {
-    "pack": {
-        "description": "create resources",
-        "pack_format": 6
-    }
+  "pack": {
+    "description": "Create resources",
+    "pack_format": 6
+  }
 }


### PR DESCRIPTION
Cleanup initialization code (All*, Create, CreateClient):
- Refactor AllContainerTypes to use Registrate
- Replace RegistryEntry in AllEntityTypes and AllFluids with EntityEntry and FluidEntry, respectively
- Make AllEntityTypes use Registrate to register entity renderers instead of a separate method
- Refactor AllColorHandlers: use color handler events, remove extra implementation classes, and register vertex colors directly
- Make static fields in Create and CreateClient final and rename them to be upper snake case

Block movement check and contraption movement cleanup and refactoring:
- Allow registering custom block movement checks: Registering block movement checks works by using one of the six static register methods on an instance of an implementation of one of the six corresponding interfaces. Each one takes some arguments and returns a CheckResult, which defines whether to return from the global check or fall through to the next registered check or fallback check.
- Fix error when a POI block is moved by a contraption
- Make the bottom half of doors attach up and down as opposed to just down
- Remove door check from Contrapion#moveBlock as it is unnecessary
- Pass World instead of IBlockReader to isBlockAttachedTowards
- Rename BlockMovementTraits to BlockMovementChecks
- Rename some check methods to be consistent

Extra formatting/cleanup:
- Add I prefix to Coordinate interface
- Fix typo (BracketedTileEntityBehaviour#isBacketPresent)
- Make mixins go in alphabetical order
- Make pack.mcmeta use 2 spaces for indents

Fix dyed handle compilation error:
- Revert DYED_VALVE_HANDLES to using an array instead of a Vector