### PR TITLE
Fix #1872 by removing a unnecessary override

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/gui/AbstractSimiContainerScreen.java
+++ b/src/main/java/com/simibubi/create/foundation/gui/AbstractSimiContainerScreen.java
@@ -150,11 +150,6 @@ public abstract class AbstractSimiContainerScreen<T extends Container> extends C
 		return true;
 	}
 
-	@Override
-	public boolean isPauseScreen() {
-		return false;
-	}
-
 	protected abstract void renderWindow(MatrixStack ms, int mouseX, int mouseY, float partialTicks);
 
 	@Override


### PR DESCRIPTION
The parent class uses the exact same code to stop the screen from pausing. AFAIK it shouldn't break anything.