### PR TITLE
Scale hose pulley timer with server's infinite block threshold

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/fluids/actors/FluidManipulationBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/fluids/actors/FluidManipulationBehaviour.java
@@ -53,7 +53,6 @@ public abstract class FluidManipulationBehaviour extends TileEntityBehaviour {
 	List<BlockPosEntry> frontier;
 	Set<BlockPos> visited;
 
-	static final int validationTimer = 160;
 	int revalidateIn;
 
 	public FluidManipulationBehaviour(SmartTileEntity te) {
@@ -68,12 +67,20 @@ public abstract class FluidManipulationBehaviour extends TileEntityBehaviour {
 		counterpartActed = true;
 	}
 
+	private int validationTimer() {
+		int maxBlocks = maxBlocks();
+		return infinite || maxBlocks < 0
+			? 160
+			// Allow enough time for the server's infinite block threshold to be reached
+			: maxBlocks / searchedPerTick;
+	}
+
 	protected int setValidationTimer() {
-		return revalidateIn = validationTimer;
+		return revalidateIn = validationTimer();
 	}
 
 	protected int setLongValidationTimer() {
-		return revalidateIn = validationTimer * 2;
+		return revalidateIn = validationTimer() * 2;
 	}
 
 	protected int maxRange() {


### PR DESCRIPTION
## Motivation

Seeing this mod on Youtube motivated me to build a giant dam in front of a gigantic reservoir as a real-world-inspired way to get lots of power. But how to build such a thing? Ooh, Create has a **Hose Pulley**, that sounds like much more fun than doing the bucket dance by hand myself, vanilla-style!

## Problem

I found a roughly 104x72 lake, 17 meters deep at the lowest point, and built an 8-high retaining wall around it. This represents around 104 * 72 * 17 = 127296 water source blocks given by nature, with a future capacity of 187200 after filling the reservoir to the top of the wall. My contraption was simple: A mechanical pump on top of the wall, on each side of which is one fluid pipe and then a Hose Pulley (one of which is inside the reservoir, the other of which sits over a much larger body of water outside), and finally a valve handle to lower the hoses to the desired levels. Then a windmill with 5 large/small cog speed doublings to power the mechanical pump.

After building all this, I waited in vain for the reservoir to begin filling.

(Screenshots available upon request, omitted for now to reduce bloat.)

## Red herrings

First I discovered a hole in the dam (between the bodies of water) and a second hole from which the eventually-filled reservoir could have leaked out onto dry land. Patching these didn't fix the problem.

Then I found the `hosePulleyBlockThreshold` server setting and changed it from 10000 to 250000. After this, hovering the outer Hose Pulley indicated it was connected to a bottomless supply and hovering the inner Hose Pulley indicated it was finite, which is good, but still the reservoir did not fill.

## Cause

The Hose Pulley has a timer that resets its search for a block to fill every 160 ticks (about 8 seconds):

https://github.com/Creators-of-Create/Create/blob/3372947c7577eaaae6b3ca67e158e47329e9dab8/src/main/java/com/simibubi/create/content/contraptions/fluids/actors/FluidManipulationBehaviour.java#L56
https://github.com/Creators-of-Create/Create/blob/3372947c7577eaaae6b3ca67e158e47329e9dab8/src/main/java/com/simibubi/create/content/contraptions/fluids/actors/FluidManipulationBehaviour.java#L71-L73
https://github.com/Creators-of-Create/Create/blob/3372947c7577eaaae6b3ca67e158e47329e9dab8/src/main/java/com/simibubi/create/content/contraptions/fluids/actors/FluidFillingBehaviour.java#L114-L121

In each of those ticks, it searches 256 existing water source blocks:

https://github.com/Creators-of-Create/Create/blob/3372947c7577eaaae6b3ca67e158e47329e9dab8/src/main/java/com/simibubi/create/content/contraptions/fluids/actors/FluidManipulationBehaviour.java#L52
https://github.com/Creators-of-Create/Create/blob/3372947c7577eaaae6b3ca67e158e47329e9dab8/src/main/java/com/simibubi/create/content/contraptions/fluids/actors/FluidFillingBehaviour.java#L150

... so it will search up to 160 * 256 = 40960 blocks before restarting.

In the case of my 127296-block lake, the Hose Pulley was always still checking the existing water blocks for low-down gaps and holes when the timer fired and reset everything; since it never finished those checks,it never got around to adding a new layer of water blocks on top, even though the server was configured to treat 249999 blocks as finite.

## Changes

Now the Hose Pulley's timer isn't always a fixed 160 ticks. Instead, it is set to the number of ticks needed to search enough blocks to reach the server's configured infinite block threshold. If the server uses a very high threshold, then large bodies of water may be filled and expanded. If the threshold is set to `-1` or the source is infinite, then the previous 160 tick timer is used.

With this change applied, my reservoir has finally slowly begun to fill.

I think this _might_ fix #1288, but it's hard to say for sure; that issue is about draining and my case is about filling, but the fix is in a base class that is shared between both cases.