### PR TITLE
make shape builder public

### DIFF
--- a/src/main/java/com/simibubi/create/AllShapes.java
+++ b/src/main/java/com/simibubi/create/AllShapes.java
@@ -232,7 +232,7 @@ public class AllShapes {
 		return Block.makeCuboidShape(x1, y1, z1, x2, y2, z2);
 	}
 
-	private static class Builder {
+	public static class Builder {
 		VoxelShape shape;
 
 		public Builder(VoxelShape shape) {


### PR DESCRIPTION
the builder is really useful, though any addons wanting to use it right now have to copy-paste it even though it has no reason to be private