### PR TITLE
Allow conversion directly between honey and honey blocks.

### DIFF
--- a/src/generated/resources/data/create/recipes/compacting/honey_block.json
+++ b/src/generated/resources/data/create/recipes/compacting/honey_block.json
@@ -1,0 +1,15 @@
+{
+  "type": "create:compacting",
+  "ingredients": [
+    {
+      "fluid": "forge:honey",
+      "nbt": {},
+      "amount": 1000
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:honey_block"
+    }
+  ]
+}

--- a/src/generated/resources/data/create/recipes/mixing/honey_from_honey_block.json
+++ b/src/generated/resources/data/create/recipes/mixing/honey_from_honey_block.json
@@ -1,0 +1,14 @@
+{
+  "type": "create:mixing",
+  "ingredients": [
+    {
+      "item": "minecraft:honey_block"
+    }
+  ],
+  "results": [
+    {
+      "fluid": "forge:honey",
+      "amount": 1000
+    }
+  ]
+}


### PR DESCRIPTION
The honey bottles are an unnecessary intermediate step. This pull request adds recipes to compact honey into honey blocks, and to mix honey blocks back into honey. (I would have made honey block to honey a draining recipe, but it doesn't seem that it's possible to make a draining recipe with no item result)