### PR TITLE
changes to make it easier for addons

### DIFF
--- a/src/main/java/com/simibubi/create/AllShapes.java
+++ b/src/main/java/com/simibubi/create/AllShapes.java
@@ -232,57 +232,57 @@ public class AllShapes {
 		return Block.makeCuboidShape(x1, y1, z1, x2, y2, z2);
 	}
 
-	private static class Builder {
+	public static class Builder {
 		VoxelShape shape;
 
 		public Builder(VoxelShape shape) {
 			this.shape = shape;
 		}
 
-		Builder add(VoxelShape shape) {
+		public Builder add(VoxelShape shape) {
 			this.shape = VoxelShapes.or(this.shape, shape);
 			return this;
 		}
 
-		Builder add(double x1, double y1, double z1, double x2, double y2, double z2) {
+		public Builder add(double x1, double y1, double z1, double x2, double y2, double z2) {
 			return add(cuboid(x1, y1, z1, x2, y2, z2));
 		}
 
-		Builder erase(double x1, double y1, double z1, double x2, double y2, double z2) {
+		public Builder erase(double x1, double y1, double z1, double x2, double y2, double z2) {
 			this.shape =
 				VoxelShapes.combineAndSimplify(shape, cuboid(x1, y1, z1, x2, y2, z2), IBooleanFunction.ONLY_FIRST);
 			return this;
 		}
 
-		VoxelShape build() {
+		public VoxelShape build() {
 			return shape;
 		}
 
-		VoxelShaper build(BiFunction<VoxelShape, Direction, VoxelShaper> factory, Direction direction) {
+		public VoxelShaper build(BiFunction<VoxelShape, Direction, VoxelShaper> factory, Direction direction) {
 			return factory.apply(shape, direction);
 		}
 
-		VoxelShaper build(BiFunction<VoxelShape, Axis, VoxelShaper> factory, Axis axis) {
+		public VoxelShaper build(BiFunction<VoxelShape, Axis, VoxelShaper> factory, Axis axis) {
 			return factory.apply(shape, axis);
 		}
 
-		VoxelShaper forDirectional(Direction direction) {
+		public VoxelShaper forDirectional(Direction direction) {
 			return build(VoxelShaper::forDirectional, direction);
 		}
 
-		VoxelShaper forAxis() {
+		public VoxelShaper forAxis() {
 			return build(VoxelShaper::forAxis, Axis.Y);
 		}
 
-		VoxelShaper forHorizontalAxis() {
+		public VoxelShaper forHorizontalAxis() {
 			return build(VoxelShaper::forHorizontalAxis, Axis.Z);
 		}
 
-		VoxelShaper forHorizontal(Direction direction) {
+		public VoxelShaper forHorizontal(Direction direction) {
 			return build(VoxelShaper::forHorizontal, direction);
 		}
 
-		VoxelShaper forDirectional() {
+		public VoxelShaper forDirectional() {
 			return forDirectional(UP);
 		}
 

--- a/src/main/java/com/simibubi/create/content/contraptions/processing/ProcessingRecipeBuilder.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/processing/ProcessingRecipeBuilder.java
@@ -230,8 +230,8 @@ public class ProcessingRecipeBuilder<T extends ProcessingRecipe<?>> {
 			if (!(recipeType.serializer instanceof ProcessingRecipeSerializer))
 				throw new IllegalStateException("Cannot datagen ProcessingRecipe of type: " + typeName);
 
-			this.id = Create.asResource(typeName + "/" + recipe.getId()
-				.getPath());
+			this.id = new ResourceLocation(recipe.getId().getNamespace(),
+					typeName + "/" + recipe.getId().getPath());
 			this.serializer = (ProcessingRecipeSerializer<S>) recipe.getSerializer();
 		}
 

--- a/src/main/java/com/simibubi/create/foundation/data/recipe/CreateRecipeProvider.java
+++ b/src/main/java/com/simibubi/create/foundation/data/recipe/CreateRecipeProvider.java
@@ -33,7 +33,7 @@ public abstract class CreateRecipeProvider extends RecipeProvider {
 	}
 
 	@FunctionalInterface
-	interface GeneratedRecipe {
+	public interface GeneratedRecipe {
 		void register(Consumer<IFinishedRecipe> consumer);
 	}
 

--- a/src/main/java/com/simibubi/create/foundation/data/recipe/ProcessingRecipeGen.java
+++ b/src/main/java/com/simibubi/create/foundation/data/recipe/ProcessingRecipeGen.java
@@ -17,6 +17,7 @@ import net.minecraft.data.DirectoryCache;
 import net.minecraft.data.IDataProvider;
 import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.util.IItemProvider;
+import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fluids.FluidAttributes;
 
 public abstract class ProcessingRecipeGen extends CreateRecipeProvider {
@@ -37,14 +38,14 @@ public abstract class ProcessingRecipeGen extends CreateRecipeProvider {
 		generators.add(new PressingRecipeGen(gen));
 		generators.add(new FillingRecipeGen(gen));
 		generators.add(new EmptyingRecipeGen(gen));
-		
+
 		gen.addProvider(new IDataProvider() {
-			
+
 			@Override
 			public String getName() {
 				return "Create's Processing Recipes";
 			}
-			
+
 			@Override
 			public void act(DirectoryCache dc) throws IOException {
 				generators.forEach(g -> {
@@ -57,22 +58,22 @@ public abstract class ProcessingRecipeGen extends CreateRecipeProvider {
 			}
 		});
 	}
-	
+
 	public ProcessingRecipeGen(DataGenerator p_i48262_1_) {
 		super(p_i48262_1_);
 	}
-	
+
 	/**
 	 * Create a processing recipe with a single itemstack ingredient, using its id
 	 * as the name of the recipe
 	 */
-	protected <T extends ProcessingRecipe<?>> GeneratedRecipe create(Supplier<IItemProvider> singleIngredient,
+	protected <T extends ProcessingRecipe<?>> GeneratedRecipe create(String namespace, Supplier<IItemProvider> singleIngredient,
 		UnaryOperator<ProcessingRecipeBuilder<T>> transform) {
 		ProcessingRecipeSerializer<T> serializer = getSerializer();
 		GeneratedRecipe generatedRecipe = c -> {
 			IItemProvider iItemProvider = singleIngredient.get();
 			transform
-				.apply(new ProcessingRecipeBuilder<>(serializer.getFactory(), Create.asResource(iItemProvider.asItem()
+				.apply(new ProcessingRecipeBuilder<>(serializer.getFactory(), new ResourceLocation(namespace, iItemProvider.asItem()
 					.getRegistryName()
 					.getPath())).withItemIngredients(Ingredient.fromItems(iItemProvider)))
 				.build(c);
@@ -82,21 +83,39 @@ public abstract class ProcessingRecipeGen extends CreateRecipeProvider {
 	}
 
 	/**
+	 * Create a processing recipe with a single itemstack ingredient, using its id
+	 * as the name of the recipe
+	 */
+	protected <T extends ProcessingRecipe<?>> GeneratedRecipe create(Supplier<IItemProvider> singleIngredient,
+																	 UnaryOperator<ProcessingRecipeBuilder<T>> transform) {
+		return create(Create.ID, singleIngredient, transform);
+	}
+
+	/**
 	 * Create a new processing recipe, with recipe definitions provided by the
 	 * function
 	 */
-	protected <T extends ProcessingRecipe<?>> GeneratedRecipe create(String name,
-		UnaryOperator<ProcessingRecipeBuilder<T>> transform) {
+	protected <T extends ProcessingRecipe<?>> GeneratedRecipe create(ResourceLocation name,
+																	 UnaryOperator<ProcessingRecipeBuilder<T>> transform) {
 		ProcessingRecipeSerializer<T> serializer = getSerializer();
 		GeneratedRecipe generatedRecipe =
-			c -> transform.apply(new ProcessingRecipeBuilder<>(serializer.getFactory(), Create.asResource(name)))
+			c -> transform.apply(new ProcessingRecipeBuilder<>(serializer.getFactory(), name))
 				.build(c);
 		all.add(generatedRecipe);
 		return generatedRecipe;
 	}
 
+	/**
+	 * Create a new processing recipe, with recipe definitions provided by the
+	 * function
+	 */
+	protected <T extends ProcessingRecipe<?>> GeneratedRecipe create(String name,
+																	 UnaryOperator<ProcessingRecipeBuilder<T>> transform) {
+		return create(Create.asResource(name), transform);
+	}
+
 	@SuppressWarnings("unchecked")
-	private <T extends ProcessingRecipe<?>> ProcessingRecipeSerializer<T> getSerializer() {
+	protected  <T extends ProcessingRecipe<?>> ProcessingRecipeSerializer<T> getSerializer() {
 		ProcessingRecipeSerializer<T> serializer = (ProcessingRecipeSerializer<T>) getRecipeType().serializer;
 		return serializer;
 	}
@@ -105,7 +124,7 @@ public abstract class ProcessingRecipeGen extends CreateRecipeProvider {
 	public final String getName() {
 		return "Create's Processing Recipes: " + getRecipeType();
 	}
-	
+
 	protected abstract AllRecipeTypes getRecipeType();
 
 }


### PR DESCRIPTION
[this is pretty much my old pr but with more stuff](https://github.com/Creators-of-Create/Create/pull/1870)

so far with my addons i had 3 issues:
- ~~to create block partials you have to reflect the constructor. [my addon code](https://github.com/Create-Additions/CreateAutomated/blob/e1ec32f285d9922d27b8d9350c831cbc0f6575ad/src/main/java/com/kotakotik/createautomated/register/ModBlockPartials.java#L30).~~ however seems like this has been fixed in the latest dev version
- generating create type recipes will generate them in the create namespace, easiest way to fix that is overriding the act method for the provider. [my addon code](https://github.com/Create-Additions/CreateAutomated/blob/e1ec32f285d9922d27b8d9350c831cbc0f6575ad/src/main/java/com/kotakotik/createautomated/register/recipes/ModMixingRecipes.java#L48)
- shape builder class is private, so no way of inheriting it, extending it or accessing it at all, so you have to either copy-paste it or just write the code yourself (builder is just a shortcut to [public VoxelShaper methods](https://github.com/Creators-of-Create/Create/blob/b0d43767308434f37c74ee96070d47ede78ef394/src/main/java/com/simibubi/create/AllShapes.java#L270) so its not that hard, but still the builder is nice)

this pr fixes the second and the third issue