### PR TITLE
Convert to parchment mappings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,13 @@
 buildscript {
     repositories {
+        maven { url = 'https://sizableshrimp.me/maven' }
         maven { url = 'https://maven.minecraftforge.net' }
         mavenCentral()
         jcenter()
         maven { url = 'https://repo.spongepowered.org/repository/maven-public/' }
     }
     dependencies {
-        classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: "${forgegradle_version}", changing: true
+        classpath group: 'me.sizableshrimp.parchmenttest', name: 'ForgeGradle', version: "${forgegradle_version}", changing: true
         classpath group: 'org.spongepowered', name: 'mixingradle', version: "${mixingradle_version}"
     }
 }
@@ -32,7 +33,7 @@ archivesBaseName = 'create'
 java.toolchain.languageVersion = JavaLanguageVersion.of(8)
 
 minecraft {
-    mappings channel: 'official', version: "${minecraft_version}"
+    mappings channel: mappings_channel, version: mappings_version
     accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
 
     runs {

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,10 @@ registrate_version = 1.0.4
 flywheel_version = 1.16-0.1.1.24
 jei_version = 7.7.0.106
 
+#mappings
+mappings_channel = parchment
+mappings_version = 20210608-SNAPSHOT-1.16.5
+
 # curseforge information
 projectId = 328085
 curse_type = beta

--- a/src/main/java/com/simibubi/create/AllKeys.java
+++ b/src/main/java/com/simibubi/create/AllKeys.java
@@ -19,7 +19,7 @@ public enum AllKeys {
 	private int key;
 	private boolean modifiable;
 
-	private AllKeys(String description, int defaultKey) {
+	AllKeys(String description, int defaultKey) {
 		this.description = Create.ID + ".keyinfo." + description;
 		this.key = defaultKey;
 		this.modifiable = !description.isEmpty();

--- a/src/main/java/com/simibubi/create/AllSoundEvents.java
+++ b/src/main/java/com/simibubi/create/AllSoundEvents.java
@@ -203,17 +203,17 @@ public class AllSoundEvents {
 			.playExisting(SoundEvents.NETHERRACK_HIT)
 			.category(SoundCategory.BLOCKS)
 			.build(),
-			
+
 		CRUSHING_2 = create("crushing_2").noSubtitle()
 			.playExisting(SoundEvents.GRAVEL_PLACE)
 			.category(SoundCategory.BLOCKS)
 			.build(),
-			
+
 		CRUSHING_3 = create("crushing_3").noSubtitle()
 			.playExisting(SoundEvents.NETHERITE_BLOCK_BREAK)
 			.category(SoundCategory.BLOCKS)
 			.build(),
-			
+
 		PECULIAR_BELL_USE = create("peculiar_bell_use").subtitle("Peculiar Bell tolls")
 			.playExisting(SoundEvents.BELL_BLOCK)
 			.category(SoundCategory.BLOCKS)
@@ -322,7 +322,7 @@ public class AllSoundEvents {
 			this.subtitle = subtitle;
 			return this;
 		}
-		
+
 		public SoundEntryBuilder noSubtitle() {
 			this.subtitle = null;
 			return this;
@@ -382,7 +382,7 @@ public class AllSoundEvents {
 		public ResourceLocation getLocation() {
 			return Create.asResource(id);
 		}
-		
+
 		public boolean hasSubtitle() {
 			return subtitle != null;
 		}

--- a/src/main/java/com/simibubi/create/AllSpecialTextures.java
+++ b/src/main/java/com/simibubi/create/AllSpecialTextures.java
@@ -17,7 +17,7 @@ public enum AllSpecialTextures {
 	public static final String ASSET_PATH = "textures/special/";
 	private ResourceLocation location;
 
-	private AllSpecialTextures(String filename) {
+	AllSpecialTextures(String filename) {
 		location = new ResourceLocation(Create.ID, ASSET_PATH + filename);
 	}
 

--- a/src/main/java/com/simibubi/create/AllTags.java
+++ b/src/main/java/com/simibubi/create/AllTags.java
@@ -61,7 +61,7 @@ public class AllTags {
 		return wrapperFactory.apply(new ResourceLocation(domain, name).toString());
 	}
 
-	public static enum NameSpace {
+	public enum NameSpace {
 
 		MOD(Create.ID), FORGE("forge"), MC("minecraft"), TIC("tconstruct")
 
@@ -69,12 +69,12 @@ public class AllTags {
 
 		String id;
 
-		private NameSpace(String id) {
+		NameSpace(String id) {
 			this.id = id;
 		}
 	}
 
-	public static enum AllItemTags {
+	public enum AllItemTags {
 		CRUSHED_ORES(MOD),
 		SEATS(MOD),
 		VALVE_HANDLES(MOD),
@@ -90,11 +90,11 @@ public class AllTags {
 
 		public ITag.INamedTag<Item> tag;
 
-		private AllItemTags(NameSpace namespace) {
+		AllItemTags(NameSpace namespace) {
 			this(namespace, "");
 		}
 
-		private AllItemTags(NameSpace namespace, String path) {
+		AllItemTags(NameSpace namespace, String path) {
 			tag = ItemTags.bind(
 				new ResourceLocation(namespace.id, (path.isEmpty() ? "" : path + "/") + Lang.asId(name())).toString());
 			REGISTRATE.addDataGenerator(ProviderType.ITEM_TAGS, prov -> prov.tag(tag));
@@ -115,7 +115,7 @@ public class AllTags {
 		}
 	}
 
-	public static enum AllFluidTags {
+	public enum AllFluidTags {
 		NO_INFINITE_DRAINING,
 		HONEY(FORGE)
 
@@ -123,15 +123,15 @@ public class AllTags {
 
 		public ITag.INamedTag<Fluid> tag;
 
-		private AllFluidTags() {
+		AllFluidTags() {
 			this(MOD, "");
 		}
 
-		private AllFluidTags(NameSpace namespace) {
+		AllFluidTags(NameSpace namespace) {
 			this(namespace, "");
 		}
 
-		private AllFluidTags(NameSpace namespace, String path) {
+		AllFluidTags(NameSpace namespace, String path) {
 			tag = FluidTags.createOptional(
 				new ResourceLocation(namespace.id, (path.isEmpty() ? "" : path + "/") + Lang.asId(name())));
 		}
@@ -143,7 +143,7 @@ public class AllTags {
 		static void loadClass() {}
 	}
 
-	public static enum AllBlockTags {
+	public enum AllBlockTags {
 		WINDMILL_SAILS,
 		FAN_HEATERS,
 		WINDOWABLE,
@@ -160,15 +160,15 @@ public class AllTags {
 
 		public ITag.INamedTag<Block> tag;
 
-		private AllBlockTags() {
+		AllBlockTags() {
 			this(MOD, "");
 		}
 
-		private AllBlockTags(NameSpace namespace) {
+		AllBlockTags(NameSpace namespace) {
 			this(namespace, "");
 		}
 
-		private AllBlockTags(NameSpace namespace, String path) {
+		AllBlockTags(NameSpace namespace, String path) {
 			ResourceLocation id =
 				new ResourceLocation(namespace.id, (path.isEmpty() ? "" : path + "/") + Lang.asId(name()));
 			if (ModList.get()

--- a/src/main/java/com/simibubi/create/content/AllSections.java
+++ b/src/main/java/com/simibubi/create/content/AllSections.java
@@ -21,7 +21,7 @@ public enum AllSections {
 
 	/** Decorative blocks */
 	PALETTES(Palette.Green),
-	
+
 	/** Helpful gadgets and other shenanigans */
 	CURIOSITIES(Palette.Purple),
 
@@ -35,7 +35,7 @@ public enum AllSections {
 
 	private Palette tooltipPalette;
 
-	private AllSections(Palette tooltipPalette) {
+	AllSections(Palette tooltipPalette) {
 		this.tooltipPalette = tooltipPalette;
 	}
 

--- a/src/main/java/com/simibubi/create/content/contraptions/base/KineticTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/base/KineticTileEntity.java
@@ -4,6 +4,7 @@ import static net.minecraft.util.text.TextFormatting.GOLD;
 import static net.minecraft.util.text.TextFormatting.GRAY;
 
 import java.util.List;
+import java.util.Objects;
 
 import javax.annotation.Nullable;
 
@@ -313,7 +314,7 @@ public abstract class KineticTileEntity extends SmartTileEntity
 	}
 
 	public void setNetwork(@Nullable Long networkIn) {
-		if (network == networkIn)
+		if (Objects.equals(network, networkIn))
 			return;
 		if (network != null)
 			getOrCreateNetwork().remove(this);
@@ -323,7 +324,6 @@ public abstract class KineticTileEntity extends SmartTileEntity
 		if (networkIn == null)
 			return;
 
-		network = networkIn;
 		KineticNetwork network = getOrCreateNetwork();
 		network.initialized = true;
 		network.add(this);

--- a/src/main/java/com/simibubi/create/content/contraptions/components/actors/PortableStorageInterfaceBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/actors/PortableStorageInterfaceBlock.java
@@ -52,8 +52,8 @@ public class PortableStorageInterfaceBlock extends ProperDirectionalBlock
 	}
 
 	@Override
-	public void neighborChanged(BlockState state, World world, BlockPos pos, Block p_220069_4_, BlockPos p_220069_5_,
-		boolean p_220069_6_) {
+	public void neighborChanged(BlockState state, World world, BlockPos pos, Block pBlockIn, BlockPos pFromPos,
+		boolean pIsMoving) {
 		withTileEntityDo(world, pos, PortableStorageInterfaceTileEntity::neighbourChanged);
 	}
 

--- a/src/main/java/com/simibubi/create/content/contraptions/components/actors/SeatBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/actors/SeatBlock.java
@@ -47,15 +47,15 @@ public class SeatBlock extends Block {
 	}
 
 	@Override
-	public void fillItemCategory(ItemGroup group, NonNullList<ItemStack> p_149666_2_) {
+	public void fillItemCategory(ItemGroup group, NonNullList<ItemStack> pItems) {
 		if (group != ItemGroup.TAB_SEARCH && !inCreativeTab)
 			return;
-		super.fillItemCategory(group, p_149666_2_);
+		super.fillItemCategory(group, pItems);
 	}
 
 	@Override
-	public void fallOn(World p_180658_1_, BlockPos p_180658_2_, Entity p_180658_3_, float p_180658_4_) {
-		super.fallOn(p_180658_1_, p_180658_2_, p_180658_3_, p_180658_4_ * 0.5F);
+	public void fallOn(World pWorldIn, BlockPos pPos, Entity pEntityIn, float pFallDistance) {
+		super.fallOn(pWorldIn, pPos, pEntityIn, pFallDistance * 0.5F);
 	}
 
 	@Override
@@ -78,20 +78,20 @@ public class SeatBlock extends Block {
 	}
 
 	@Override
-	public VoxelShape getShape(BlockState p_220053_1_, IBlockReader p_220053_2_, BlockPos p_220053_3_,
-		ISelectionContext p_220053_4_) {
+	public VoxelShape getShape(BlockState pState, IBlockReader pWorldIn, BlockPos pPos,
+		ISelectionContext pContext) {
 		return AllShapes.SEAT;
 	}
 
 	@Override
-	public VoxelShape getCollisionShape(BlockState p_220071_1_, IBlockReader p_220071_2_, BlockPos p_220071_3_,
-		ISelectionContext p_220071_4_) {
+	public VoxelShape getCollisionShape(BlockState pState, IBlockReader pWorldIn, BlockPos pPos,
+		ISelectionContext pContext) {
 		return AllShapes.SEAT_COLLISION;
 	}
 
 	@Override
 	public ActionResultType use(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand,
-		BlockRayTraceResult p_225533_6_) {
+		BlockRayTraceResult pHit) {
 		if (player.isShiftKeyDown())
 			return ActionResultType.PASS;
 

--- a/src/main/java/com/simibubi/create/content/contraptions/components/actors/SeatEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/actors/SeatEntity.java
@@ -50,7 +50,7 @@ public class SeatEntity extends Entity implements IEntityAdditionalSpawnData {
 	}
 
 	@Override
-	public void setDeltaMovement(Vector3d p_213317_1_) {}
+	public void setDeltaMovement(Vector3d pMotionIn) {}
 
 	@Override
 	public void tick() {
@@ -80,10 +80,10 @@ public class SeatEntity extends Entity implements IEntityAdditionalSpawnData {
 	protected void defineSynchedData() {}
 
 	@Override
-	protected void readAdditionalSaveData(CompoundNBT p_70037_1_) {}
+	protected void readAdditionalSaveData(CompoundNBT pCompound) {}
 
 	@Override
-	protected void addAdditionalSaveData(CompoundNBT p_213281_1_) {}
+	protected void addAdditionalSaveData(CompoundNBT pCompound) {}
 
 	@Override
 	public IPacket<?> getAddEntityPacket() {
@@ -97,12 +97,12 @@ public class SeatEntity extends Entity implements IEntityAdditionalSpawnData {
 		}
 
 		@Override
-		public boolean shouldRender(SeatEntity p_225626_1_, ClippingHelper p_225626_2_, double p_225626_3_, double p_225626_5_, double p_225626_7_) {
+		public boolean shouldRender(SeatEntity pLivingEntityIn, ClippingHelper pCamera, double pCamX, double pCamY, double pCamZ) {
 			return false;
 		}
 
 		@Override
-		public ResourceLocation getTextureLocation(SeatEntity p_110775_1_) {
+		public ResourceLocation getTextureLocation(SeatEntity pEntity) {
 			return null;
 		}
 	}

--- a/src/main/java/com/simibubi/create/content/contraptions/components/actors/dispenser/MovedDefaultDispenseItemBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/actors/dispenser/MovedDefaultDispenseItemBehaviour.java
@@ -17,20 +17,20 @@ import net.minecraftforge.items.ItemHandlerHelper;
 public class MovedDefaultDispenseItemBehaviour implements IMovedDispenseItemBehaviour {
 	private static final MovedDefaultDispenseItemBehaviour defaultInstance = new MovedDefaultDispenseItemBehaviour();
 
-	public static void doDispense(World p_82486_0_, ItemStack p_82486_1_, int p_82486_2_, Vector3d facing, BlockPos p_82486_4_, MovementContext context) {
-		double d0 = p_82486_4_.getX() + facing.x + .5;
-		double d1 = p_82486_4_.getY() + facing.y + .5;
-		double d2 = p_82486_4_.getZ() + facing.z + .5;
+	public static void doDispense(World pWorldIn, ItemStack pStack, int pSpeed, Vector3d facing, BlockPos pPosition, MovementContext context) {
+		double d0 = pPosition.getX() + facing.x + .5;
+		double d1 = pPosition.getY() + facing.y + .5;
+		double d2 = pPosition.getZ() + facing.z + .5;
 		if (Direction.getNearest(facing.x, facing.y, facing.z).getAxis() == Direction.Axis.Y) {
 			d1 = d1 - 0.125D;
 		} else {
 			d1 = d1 - 0.15625D;
 		}
 
-		ItemEntity itementity = new ItemEntity(p_82486_0_, d0, d1, d2, p_82486_1_);
-		double d3 = p_82486_0_.random.nextDouble() * 0.1D + 0.2D;
-		itementity.setDeltaMovement(p_82486_0_.random.nextGaussian() * (double) 0.0075F * (double) p_82486_2_ + facing.x() * d3 + context.motion.x, p_82486_0_.random.nextGaussian() * (double) 0.0075F * (double) p_82486_2_ + facing.y() * d3 + context.motion.y, p_82486_0_.random.nextGaussian() * (double) 0.0075F * (double) p_82486_2_ + facing.z() * d3 + context.motion.z);
-		p_82486_0_.addFreshEntity(itementity);
+		ItemEntity itementity = new ItemEntity(pWorldIn, d0, d1, d2, pStack);
+		double d3 = pWorldIn.random.nextDouble() * 0.1D + 0.2D;
+		itementity.setDeltaMovement(pWorldIn.random.nextGaussian() * (double) 0.0075F * (double) pSpeed + facing.x() * d3 + context.motion.x, pWorldIn.random.nextGaussian() * (double) 0.0075F * (double) pSpeed + facing.y() * d3 + context.motion.y, pWorldIn.random.nextGaussian() * (double) 0.0075F * (double) pSpeed + facing.z() * d3 + context.motion.z);
+		pWorldIn.addFreshEntity(itementity);
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/contraptions/components/actors/dispenser/MovedProjectileDispenserBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/actors/dispenser/MovedProjectileDispenserBehaviour.java
@@ -81,19 +81,19 @@ public abstract class MovedProjectileDispenserBehaviour extends MovedDefaultDisp
 	}
 
 	private static Method getProjectileEntityLookup() {
-		Method getProjectileEntity = ObfuscationReflectionHelper.findMethod(ProjectileDispenseBehavior.class, "func_82499_a", World.class, IPosition.class, ItemStack.class); // getProjectile
+		Method getProjectileEntity = ObfuscationReflectionHelper.findMethod(ProjectileDispenseBehavior.class, "getProjectile", World.class, IPosition.class, ItemStack.class); // getProjectile
 		getProjectileEntity.setAccessible(true);
 		return getProjectileEntity;
 	}
 
 	private static Method getProjectileInaccuracyLookup() {
-		Method getProjectileInaccuracy = ObfuscationReflectionHelper.findMethod(ProjectileDispenseBehavior.class, "func_82498_a"); // getUncertainty
+		Method getProjectileInaccuracy = ObfuscationReflectionHelper.findMethod(ProjectileDispenseBehavior.class, "getUncertainty"); // getUncertainty
 		getProjectileInaccuracy.setAccessible(true);
 		return getProjectileInaccuracy;
 	}
 
 	private static Method getProjectileVelocityLookup() {
-		Method getProjectileVelocity = ObfuscationReflectionHelper.findMethod(ProjectileDispenseBehavior.class, "func_82500_b"); // getPower
+		Method getProjectileVelocity = ObfuscationReflectionHelper.findMethod(ProjectileDispenseBehavior.class, "getPower"); // getPower
 		getProjectileVelocity.setAccessible(true);
 		return getProjectileVelocity;
 	}

--- a/src/main/java/com/simibubi/create/content/contraptions/components/clock/CuckooClockBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/clock/CuckooClockBlock.java
@@ -45,8 +45,8 @@ public class CuckooClockBlock extends HorizontalKineticBlock {
 	}
 	
 	@Override
-	public VoxelShape getShape(BlockState p_220053_1_, IBlockReader p_220053_2_, BlockPos p_220053_3_,
-		ISelectionContext p_220053_4_) {
+	public VoxelShape getShape(BlockState pState, IBlockReader pWorldIn, BlockPos pPos,
+		ISelectionContext pContext) {
 		return AllShapes.CUCKOO_CLOCK;
 	}
 

--- a/src/main/java/com/simibubi/create/content/contraptions/components/crank/ValveHandleBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/crank/ValveHandleBlock.java
@@ -62,10 +62,10 @@ public class ValveHandleBlock extends HandCrankBlock {
 	}
 
 	@Override
-	public void fillItemCategory(ItemGroup group, NonNullList<ItemStack> p_149666_2_) {
+	public void fillItemCategory(ItemGroup group, NonNullList<ItemStack> pItems) {
 		if (group != ItemGroup.TAB_SEARCH && !inCreativeTab)
 			return;
-		super.fillItemCategory(group, p_149666_2_);
+		super.fillItemCategory(group, pItems);
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/contraptions/components/deployer/DeployerApplicationRecipe.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/deployer/DeployerApplicationRecipe.java
@@ -35,7 +35,7 @@ public class DeployerApplicationRecipe extends ProcessingRecipe<RecipeWrapper> i
 	}
 
 	@Override
-	public boolean matches(RecipeWrapper inv, World p_77569_2_) {
+	public boolean matches(RecipeWrapper inv, World pWorldIn) {
 		return ingredients.get(0)
 			.test(inv.getItem(0))
 			&& ingredients.get(1)

--- a/src/main/java/com/simibubi/create/content/contraptions/components/deployer/DeployerBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/deployer/DeployerBlock.java
@@ -122,8 +122,8 @@ public class DeployerBlock extends DirectionalAxisKineticBlock implements ITE<De
 	}
 
 	@Override
-	public void neighborChanged(BlockState state, World world, BlockPos pos, Block p_220069_4_,
-		BlockPos p_220069_5_, boolean p_220069_6_) {
+	public void neighborChanged(BlockState state, World world, BlockPos pos, Block pBlockIn,
+		BlockPos pFromPos, boolean pIsMoving) {
 		withTileEntityDo(world, pos, DeployerTileEntity::redstoneUpdate);
 	}
 

--- a/src/main/java/com/simibubi/create/content/contraptions/components/deployer/DeployerFakePlayer.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/deployer/DeployerFakePlayer.java
@@ -114,7 +114,7 @@ public class DeployerFakePlayer extends FakePlayer {
 	}
 
 	@Override
-	protected void playEquipSound(ItemStack p_184606_1_) {}
+	protected void playEquipSound(ItemStack pStack) {}
 
 	@Override
 	public void remove(boolean keepData) {

--- a/src/main/java/com/simibubi/create/content/contraptions/components/fan/EncasedFanBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/fan/EncasedFanBlock.java
@@ -45,8 +45,8 @@ public class EncasedFanBlock extends DirectionalKineticBlock implements ITE<Enca
 	}
 
 	@Override
-	public void onRemove(BlockState state, World world, BlockPos pos, BlockState p_196243_4_, boolean p_196243_5_) {
-		if (state.hasTileEntity() && (state.getBlock() != p_196243_4_.getBlock() || !p_196243_4_.hasTileEntity())) {
+	public void onRemove(BlockState state, World world, BlockPos pos, BlockState pNewState, boolean pIsMoving) {
+		if (state.hasTileEntity() && (state.getBlock() != pNewState.getBlock() || !pNewState.hasTileEntity())) {
 			withTileEntityDo(world, pos, EncasedFanTileEntity::updateChute);
 			world.removeBlockEntity(pos);
 		}

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/AbstractContraptionEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/AbstractContraptionEntity.java
@@ -154,8 +154,8 @@ public abstract class AbstractContraptionEntity extends Entity implements IEntit
 	}
 
 	@Override
-	protected boolean canAddPassenger(Entity p_184219_1_) {
-		if (p_184219_1_ instanceof OrientedContraptionEntity)
+	protected boolean canAddPassenger(Entity pPassenger) {
+		if (pPassenger instanceof OrientedContraptionEntity)
 			return true;
 		return contraption.getSeatMapping()
 			.size() < contraption.getSeats()
@@ -395,7 +395,7 @@ public abstract class AbstractContraptionEntity extends Entity implements IEntit
 			int estimatedPacketSize = byteArray.length;
 			if (estimatedPacketSize > 2_000_000) {
 				Create.LOGGER.warn("Could not send Contraption Spawn Data (Packet too big): "
-						+ getContraption().getType().id + " @" + position() + " (" + getUUID().toString() + ")");
+						+ getContraption().getType().id + " @" + position() + " (" + getUUID() + ")");
 				buffer.writeNbt(new CompoundNBT());
 				return;
 			}
@@ -697,7 +697,7 @@ public abstract class AbstractContraptionEntity extends Entity implements IEntit
 	}
 
 	@Override
-	public void setSecondsOnFire(int p_70015_1_) {
+	public void setSecondsOnFire(int pSeconds) {
 		// Contraptions no longer catch fire
 	}
 

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/BlockMovementChecks.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/BlockMovementChecks.java
@@ -408,7 +408,7 @@ public class BlockMovementChecks {
 	public static interface AllChecks extends MovementNecessaryCheck, MovementAllowedCheck, BrittleCheck, AttachedCheck, NotSupportiveCheck {
 	}
 
-	public static enum CheckResult {
+	public enum CheckResult {
 		SUCCESS,
 		FAIL,
 		PASS;

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/ContraptionCollider.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/ContraptionCollider.java
@@ -125,8 +125,7 @@ public class ContraptionCollider {
 				ReuseableStream<VoxelShape> potentialHits =
 					getPotentiallyCollidedShapes(world, contraption, localBB.expandTowards(motionCopy));
 				potentialHits.getStream()
-					.forEach(shape -> shape.toAabbs()
-						.forEach(bbs::add));
+					.forEach(shape -> bbs.addAll(shape.toAabbs()));
 				return bbs;
 
 			});

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/ContraptionWorld.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/ContraptionWorld.java
@@ -43,7 +43,7 @@ public class ContraptionWorld extends WrappedWorld {
     }
 
     @Override
-    public void playLocalSound(double x, double y, double z, SoundEvent p_184134_7_, SoundCategory p_184134_8_, float p_184134_9_, float p_184134_10_, boolean p_184134_11_) {
-        world.playLocalSound(x, y, z, p_184134_7_, p_184134_8_, p_184134_9_, p_184134_10_, p_184134_11_);
+    public void playLocalSound(double x, double y, double z, SoundEvent pSoundIn, SoundCategory pCategory, float pVolume, float pPitch, boolean pDistanceDelay) {
+        world.playLocalSound(x, y, z, pSoundIn, pCategory, pVolume, pPitch, pDistanceDelay);
     }
 }

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/ControlledContraptionEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/ControlledContraptionEntity.java
@@ -126,7 +126,7 @@ public class ControlledContraptionEntity extends AbstractContraptionEntity {
 	}
 
 	@Override
-	public void teleportTo(double p_70634_1_, double p_70634_3_, double p_70634_5_) {}
+	public void teleportTo(double pX, double pY, double pZ) {}
 
 	@Override
 	@OnlyIn(Dist.CLIENT)

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/IControlContraption.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/IControlContraption.java
@@ -9,18 +9,18 @@ import net.minecraft.util.math.BlockPos;
 public interface IControlContraption {
 
 	public boolean isAttachedTo(AbstractContraptionEntity contraption);
-	
+
 	public void attach(ControlledContraptionEntity contraption);
 
 	public void onStall();
 
 	public boolean isValid();
-	
+
 	public void collided();
-	
+
 	public BlockPos getBlockPosition();
 
-	static enum MovementMode implements INamedIconOptions {
+	enum MovementMode implements INamedIconOptions {
 
 		MOVE_PLACE(AllIcons.I_MOVE_PLACE),
 		MOVE_PLACE_RETURNED(AllIcons.I_MOVE_PLACE_RETURNED),
@@ -31,7 +31,7 @@ public interface IControlContraption {
 		private String translationKey;
 		private AllIcons icon;
 
-		private MovementMode(AllIcons icon) {
+		MovementMode(AllIcons icon) {
 			this.icon = icon;
 			translationKey = "contraptions.movement_mode." + Lang.asId(name());
 		}
@@ -48,7 +48,7 @@ public interface IControlContraption {
 
 	}
 
-	static enum RotationMode implements INamedIconOptions {
+	enum RotationMode implements INamedIconOptions {
 
 		ROTATE_PLACE(AllIcons.I_ROTATE_PLACE),
 		ROTATE_PLACE_RETURNED(AllIcons.I_ROTATE_PLACE_RETURNED),
@@ -59,7 +59,7 @@ public interface IControlContraption {
 		private String translationKey;
 		private AllIcons icon;
 
-		private RotationMode(AllIcons icon) {
+		RotationMode(AllIcons icon) {
 			this.icon = icon;
 			translationKey = "contraptions.movement_mode." + Lang.asId(name());
 		}

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/OrientedContraptionEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/OrientedContraptionEntity.java
@@ -489,7 +489,7 @@ public class OrientedContraptionEntity extends AbstractContraptionEntity {
 	@Nullable
 	public UUID getCouplingId() {
 		Optional<UUID> uuid = entityData.get(COUPLING);
-		return uuid == null ? null : uuid.isPresent() ? uuid.get() : null;
+		return uuid.orElse(null);
 	}
 
 	public void setCouplingId(UUID id) {

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/OrientedContraptionEntityRenderer.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/OrientedContraptionEntityRenderer.java
@@ -10,9 +10,9 @@ public class OrientedContraptionEntityRenderer extends ContraptionEntityRenderer
 	}
 
 	@Override
-	public boolean shouldRender(OrientedContraptionEntity entity, ClippingHelper p_225626_2_, double p_225626_3_,
-		double p_225626_5_, double p_225626_7_) {
-		if (!super.shouldRender(entity, p_225626_2_, p_225626_3_, p_225626_5_, p_225626_7_))
+	public boolean shouldRender(OrientedContraptionEntity entity, ClippingHelper pCamera, double pCamX,
+		double pCamY, double pCamZ) {
+		if (!super.shouldRender(entity, pCamera, pCamX, pCamY, pCamZ))
 			return false;
 		if (entity.getContraption()
 				  .getType() == ContraptionType.MOUNTED && entity.getVehicle() == null)

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/bearing/ClockworkBearingTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/bearing/ClockworkBearingTileEntity.java
@@ -385,7 +385,7 @@ public class ClockworkBearingTileEntity extends KineticTileEntity
 		return running;
 	}
 
-	static enum ClockHands implements INamedIconOptions {
+	enum ClockHands implements INamedIconOptions {
 
 		HOUR_FIRST(AllIcons.I_HOUR_HAND_FIRST),
 		MINUTE_FIRST(AllIcons.I_MINUTE_HAND_FIRST),
@@ -396,7 +396,7 @@ public class ClockworkBearingTileEntity extends KineticTileEntity
 		private String translationKey;
 		private AllIcons icon;
 
-		private ClockHands(AllIcons icon) {
+		ClockHands(AllIcons icon) {
 			this.icon = icon;
 			translationKey = "contraptions.clockwork." + Lang.asId(name());
 		}

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/bearing/ClockworkContraption.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/bearing/ClockworkContraption.java
@@ -81,7 +81,7 @@ public class ClockworkContraption extends Contraption {
 		}
 		return Pair.of(hourArm, minuteArm);
 	}
-	
+
 	@Override
 	public boolean assemble(World world, BlockPos pos) throws AssemblyException {
 		return searchMovedStructure(world, pos, facing);
@@ -125,8 +125,8 @@ public class ClockworkContraption extends Contraption {
 			return false;
 		return facing.getAxis() == this.facing.getAxis();
 	}
-	
-	public static enum HandType {
+
+	public enum HandType {
 		HOUR, MINUTE
 	}
 

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/bearing/SailBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/bearing/SailBlock.java
@@ -156,15 +156,15 @@ public class SailBlock extends ProperDirectionalBlock {
 	}
 
 	@Override
-	public VoxelShape getShape(BlockState state, IBlockReader p_220053_2_, BlockPos p_220053_3_, ISelectionContext p_220053_4_) {
+	public VoxelShape getShape(BlockState state, IBlockReader pWorldIn, BlockPos pPos, ISelectionContext pContext) {
 		return (frame ? AllShapes.SAIL_FRAME : AllShapes.SAIL).get(state.getValue(FACING));
 	}
 
 	@Override
-	public VoxelShape getCollisionShape(BlockState state, IBlockReader p_220071_2_, BlockPos p_220071_3_, ISelectionContext p_220071_4_) {
+	public VoxelShape getCollisionShape(BlockState state, IBlockReader pWorldIn, BlockPos pPos, ISelectionContext pContext) {
 		if (frame)
 			return AllShapes.SAIL_FRAME_COLLISION.get(state.getValue(FACING));
-		return getShape(state, p_220071_2_, p_220071_3_, p_220071_4_);
+		return getShape(state, pWorldIn, pPos, pContext);
 	}
 
 	@Override
@@ -176,25 +176,25 @@ public class SailBlock extends ProperDirectionalBlock {
 		return pickBlock;
 	}
 
-	public void fallOn(World p_180658_1_, BlockPos p_180658_2_, Entity p_180658_3_, float p_180658_4_) {
+	public void fallOn(World pWorldIn, BlockPos pPos, Entity pEntityIn, float pFallDistance) {
 		if (frame)
-			super.fallOn(p_180658_1_, p_180658_2_, p_180658_3_, p_180658_4_);
-		super.fallOn(p_180658_1_, p_180658_2_, p_180658_3_, 0);
+			super.fallOn(pWorldIn, pPos, pEntityIn, pFallDistance);
+		super.fallOn(pWorldIn, pPos, pEntityIn, 0);
 	}
 
-	public void updateEntityAfterFallOn(IBlockReader p_176216_1_, Entity p_176216_2_) {
-		if (frame || p_176216_2_.isSuppressingBounce()) {
-			super.updateEntityAfterFallOn(p_176216_1_, p_176216_2_);
+	public void updateEntityAfterFallOn(IBlockReader pWorldIn, Entity pEntityIn) {
+		if (frame || pEntityIn.isSuppressingBounce()) {
+			super.updateEntityAfterFallOn(pWorldIn, pEntityIn);
 		} else {
-			this.bounce(p_176216_2_);
+			this.bounce(pEntityIn);
 		}
 	}
 
-	private void bounce(Entity p_226860_1_) {
-		Vector3d Vector3d = p_226860_1_.getDeltaMovement();
+	private void bounce(Entity pEntity) {
+		Vector3d Vector3d = pEntity.getDeltaMovement();
 		if (Vector3d.y < 0.0D) {
-			double d0 = p_226860_1_ instanceof LivingEntity ? 1.0D : 0.8D;
-			p_226860_1_.setDeltaMovement(Vector3d.x, -Vector3d.y * (double) 0.26F * d0, Vector3d.z);
+			double d0 = pEntity instanceof LivingEntity ? 1.0D : 0.8D;
+			pEntity.setDeltaMovement(Vector3d.x, -Vector3d.y * (double) 0.26F * d0, Vector3d.z);
 		}
 
 	}

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/bearing/WindmillBearingTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/bearing/WindmillBearingTileEntity.java
@@ -91,7 +91,7 @@ public class WindmillBearingTileEntity extends MechanicalBearingTileEntity {
 		return true;
 	}
 
-	static enum RotationDirection implements INamedIconOptions {
+	enum RotationDirection implements INamedIconOptions {
 
 		CLOCKWISE(AllIcons.I_REFRESH), COUNTER_CLOCKWISE(AllIcons.I_ROTATE_CCW),
 
@@ -100,7 +100,7 @@ public class WindmillBearingTileEntity extends MechanicalBearingTileEntity {
 		private String translationKey;
 		private AllIcons icon;
 
-		private RotationDirection(AllIcons icon) {
+		RotationDirection(AllIcons icon) {
 			this.icon = icon;
 			translationKey = "generic." + Lang.asId(name());
 		}

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/chassis/ChassisRangeDisplay.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/chassis/ChassisRangeDisplay.java
@@ -47,12 +47,10 @@ public class ChassisRangeDisplay {
 		}
 
 		protected Set<BlockPos> createSelection(ChassisTileEntity chassis) {
-			Set<BlockPos> positions = new HashSet<>();
 			List<BlockPos> includedBlockPositions = chassis.getIncludedBlockPositions(null, true);
 			if (includedBlockPositions == null)
 				return Collections.emptySet();
-			positions.addAll(includedBlockPositions);
-			return positions;
+			return new HashSet<>(includedBlockPositions);
 		}
 
 	}

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/chassis/LinearChassisBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/chassis/LinearChassisBlock.java
@@ -56,8 +56,8 @@ public class LinearChassisBlock extends AbstractChassisBlock {
 	}
 
 	@Override
-	public BlockState updateShape(BlockState state, Direction side, BlockState other, IWorld p_196271_4_,
-		BlockPos p_196271_5_, BlockPos p_196271_6_) {
+	public BlockState updateShape(BlockState state, Direction side, BlockState other, IWorld pWorldIn,
+		BlockPos pCurrentPos, BlockPos pFacingPos) {
 		BooleanProperty property = getGlueableSide(state, side);
 		if (property == null || !sameKind(state, other) || state.getValue(AXIS) != other.getValue(AXIS))
 			return state;

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/chassis/StickerBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/chassis/StickerBlock.java
@@ -98,41 +98,41 @@ public class StickerBlock extends ProperDirectionalBlock implements ITE<StickerT
 	}
 
 	@Override
-	public void fallOn(World p_180658_1_, BlockPos p_180658_2_, Entity p_180658_3_, float p_180658_4_) {
-		if (!isUprightSticker(p_180658_1_, p_180658_2_) || p_180658_3_.isSuppressingBounce()) {
-			super.fallOn(p_180658_1_, p_180658_2_, p_180658_3_, p_180658_4_);
+	public void fallOn(World pWorldIn, BlockPos pPos, Entity pEntityIn, float pFallDistance) {
+		if (!isUprightSticker(pWorldIn, pPos) || pEntityIn.isSuppressingBounce()) {
+			super.fallOn(pWorldIn, pPos, pEntityIn, pFallDistance);
 		} else {
-			p_180658_3_.causeFallDamage(p_180658_4_, 0.0F);
+			pEntityIn.causeFallDamage(pFallDistance, 0.0F);
 		}
 	}
 
 	@Override
-	public void updateEntityAfterFallOn(IBlockReader p_176216_1_, Entity p_176216_2_) {
-		if (!isUprightSticker(p_176216_1_, p_176216_2_.blockPosition()
-			.below()) || p_176216_2_.isSuppressingBounce()) {
-			super.updateEntityAfterFallOn(p_176216_1_, p_176216_2_);
+	public void updateEntityAfterFallOn(IBlockReader pWorldIn, Entity pEntityIn) {
+		if (!isUprightSticker(pWorldIn, pEntityIn.blockPosition()
+			.below()) || pEntityIn.isSuppressingBounce()) {
+			super.updateEntityAfterFallOn(pWorldIn, pEntityIn);
 		} else {
-			this.bounceUp(p_176216_2_);
+			this.bounceUp(pEntityIn);
 		}
 	}
 
-	private void bounceUp(Entity p_226946_1_) {
-		Vector3d Vector3d = p_226946_1_.getDeltaMovement();
+	private void bounceUp(Entity pEntity) {
+		Vector3d Vector3d = pEntity.getDeltaMovement();
 		if (Vector3d.y < 0.0D) {
-			double d0 = p_226946_1_ instanceof LivingEntity ? 1.0D : 0.8D;
-			p_226946_1_.setDeltaMovement(Vector3d.x, -Vector3d.y * d0, Vector3d.z);
+			double d0 = pEntity instanceof LivingEntity ? 1.0D : 0.8D;
+			pEntity.setDeltaMovement(Vector3d.x, -Vector3d.y * d0, Vector3d.z);
 		}
 	}
 
 	@Override
-	public void stepOn(World p_176199_1_, BlockPos p_176199_2_, Entity p_176199_3_) {
-		double d0 = Math.abs(p_176199_3_.getDeltaMovement().y);
-		if (d0 < 0.1D && !p_176199_3_.isSteppingCarefully() && isUprightSticker(p_176199_1_, p_176199_2_)) {
+	public void stepOn(World pWorldIn, BlockPos pPos, Entity pEntityIn) {
+		double d0 = Math.abs(pEntityIn.getDeltaMovement().y);
+		if (d0 < 0.1D && !pEntityIn.isSteppingCarefully() && isUprightSticker(pWorldIn, pPos)) {
 			double d1 = 0.4D + d0 * 0.2D;
-			p_176199_3_.setDeltaMovement(p_176199_3_.getDeltaMovement()
+			pEntityIn.setDeltaMovement(pEntityIn.getDeltaMovement()
 				.multiply(d1, 1.0D, d1));
 		}
-		super.stepOn(p_176199_1_, p_176199_2_, p_176199_3_);
+		super.stepOn(pWorldIn, pPos, pEntityIn);
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/gantry/GantryCarriageBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/gantry/GantryCarriageBlock.java
@@ -84,8 +84,8 @@ public class GantryCarriageBlock extends DirectionalAxisKineticBlock implements 
 	}
 
 	@Override
-	public void neighborChanged(BlockState state, World world, BlockPos pos, Block p_220069_4_, BlockPos updatePos,
-		boolean p_220069_6_) {
+	public void neighborChanged(BlockState state, World world, BlockPos pos, Block pBlockIn, BlockPos updatePos,
+		boolean pIsMoving) {
 		if (updatePos.equals(pos.relative(state.getValue(FACING)
 			.getOpposite())) && !canSurvive(state, world, pos))
 			world.destroyBlock(pos, true);
@@ -93,7 +93,7 @@ public class GantryCarriageBlock extends DirectionalAxisKineticBlock implements 
 
 	@Override
 	public BlockState updateShape(BlockState state, Direction direction, BlockState otherState, IWorld world,
-		BlockPos pos, BlockPos p_196271_6_) {
+		BlockPos pos, BlockPos pFacingPos) {
 		if (state.getValue(FACING) != direction.getOpposite())
 			return state;
 		return cycleAxisIfNecessary(state, direction, otherState);

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/gantry/GantryContraptionEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/gantry/GantryContraptionEntity.java
@@ -160,7 +160,7 @@ public class GantryContraptionEntity extends AbstractContraptionEntity {
 	}
 
 	@Override
-	public void teleportTo(double p_70634_1_, double p_70634_3_, double p_70634_5_) {}
+	public void teleportTo(double pX, double pY, double pZ) {}
 
 	@Override
 	@OnlyIn(Dist.CLIENT)

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/mounted/CartAssemblerBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/mounted/CartAssemblerBlock.java
@@ -271,12 +271,12 @@ public class CartAssemblerBlock extends AbstractRailBlock
 
 	@SuppressWarnings("deprecation")
 	public List<ItemStack> getDropsNoRail(BlockState state, ServerWorld world, BlockPos pos,
-		@Nullable TileEntity p_220077_3_, @Nullable Entity p_220077_4_, ItemStack p_220077_5_) {
+		@Nullable TileEntity pTileEntityIn, @Nullable Entity pEntityIn, ItemStack pStack) {
 		return super.getDrops(state, (new LootContext.Builder(world)).withRandom(world.random)
 			.withParameter(LootParameters.ORIGIN, Vector3d.atLowerCornerOf(pos))
-			.withParameter(LootParameters.TOOL, p_220077_5_)
-			.withOptionalParameter(LootParameters.THIS_ENTITY, p_220077_4_)
-			.withOptionalParameter(LootParameters.BLOCK_ENTITY, p_220077_3_));
+			.withParameter(LootParameters.TOOL, pStack)
+			.withOptionalParameter(LootParameters.THIS_ENTITY, pEntityIn)
+			.withOptionalParameter(LootParameters.BLOCK_ENTITY, pTileEntityIn));
 	}
 
 	@Override
@@ -309,8 +309,8 @@ public class CartAssemblerBlock extends AbstractRailBlock
 
 		@Override
 		@Nonnull
-		public VoxelShape getShape(@Nonnull BlockState p_220053_1_, @Nonnull IBlockReader p_220053_2_,
-			@Nonnull BlockPos p_220053_3_, @Nonnull ISelectionContext p_220053_4_) {
+		public VoxelShape getShape(@Nonnull BlockState pState, @Nonnull IBlockReader pWorldIn,
+			@Nonnull BlockPos pPos, @Nonnull ISelectionContext pContext) {
 			return VoxelShapes.empty();
 		}
 	}

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/piston/MechanicalPistonBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/piston/MechanicalPistonBlock.java
@@ -103,8 +103,8 @@ public class MechanicalPistonBlock extends DirectionalAxisKineticBlock implement
 	}
 
 	@Override
-	public void neighborChanged(BlockState state, World world, BlockPos pos, Block p_220069_4_, BlockPos fromPos,
-		boolean p_220069_6_) {
+	public void neighborChanged(BlockState state, World world, BlockPos pos, Block pBlockIn, BlockPos fromPos,
+		boolean pIsMoving) {
 		Direction direction = state.getValue(FACING);
 		if (!fromPos.equals(pos.relative(direction.getOpposite())))
 			return;
@@ -159,7 +159,7 @@ public class MechanicalPistonBlock extends DirectionalAxisKineticBlock implement
 		BlockPos pistonBase = pos;
 		boolean dropBlocks = player == null || !player.isCreative();
 
-		Integer maxPoles = maxAllowedPistonPoles();
+		int maxPoles = maxAllowedPistonPoles();
 		for (int offset = 1; offset < maxPoles; offset++) {
 			BlockPos currentPos = pos.relative(direction, offset);
 			BlockState block = worldIn.getBlockState(currentPos);

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/pulley/AbstractPulleyRenderer.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/pulley/AbstractPulleyRenderer.java
@@ -36,7 +36,7 @@ public abstract class AbstractPulleyRenderer extends KineticTileEntityRenderer {
 	}
 
 	@Override
-	public boolean shouldRenderOffScreen(KineticTileEntity p_188185_1_) {
+	public boolean shouldRenderOffScreen(KineticTileEntity pTe) {
 		return true;
 	}
 

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/train/capability/CapabilityMinecartController.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/train/capability/CapabilityMinecartController.java
@@ -94,8 +94,8 @@ public class CapabilityMinecartController implements ICapabilitySerializable<Com
 		Set<UUID> cartsWithCoupling = loadedMinecartsWithCoupling.get(world);
 		Set<UUID> keySet = carts.keySet();
 
-		keySet.removeAll(queuedRemovals);
-		cartsWithCoupling.removeAll(queuedRemovals);
+		queuedRemovals.forEach(keySet::remove);
+		queuedRemovals.forEach(cartsWithCoupling::remove);
 
 		for (AbstractMinecartEntity cart : queued) {
 			UUID uniqueID = cart.getUUID();
@@ -138,8 +138,8 @@ public class CapabilityMinecartController implements ICapabilitySerializable<Com
 			toRemove.add(entry.getKey());
 		}
 
-		cartsWithCoupling.removeAll(toRemove);
-		keySet.removeAll(toRemove);
+		toRemove.forEach(cartsWithCoupling::remove);
+		toRemove.forEach(keySet::remove);
 	}
 
 	public static void onChunkUnloaded(ChunkEvent.Unload event) {

--- a/src/main/java/com/simibubi/create/content/contraptions/components/tracks/ControllerRailBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/tracks/ControllerRailBlock.java
@@ -77,8 +77,8 @@ public class ControllerRailBlock extends AbstractRailBlock implements IWrenchabl
 	}
 
 	@Override
-	protected BlockState updateDir(World world, BlockPos pos, BlockState state, boolean p_208489_4_) {
-		BlockState updatedState = super.updateDir(world, pos, state, p_208489_4_);
+	protected BlockState updateDir(World world, BlockPos pos, BlockState state, boolean pPlacing) {
+		BlockState updatedState = super.updateDir(world, pos, state, pPlacing);
 		if (updatedState.getValue(SHAPE) == state.getValue(SHAPE))
 			return updatedState;
 		BlockState reversedUpdatedState = updatedState;
@@ -124,9 +124,9 @@ public class ControllerRailBlock extends AbstractRailBlock implements IWrenchabl
 	}
 
 	@Override
-	public BlockState getStateForPlacement(BlockItemUseContext p_196258_1_) {
-		Direction direction = p_196258_1_.getHorizontalDirection();
-		BlockState base = super.getStateForPlacement(p_196258_1_);
+	public BlockState getStateForPlacement(BlockItemUseContext pContext) {
+		Direction direction = pContext.getHorizontalDirection();
+		BlockState base = super.getStateForPlacement(pContext);
 		return (base == null ? defaultBlockState() : base).setValue(BACKWARDS,
 			direction.getAxisDirection() == AxisDirection.POSITIVE);
 	}
@@ -137,8 +137,8 @@ public class ControllerRailBlock extends AbstractRailBlock implements IWrenchabl
 	}
 
 	@Override
-	protected void createBlockStateDefinition(StateContainer.Builder<Block, BlockState> p_206840_1_) {
-		p_206840_1_.add(SHAPE, POWER, BACKWARDS);
+	protected void createBlockStateDefinition(StateContainer.Builder<Block, BlockState> pBuilder) {
+		pBuilder.add(SHAPE, POWER, BACKWARDS);
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/contraptions/components/tracks/ReinforcedRailBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/tracks/ReinforcedRailBlock.java
@@ -40,7 +40,7 @@ public class ReinforcedRailBlock extends AbstractRailBlock {
     }
 
     @Override
-    public void fillItemCategory(ItemGroup p_149666_1_, NonNullList<ItemStack> p_149666_2_) {
+    public void fillItemCategory(ItemGroup pGroup, NonNullList<ItemStack> pItems) {
     	// TODO re-add when finished
     }
 
@@ -76,13 +76,13 @@ public class ReinforcedRailBlock extends AbstractRailBlock {
     @Override
     @Nonnull
     protected BlockState updateDir(@Nonnull World world, BlockPos pos, BlockState state,
-                                         boolean p_208489_4_) {
+                                         boolean pPlacing) {
 
         boolean alongX = state.getValue(RAIL_SHAPE) == RailShape.EAST_WEST;
         BlockPos sPos = pos.offset(alongX ? -1 : 0, 0, alongX ? 0 : 1);
         BlockPos nPos = pos.offset(alongX ? 1 : 0, 0, alongX ? 0 : -1);
 
-        return super.updateDir(world, pos, state, p_208489_4_).setValue(CONNECTS_S, world.getBlockState(sPos).getBlock() instanceof ReinforcedRailBlock &&
+        return super.updateDir(world, pos, state, pPlacing).setValue(CONNECTS_S, world.getBlockState(sPos).getBlock() instanceof ReinforcedRailBlock &&
                 (world.getBlockState(sPos).getValue(RAIL_SHAPE) == state.getValue(RAIL_SHAPE)))
                 .setValue(CONNECTS_N, world.getBlockState(nPos).getBlock() instanceof ReinforcedRailBlock &&
                         (world.getBlockState(nPos).getValue(RAIL_SHAPE) == state.getValue(RAIL_SHAPE)));
@@ -122,10 +122,10 @@ public class ReinforcedRailBlock extends AbstractRailBlock {
     }
 
     @Override
-    public void neighborChanged(@Nonnull BlockState state, World world, @Nonnull BlockPos pos, @Nonnull Block block, @Nonnull BlockPos pos2, boolean p_220069_6_) {
+    public void neighborChanged(@Nonnull BlockState state, World world, @Nonnull BlockPos pos, @Nonnull Block block, @Nonnull BlockPos pos2, boolean pIsMoving) {
         if (!world.isClientSide) {
             if ((world.getBlockState(pos.below()).getBlock() instanceof AbstractRailBlock)) {
-                if (!p_220069_6_) {
+                if (!pIsMoving) {
                     dropResources(state, world, pos);
                 }
                 world.removeBlock(pos, false);

--- a/src/main/java/com/simibubi/create/content/contraptions/fluids/FluidTransportBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/fluids/FluidTransportBehaviour.java
@@ -256,7 +256,7 @@ public abstract class FluidTransportBehaviour extends TileEntityBehaviour {
 		return AttachmentTypes.RIM;
 	}
 
-	public static enum AttachmentTypes {
+	public enum AttachmentTypes {
 		NONE, RIM, DRAIN;
 
 		public boolean hasModel() {

--- a/src/main/java/com/simibubi/create/content/contraptions/fluids/PumpBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/fluids/PumpBlock.java
@@ -80,8 +80,8 @@ public class PumpBlock extends DirectionalKineticBlock implements IWaterLoggable
 	}
 
 	@Override
-	public VoxelShape getShape(BlockState state, IBlockReader p_220053_2_, BlockPos p_220053_3_,
-		ISelectionContext p_220053_4_) {
+	public VoxelShape getShape(BlockState state, IBlockReader pWorldIn, BlockPos pPos,
+		ISelectionContext pContext) {
 		return AllShapes.PUMP.get(state.getValue(FACING));
 	}
 

--- a/src/main/java/com/simibubi/create/content/contraptions/fluids/VirtualFluid.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/fluids/VirtualFluid.java
@@ -37,12 +37,12 @@ public class VirtualFluid extends ForgeFlowingFluid {
 	}
 
 	@Override
-	public boolean isSource(FluidState p_207193_1_) {
+	public boolean isSource(FluidState pState) {
 		return false;
 	}
 
 	@Override
-	public int getAmount(FluidState p_207192_1_) {
+	public int getAmount(FluidState pState) {
 		return 0;
 	}
 

--- a/src/main/java/com/simibubi/create/content/contraptions/fluids/actors/FillingRecipe.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/fluids/actors/FillingRecipe.java
@@ -31,7 +31,7 @@ public class FillingRecipe extends ProcessingRecipe<RecipeWrapper> implements IA
 	}
 
 	@Override
-	public boolean matches(RecipeWrapper inv, World p_77569_2_) {
+	public boolean matches(RecipeWrapper inv, World pWorldIn) {
 		return ingredients.get(0)
 			.test(inv.getItem(0));
 	}

--- a/src/main/java/com/simibubi/create/content/contraptions/fluids/actors/HosePulleyBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/fluids/actors/HosePulleyBlock.java
@@ -84,10 +84,10 @@ public class HosePulleyBlock extends HorizontalKineticBlock implements ITE<HoseP
 	}
 
 	@Override
-	public void onRemove(BlockState p_196243_1_, World world, BlockPos pos, BlockState p_196243_4_,
-		boolean p_196243_5_) {
-		if (p_196243_1_.hasTileEntity()
-			&& (p_196243_1_.getBlock() != p_196243_4_.getBlock() || !p_196243_4_.hasTileEntity())) {
+	public void onRemove(BlockState pState, World world, BlockPos pos, BlockState pNewState,
+		boolean pIsMoving) {
+		if (pState.hasTileEntity()
+			&& (pState.getBlock() != pNewState.getBlock() || !pNewState.hasTileEntity())) {
 			TileEntityBehaviour.destroy(world, pos, FluidDrainingBehaviour.TYPE);
 			TileEntityBehaviour.destroy(world, pos, FluidFillingBehaviour.TYPE);
 			world.removeBlockEntity(pos);

--- a/src/main/java/com/simibubi/create/content/contraptions/fluids/actors/ItemDrainBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/fluids/actors/ItemDrainBlock.java
@@ -67,8 +67,8 @@ public class ItemDrainBlock extends Block implements IWrenchable, ITE<ItemDrainT
 	}
 
 	@Override
-	public VoxelShape getShape(BlockState p_220053_1_, IBlockReader p_220053_2_, BlockPos p_220053_3_,
-		ISelectionContext p_220053_4_) {
+	public VoxelShape getShape(BlockState pState, IBlockReader pWorldIn, BlockPos pPos,
+		ISelectionContext pContext) {
 		return AllShapes.CASING_13PX.get(Direction.UP);
 	}
 

--- a/src/main/java/com/simibubi/create/content/contraptions/fluids/actors/SpoutBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/fluids/actors/SpoutBlock.java
@@ -29,8 +29,8 @@ public class SpoutBlock extends Block implements IWrenchable {
 	}
 
 	@Override
-	public VoxelShape getShape(BlockState p_220053_1_, IBlockReader p_220053_2_, BlockPos p_220053_3_,
-		ISelectionContext p_220053_4_) {
+	public VoxelShape getShape(BlockState pState, IBlockReader pWorldIn, BlockPos pPos,
+		ISelectionContext pContext) {
 		return AllShapes.SPOUT;
 	}
 

--- a/src/main/java/com/simibubi/create/content/contraptions/fluids/particle/FluidStackParticle.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/fluids/particle/FluidStackParticle.java
@@ -54,8 +54,8 @@ public class FluidStackParticle extends SpriteTexturedParticle {
 	}
 
 	@Override
-	protected int getLightColor(float p_189214_1_) {
-		int brightnessForRender = super.getLightColor(p_189214_1_);
+	protected int getLightColor(float pPartialTick) {
+		int brightnessForRender = super.getLightColor(pPartialTick);
 		int skyLight = brightnessForRender >> 20;
 		int blockLight = (brightnessForRender >> 4) & 0xf;
 		blockLight = Math.max(blockLight, fluid.getFluid()

--- a/src/main/java/com/simibubi/create/content/contraptions/fluids/pipes/AxisPipeBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/fluids/pipes/AxisPipeBlock.java
@@ -112,8 +112,8 @@ public class AxisPipeBlock extends RotatedPillarBlock implements IWrenchableWith
 	}
 
 	@Override
-	public VoxelShape getShape(BlockState state, IBlockReader p_220053_2_, BlockPos p_220053_3_,
-		ISelectionContext p_220053_4_) {
+	public VoxelShape getShape(BlockState state, IBlockReader pWorldIn, BlockPos pPos,
+		ISelectionContext pContext) {
 		return AllShapes.EIGHT_VOXEL_POLE.get(state.getValue(AXIS));
 	}
 

--- a/src/main/java/com/simibubi/create/content/contraptions/fluids/pipes/BracketBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/fluids/pipes/BracketBlock.java
@@ -27,7 +27,7 @@ public class BracketBlock extends ProperDirectionalBlock {
 		DirectionalAxisKineticBlock.AXIS_ALONG_FIRST_COORDINATE;
 	public static final EnumProperty<BracketType> TYPE = EnumProperty.create("type", BracketType.class);
 
-	public static enum BracketType implements IStringSerializable {
+	public enum BracketType implements IStringSerializable {
 		PIPE, COG, SHAFT;
 
 		@Override

--- a/src/main/java/com/simibubi/create/content/contraptions/fluids/pipes/FluidValveBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/fluids/pipes/FluidValveBlock.java
@@ -40,8 +40,8 @@ public class FluidValveBlock extends DirectionalAxisKineticBlock implements IAxi
 	}
 
 	@Override
-	public VoxelShape getShape(BlockState state, IBlockReader p_220053_2_, BlockPos p_220053_3_,
-		ISelectionContext p_220053_4_) {
+	public VoxelShape getShape(BlockState state, IBlockReader pWorldIn, BlockPos pPos,
+		ISelectionContext pContext) {
 		return AllShapes.FLUID_VALVE.get(getPipeAxis(state));
 	}
 
@@ -98,7 +98,7 @@ public class FluidValveBlock extends DirectionalAxisKineticBlock implements IAxi
 	}
 
 	@Override
-	public boolean canSurvive(BlockState p_196260_1_, IWorldReader p_196260_2_, BlockPos p_196260_3_) {
+	public boolean canSurvive(BlockState pState, IWorldReader pWorldIn, BlockPos pPos) {
 		return true;
 	}
 

--- a/src/main/java/com/simibubi/create/content/contraptions/fluids/pipes/GlassFluidPipeBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/fluids/pipes/GlassFluidPipeBlock.java
@@ -41,8 +41,8 @@ public class GlassFluidPipeBlock extends AxisPipeBlock implements IWaterLoggable
 	}
 
 	@Override
-	protected void createBlockStateDefinition(Builder<Block, BlockState> p_206840_1_) {
-		super.createBlockStateDefinition(p_206840_1_.add(ALT, BlockStateProperties.WATERLOGGED));
+	protected void createBlockStateDefinition(Builder<Block, BlockState> pBuilder) {
+		super.createBlockStateDefinition(pBuilder.add(ALT, BlockStateProperties.WATERLOGGED));
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/contraptions/fluids/pipes/SmartFluidPipeBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/fluids/pipes/SmartFluidPipeBlock.java
@@ -91,7 +91,7 @@ public class SmartFluidPipeBlock extends HorizontalFaceBlock implements IAxisPip
 	}
 
 	@Override
-	public boolean canSurvive(BlockState p_196260_1_, IWorldReader p_196260_2_, BlockPos p_196260_3_) {
+	public boolean canSurvive(BlockState pState, IWorldReader pWorldIn, BlockPos pPos) {
 		return true;
 	}
 
@@ -143,8 +143,8 @@ public class SmartFluidPipeBlock extends HorizontalFaceBlock implements IAxisPip
 	}
 
 	@Override
-	public VoxelShape getShape(BlockState state, IBlockReader p_220053_2_, BlockPos p_220053_3_,
-		ISelectionContext p_220053_4_) {
+	public VoxelShape getShape(BlockState state, IBlockReader pWorldIn, BlockPos pPos,
+		ISelectionContext pContext) {
 		AttachFace face = state.getValue(FACE);
 		VoxelShaper shape = face == AttachFace.FLOOR ? AllShapes.SMART_FLUID_PIPE_FLOOR
 			: face == AttachFace.CEILING ? AllShapes.SMART_FLUID_PIPE_CEILING : AllShapes.SMART_FLUID_PIPE_WALL;

--- a/src/main/java/com/simibubi/create/content/contraptions/fluids/potion/PotionFluidHandler.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/fluids/potion/PotionFluidHandler.java
@@ -94,7 +94,7 @@ public class PotionFluidHandler {
 
 	// Modified version of PotionUtils#addPotionTooltip
 	@OnlyIn(Dist.CLIENT)
-	public static void addPotionTooltip(FluidStack fs, List<ITextComponent> tooltip, float p_185182_2_) {
+	public static void addPotionTooltip(FluidStack fs, List<ITextComponent> tooltip, float pDurationFactor) {
 		List<EffectInstance> list = PotionUtils.getAllEffects(fs.getOrCreateTag());
 		List<Tuple<String, AttributeModifier>> list1 = Lists.newArrayList();
 		if (list.isEmpty()) {
@@ -123,7 +123,7 @@ public class PotionFluidHandler {
 
 				if (effectinstance.getDuration() > 20) {
 					textcomponent.append(" (")
-						.append(EffectUtils.formatDuration(effectinstance, p_185182_2_))
+						.append(EffectUtils.formatDuration(effectinstance, pDurationFactor))
 						.append(")");
 				}
 

--- a/src/main/java/com/simibubi/create/content/contraptions/fluids/recipe/PotionMixingRecipeManager.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/fluids/recipe/PotionMixingRecipeManager.java
@@ -1,6 +1,7 @@
 package com.simibubi.create.content.contraptions.fluids.recipe;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -33,7 +34,7 @@ import net.minecraftforge.registries.ForgeRegistries;
 public class PotionMixingRecipeManager {
 
 	public static Map<Item, List<MixingRecipe>> ALL = new HashMap<>();
-	
+
 	public static List<MixingRecipe> getAllBrewingRecipes() {
 		List<MixingRecipe> mixingRecipes = new ArrayList<>();
 
@@ -44,8 +45,7 @@ public class PotionMixingRecipeManager {
 
 			List<ItemStack> bottles = new ArrayList<>();
 			PotionBrewing.ALLOWED_CONTAINERS.forEach(i -> {
-				for (ItemStack itemStack : i.getItems())
-					bottles.add(itemStack);
+				bottles.addAll(Arrays.asList(i.getItems()));
 			});
 
 			Collection<ItemStack> reagents = getAllReagents(iBrewingRecipe);
@@ -59,9 +59,8 @@ public class PotionMixingRecipeManager {
 			}
 
 			Set<String> uniqueKeys = new HashSet<>();
-			List<ItemStack> potionFrontier = new ArrayList<>();
 			List<ItemStack> newPotions = new ArrayList<>();
-			potionFrontier.addAll(basicPotions);
+			List<ItemStack> potionFrontier = new ArrayList<>(basicPotions);
 
 			int recipeIndex = 0;
 

--- a/src/main/java/com/simibubi/create/content/contraptions/fluids/tank/FluidTankBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/fluids/tank/FluidTankBlock.java
@@ -87,8 +87,8 @@ public class FluidTankBlock extends Block implements IWrenchable, ITE<FluidTankT
 	}
 
 	@Override
-	protected void createBlockStateDefinition(Builder<Block, BlockState> p_206840_1_) {
-		p_206840_1_.add(TOP, BOTTOM, SHAPE);
+	protected void createBlockStateDefinition(Builder<Block, BlockState> pBuilder) {
+		pBuilder.add(TOP, BOTTOM, SHAPE);
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/contraptions/fluids/tank/FluidTankItem.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/fluids/tank/FluidTankItem.java
@@ -32,12 +32,12 @@ public class FluidTankItem extends BlockItem {
 	}
 
 	@Override
-	protected boolean updateCustomBlockEntityTag(BlockPos p_195943_1_, World p_195943_2_, PlayerEntity p_195943_3_,
-		ItemStack p_195943_4_, BlockState p_195943_5_) {
-		MinecraftServer minecraftserver = p_195943_2_.getServer();
+	protected boolean updateCustomBlockEntityTag(BlockPos pPos, World pWorldIn, PlayerEntity pPlayer,
+		ItemStack pStack, BlockState pState) {
+		MinecraftServer minecraftserver = pWorldIn.getServer();
 		if (minecraftserver == null)
 			return false;
-		CompoundNBT nbt = p_195943_4_.getTagElement("BlockEntityTag");
+		CompoundNBT nbt = pStack.getTagElement("BlockEntityTag");
 		if (nbt != null) {
 			nbt.remove("Luminosity");
 			nbt.remove("Size");
@@ -52,7 +52,7 @@ public class FluidTankItem extends BlockItem {
 				}
 			}
 		}
-		return super.updateCustomBlockEntityTag(p_195943_1_, p_195943_2_, p_195943_3_, p_195943_4_, p_195943_5_);
+		return super.updateCustomBlockEntityTag(pPos, pWorldIn, pPlayer, pStack, pState);
 	}
 
 	private void tryMultiPlace(BlockItemUseContext ctx) {

--- a/src/main/java/com/simibubi/create/content/contraptions/itemAssembly/SequencedAssemblyItem.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/itemAssembly/SequencedAssemblyItem.java
@@ -18,7 +18,7 @@ public class SequencedAssemblyItem extends Item {
 	}
 
 	@Override
-	public void fillItemCategory(ItemGroup p_150895_1_, NonNullList<ItemStack> p_150895_2_) {}
+	public void fillItemCategory(ItemGroup pGroup, NonNullList<ItemStack> pItems) {}
 
 	@Override
 	public double getDurabilityForDisplay(ItemStack stack) {

--- a/src/main/java/com/simibubi/create/content/contraptions/itemAssembly/SequencedAssemblyRecipe.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/itemAssembly/SequencedAssemblyRecipe.java
@@ -171,17 +171,17 @@ public class SequencedAssemblyRecipe implements IRecipe<RecipeWrapper> {
 	}
 
 	@Override
-	public boolean matches(RecipeWrapper inv, World p_77569_2_) {
+	public boolean matches(RecipeWrapper inv, World pWorldIn) {
 		return false;
 	}
 
 	@Override
-	public ItemStack assemble(RecipeWrapper p_77572_1_) {
+	public ItemStack assemble(RecipeWrapper pInv) {
 		return ItemStack.EMPTY;
 	}
 
 	@Override
-	public boolean canCraftInDimensions(int p_194133_1_, int p_194133_2_) {
+	public boolean canCraftInDimensions(int pWidth, int pHeight) {
 		return false;
 	}
 

--- a/src/main/java/com/simibubi/create/content/contraptions/particle/CubeParticle.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/particle/CubeParticle.java
@@ -130,13 +130,13 @@ public class CubeParticle extends Particle {
 	}
 
 	@Override
-	public void render(IVertexBuilder builder, ActiveRenderInfo renderInfo, float p_225606_3_) {
+	public void render(IVertexBuilder builder, ActiveRenderInfo renderInfo, float pPartialTicks) {
 		Vector3d projectedView = renderInfo.getPosition();
-		float lerpedX = (float) (MathHelper.lerp(p_225606_3_, this.xo, this.x) - projectedView.x());
-		float lerpedY = (float) (MathHelper.lerp(p_225606_3_, this.yo, this.y) - projectedView.y());
-		float lerpedZ = (float) (MathHelper.lerp(p_225606_3_, this.zo, this.z) - projectedView.z());
+		float lerpedX = (float) (MathHelper.lerp(pPartialTicks, this.xo, this.x) - projectedView.x());
+		float lerpedY = (float) (MathHelper.lerp(pPartialTicks, this.yo, this.y) - projectedView.y());
+		float lerpedZ = (float) (MathHelper.lerp(pPartialTicks, this.zo, this.z) - projectedView.z());
 
-		// int light = getBrightnessForRender(p_225606_3_);
+		// int light = getBrightnessForRender(pPartialTicks);
 		int light = 15728880;// 15<<20 && 15<<4
 		double ageMultiplier = 1 - Math.pow(age, 3) / Math.pow(lifetime, 3);
 

--- a/src/main/java/com/simibubi/create/content/contraptions/particle/HeaterParticle.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/particle/HeaterParticle.java
@@ -47,8 +47,8 @@ public class HeaterParticle extends SimpleAnimatedParticle {
 	}
 
 	@Override
-	public float getQuadSize(float p_217561_1_) {
-		float f = ((float) this.age + p_217561_1_) / (float) this.lifetime;
+	public float getQuadSize(float pScaleFactor) {
+		float f = ((float) this.age + pScaleFactor) / (float) this.lifetime;
 		return this.quadSize * (1.0F - f * f * 0.5F);
 	}
 
@@ -60,10 +60,10 @@ public class HeaterParticle extends SimpleAnimatedParticle {
 	}
 
 	@Override
-	public int getLightColor(float p_189214_1_) {
-		float f = ((float) this.age + p_189214_1_) / (float) this.lifetime;
+	public int getLightColor(float pPartialTick) {
+		float f = ((float) this.age + pPartialTick) / (float) this.lifetime;
 		f = MathHelper.clamp(f, 0.0F, 1.0F);
-		int i = super.getLightColor(p_189214_1_);
+		int i = super.getLightColor(pPartialTick);
 		int j = i & 255;
 		int k = i >> 16 & 255;
 		j = j + (int) (f * 15.0F * 16.0F);

--- a/src/main/java/com/simibubi/create/content/contraptions/processing/BasinBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/processing/BasinBlock.java
@@ -65,8 +65,8 @@ public class BasinBlock extends Block implements ITE<BasinTileEntity>, IWrenchab
 	}
 
 	@Override
-	protected void createBlockStateDefinition(Builder<Block, BlockState> p_206840_1_) {
-		super.createBlockStateDefinition(p_206840_1_.add(FACING));
+	protected void createBlockStateDefinition(Builder<Block, BlockState> pBuilder) {
+		super.createBlockStateDefinition(pBuilder.add(FACING));
 	}
 
 	@Override
@@ -164,7 +164,7 @@ public class BasinBlock extends Block implements ITE<BasinTileEntity>, IWrenchab
 	}
 
 	@Override
-	public VoxelShape getInteractionShape(BlockState p_199600_1_, IBlockReader p_199600_2_, BlockPos p_199600_3_) {
+	public VoxelShape getInteractionShape(BlockState pState, IBlockReader pWorldIn, BlockPos pPos) {
 		return AllShapes.BASIN_RAYTRACE_SHAPE;
 	}
 

--- a/src/main/java/com/simibubi/create/content/contraptions/processing/EmptyingRecipe.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/processing/EmptyingRecipe.java
@@ -14,7 +14,7 @@ public class EmptyingRecipe extends ProcessingRecipe<RecipeWrapper> {
 	}
 
 	@Override
-	public boolean matches(RecipeWrapper inv, World p_77569_2_) {
+	public boolean matches(RecipeWrapper inv, World pWorldIn) {
 		return ingredients.get(0).test(inv.getItem(0));
 	}
 

--- a/src/main/java/com/simibubi/create/content/contraptions/processing/HeatCondition.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/processing/HeatCondition.java
@@ -13,7 +13,7 @@ public enum HeatCondition {
 
 	private int color;
 
-	private HeatCondition(int color) {
+	HeatCondition(int color) {
 		this.color = color;
 	}
 

--- a/src/main/java/com/simibubi/create/content/contraptions/processing/burner/BlazeBurnerBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/processing/burner/BlazeBurnerBlock.java
@@ -74,7 +74,7 @@ public class BlazeBurnerBlock extends Block implements ITE<BlazeBurnerTileEntity
 	}
 
 	@Override
-	public void onPlace(BlockState state, World world, BlockPos pos, BlockState p_220082_4_, boolean p_220082_5_) {
+	public void onPlace(BlockState state, World world, BlockPos pos, BlockState pOldState, boolean pIsMoving) {
 		if (world.isClientSide)
 			return;
 		TileEntity tileEntity = world.getBlockEntity(pos.above());
@@ -91,9 +91,9 @@ public class BlazeBurnerBlock extends Block implements ITE<BlazeBurnerTileEntity
 	}
 
 	@Override
-	public void fillItemCategory(ItemGroup p_149666_1_, NonNullList<ItemStack> p_149666_2_) {
-		p_149666_2_.add(AllItems.EMPTY_BLAZE_BURNER.asStack());
-		super.fillItemCategory(p_149666_1_, p_149666_2_);
+	public void fillItemCategory(ItemGroup pGroup, NonNullList<ItemStack> pItems) {
+		pItems.add(AllItems.EMPTY_BLAZE_BURNER.asStack());
+		super.fillItemCategory(pGroup, pItems);
 	}
 
 	@Nullable
@@ -183,11 +183,11 @@ public class BlazeBurnerBlock extends Block implements ITE<BlazeBurnerTileEntity
 	}
 
 	@Override
-	public VoxelShape getCollisionShape(BlockState p_220071_1_, IBlockReader p_220071_2_, BlockPos p_220071_3_,
-		ISelectionContext p_220071_4_) {
-		if (p_220071_4_ == ISelectionContext.empty())
+	public VoxelShape getCollisionShape(BlockState pState, IBlockReader pWorldIn, BlockPos pPos,
+		ISelectionContext pContext) {
+		if (pContext == ISelectionContext.empty())
 			return AllShapes.HEATER_BLOCK_SPECIAL_COLLISION_SHAPE;
-		return getShape(p_220071_1_, p_220071_2_, p_220071_3_, p_220071_4_);
+		return getShape(pState, pWorldIn, pPos, pContext);
 	}
 
 	@Override
@@ -221,12 +221,12 @@ public class BlazeBurnerBlock extends Block implements ITE<BlazeBurnerTileEntity
 	}
 	
 	@Override
-	public boolean hasAnalogOutputSignal(BlockState p_149740_1_) {
+	public boolean hasAnalogOutputSignal(BlockState pState) {
 		return true;
 	}
 	
 	@Override
-	public int getAnalogOutputSignal(BlockState state, World p_180641_2_, BlockPos p_180641_3_) {
+	public int getAnalogOutputSignal(BlockState state, World pWorldIn, BlockPos pPos) {
 		return Math.max(0, state.getValue(HEAT_LEVEL).ordinal() -1);
 	}
 

--- a/src/main/java/com/simibubi/create/content/contraptions/processing/burner/BlazeBurnerBlockItem.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/processing/burner/BlazeBurnerBlockItem.java
@@ -53,10 +53,10 @@ public class BlazeBurnerBlockItem extends BlockItem {
 	}
 
 	@Override
-	public void registerBlocks(Map<Block, Item> p_195946_1_, Item p_195946_2_) {
+	public void registerBlocks(Map<Block, Item> pBlockToItemMap, Item pItemIn) {
 		if (!hasCapturedBlaze())
 			return;
-		super.registerBlocks(p_195946_1_, p_195946_2_);
+		super.registerBlocks(pBlockToItemMap, pItemIn);
 	}
 
 	private BlazeBurnerBlockItem(Block block, Properties properties, boolean capturedBlaze) {
@@ -65,10 +65,10 @@ public class BlazeBurnerBlockItem extends BlockItem {
 	}
 
 	@Override
-	public void fillItemCategory(ItemGroup p_150895_1_, NonNullList<ItemStack> p_150895_2_) {
+	public void fillItemCategory(ItemGroup pGroup, NonNullList<ItemStack> pItems) {
 		if (!hasCapturedBlaze())
 			return;
-		super.fillItemCategory(p_150895_1_, p_150895_2_);
+		super.fillItemCategory(pGroup, pItems);
 	}
 
 	@Override
@@ -91,11 +91,11 @@ public class BlazeBurnerBlockItem extends BlockItem {
 
 		AbstractSpawner spawner = ((MobSpawnerTileEntity) te).getSpawner();
 		List<WeightedSpawnerEntity> possibleSpawns =
-			ObfuscationReflectionHelper.getPrivateValue(AbstractSpawner.class, spawner, "field_98285_e");
+			ObfuscationReflectionHelper.getPrivateValue(AbstractSpawner.class, spawner, "spawnPotentials");
 		if (possibleSpawns.isEmpty()) {
 			possibleSpawns = new ArrayList<>();
 			possibleSpawns
-				.add(ObfuscationReflectionHelper.getPrivateValue(AbstractSpawner.class, spawner, "field_98282_f"));
+				.add(ObfuscationReflectionHelper.getPrivateValue(AbstractSpawner.class, spawner, "nextSpawnData"));
 		}
 
 		ResourceLocation blazeId = EntityType.BLAZE.getRegistryName();

--- a/src/main/java/com/simibubi/create/content/contraptions/processing/burner/BlazeBurnerTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/processing/burner/BlazeBurnerTileEntity.java
@@ -31,7 +31,7 @@ public class BlazeBurnerTileEntity extends SmartTileEntity {
 
 	public static final int maxHeatCapacity = 10000;
 
-	public static enum FuelType {
+	public enum FuelType {
 		NONE, NORMAL, SPECIAL
 	}
 

--- a/src/main/java/com/simibubi/create/content/contraptions/processing/burner/LitBlazeBurnerBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/processing/burner/LitBlazeBurnerBlock.java
@@ -122,12 +122,12 @@ public class LitBlazeBurnerBlock extends Block {
 	}
 
 	@Override
-	public boolean hasAnalogOutputSignal(BlockState p_149740_1_) {
+	public boolean hasAnalogOutputSignal(BlockState pState) {
 		return true;
 	}
 
 	@Override
-	public int getAnalogOutputSignal(BlockState state, World p_180641_2_, BlockPos p_180641_3_) {
+	public int getAnalogOutputSignal(BlockState state, World pWorldIn, BlockPos pPos) {
 		return state.getValue(FLAME_TYPE) == FlameType.REGULAR ? 1 : 2;
 	}
 

--- a/src/main/java/com/simibubi/create/content/contraptions/relays/advanced/GantryShaftBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/relays/advanced/GantryShaftBlock.java
@@ -80,8 +80,8 @@ public class GantryShaftBlock extends DirectionalKineticBlock {
 	}
 
 	@Override
-	public VoxelShape getShape(BlockState state, IBlockReader p_220053_2_, BlockPos p_220053_3_,
-		ISelectionContext p_220053_4_) {
+	public VoxelShape getShape(BlockState state, IBlockReader pWorldIn, BlockPos pPos,
+		ISelectionContext pContext) {
 		return AllShapes.EIGHT_VOXEL_POLE.get(state.getValue(FACING)
 			.getAxis());
 	}
@@ -186,8 +186,8 @@ public class GantryShaftBlock extends DirectionalKineticBlock {
 	}
 
 	@Override
-	public void neighborChanged(BlockState state, World worldIn, BlockPos pos, Block p_220069_4_, BlockPos p_220069_5_,
-		boolean p_220069_6_) {
+	public void neighborChanged(BlockState state, World worldIn, BlockPos pos, Block pBlockIn, BlockPos pFromPos,
+		boolean pIsMoving) {
 		if (worldIn.isClientSide)
 			return;
 		boolean previouslyPowered = state.getValue(POWERED);

--- a/src/main/java/com/simibubi/create/content/contraptions/relays/advanced/SpeedControllerBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/relays/advanced/SpeedControllerBlock.java
@@ -62,8 +62,8 @@ public class SpeedControllerBlock extends HorizontalAxisKineticBlock implements 
 	}
 
 	@Override
-	public void neighborChanged(BlockState state, World world, BlockPos pos, Block p_220069_4_, BlockPos neighbourPos,
-		boolean p_220069_6_) {
+	public void neighborChanged(BlockState state, World world, BlockPos pos, Block pBlockIn, BlockPos neighbourPos,
+		boolean pIsMoving) {
 		if (neighbourPos.equals(pos.above()))
 			withTileEntityDo(world, pos, SpeedControllerTileEntity::updateBracket);
 	}

--- a/src/main/java/com/simibubi/create/content/contraptions/relays/advanced/sequencer/InstructionSpeedModifiers.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/relays/advanced/sequencer/InstructionSpeedModifiers.java
@@ -18,12 +18,12 @@ public enum InstructionSpeedModifiers {
 	int value;
 	ITextComponent label;
 
-	private InstructionSpeedModifiers(int modifier, ITextComponent label) {
+	InstructionSpeedModifiers(int modifier, ITextComponent label) {
 		this.label = label;
 		translationKey = "gui.sequenced_gearshift.speed." + Lang.asId(name());
 		value = modifier;
 	}
-	private InstructionSpeedModifiers(int modifier, String label) {
+	InstructionSpeedModifiers(int modifier, String label) {
 		this.label = new StringTextComponent(label);
 		translationKey = "gui.sequenced_gearshift.speed." + Lang.asId(name());
 		value = modifier;

--- a/src/main/java/com/simibubi/create/content/contraptions/relays/advanced/sequencer/SequencedGearshiftBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/relays/advanced/sequencer/SequencedGearshiftBlock.java
@@ -160,7 +160,7 @@ public class SequencedGearshiftBlock extends HorizontalAxisKineticBlock implemen
 	}
 
 	@Override
-	public boolean hasAnalogOutputSignal(BlockState p_149740_1_) {
+	public boolean hasAnalogOutputSignal(BlockState pState) {
 		return true;
 	}
 

--- a/src/main/java/com/simibubi/create/content/contraptions/relays/advanced/sequencer/SequencerInstructions.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/relays/advanced/sequencer/SequencerInstructions.java
@@ -28,12 +28,12 @@ public enum SequencerInstructions {
 	int shiftStep;
 	int defaultValue;
 
-	private SequencerInstructions(String parameterName, AllGuiTextures background) {
+	SequencerInstructions(String parameterName, AllGuiTextures background) {
 		this(parameterName, background, false, false, -1, -1, -1);
 	}
 
-	private SequencerInstructions(String parameterName, AllGuiTextures background, boolean hasValueParameter,
-			boolean hasSpeedParameter, int maxValue, int shiftStep, int defaultValue) {
+	SequencerInstructions(String parameterName, AllGuiTextures background, boolean hasValueParameter,
+                          boolean hasSpeedParameter, int maxValue, int shiftStep, int defaultValue) {
 		this.hasValueParameter = hasValueParameter;
 		this.hasSpeedParameter = hasSpeedParameter;
 		this.background = background;

--- a/src/main/java/com/simibubi/create/content/contraptions/relays/belt/BeltBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/relays/belt/BeltBlock.java
@@ -92,8 +92,8 @@ public class BeltBlock extends HorizontalKineticBlock implements ITE<BeltTileEnt
 	}
 
 	@Override
-	public void fillItemCategory(ItemGroup p_149666_1_, NonNullList<ItemStack> p_149666_2_) {
-		p_149666_2_.add(AllItems.BELT_CONNECTOR.asStack());
+	public void fillItemCategory(ItemGroup pGroup, NonNullList<ItemStack> pItems) {
+		pItems.add(AllItems.BELT_CONNECTOR.asStack());
 	}
 
 	@Override
@@ -145,7 +145,7 @@ public class BeltBlock extends HorizontalKineticBlock implements ITE<BeltTileEnt
 	}
 
 	@Override
-	public void spawnAfterBreak(BlockState state, ServerWorld worldIn, BlockPos pos, ItemStack p_220062_4_) {
+	public void spawnAfterBreak(BlockState state, ServerWorld worldIn, BlockPos pos, ItemStack pStack) {
 		BeltTileEntity controllerTE = BeltHelper.getControllerTE(worldIn, pos);
 		if (controllerTE != null)
 			controllerTE.getInventory()
@@ -501,8 +501,8 @@ public class BeltBlock extends HorizontalKineticBlock implements ITE<BeltTileEnt
 	}
 
 	@Override
-	public BlockState updateShape(BlockState state, Direction side, BlockState p_196271_3_, IWorld world,
-		BlockPos pos, BlockPos p_196271_6_) {
+	public BlockState updateShape(BlockState state, Direction side, BlockState pFacingState, IWorld world,
+		BlockPos pos, BlockPos pFacingPos) {
 		if (side.getAxis()
 			.isHorizontal())
 			updateTunnelConnections(world, pos.above());

--- a/src/main/java/com/simibubi/create/content/contraptions/relays/belt/BeltTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/relays/belt/BeltTileEntity.java
@@ -78,7 +78,7 @@ public class BeltTileEntity extends KineticTileEntity implements ILightUpdateLis
 	// client
 	public byte[] light;
 
-	public static enum CasingType {
+	public enum CasingType {
 		NONE, ANDESITE, BRASS;
 	}
 

--- a/src/main/java/com/simibubi/create/content/contraptions/relays/belt/item/BeltConnectorItem.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/relays/belt/item/BeltConnectorItem.java
@@ -48,10 +48,10 @@ public class BeltConnectorItem extends BlockItem {
 	}
 
 	@Override
-	public void fillItemCategory(ItemGroup p_150895_1_, NonNullList<ItemStack> p_150895_2_) {
-		if (p_150895_1_ == Create.BASE_CREATIVE_TAB)
+	public void fillItemCategory(ItemGroup pGroup, NonNullList<ItemStack> pItems) {
+		if (pGroup == Create.BASE_CREATIVE_TAB)
 			return;
-		super.fillItemCategory(p_150895_1_, p_150895_2_);
+		super.fillItemCategory(pGroup, pItems);
 	}
 
 	@Nonnull

--- a/src/main/java/com/simibubi/create/content/contraptions/relays/gearbox/GearboxBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/relays/gearbox/GearboxBlock.java
@@ -1,6 +1,7 @@
 package com.simibubi.create.content.contraptions.relays.gearbox;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import com.simibubi.create.AllItems;
@@ -52,9 +53,9 @@ public class GearboxBlock extends RotatedPillarKineticBlock {
 	public List<ItemStack> getDrops(BlockState state, Builder builder) {
 		if (state.getValue(AXIS).isVertical())
 			return super.getDrops(state, builder);
-		return Arrays.asList(new ItemStack(AllItems.VERTICAL_GEARBOX.get()));
+		return Collections.singletonList(new ItemStack(AllItems.VERTICAL_GEARBOX.get()));
 	}
-	
+
 	@Override
 	public ItemStack getPickBlock(BlockState state, RayTraceResult target, IBlockReader world, BlockPos pos,
 			PlayerEntity player) {

--- a/src/main/java/com/simibubi/create/content/contraptions/relays/gearbox/VerticalGearboxItem.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/relays/gearbox/VerticalGearboxItem.java
@@ -29,7 +29,7 @@ public class VerticalGearboxItem extends BlockItem {
 	}
 
 	@Override
-	public void fillItemCategory(ItemGroup p_150895_1_, NonNullList<ItemStack> p_150895_2_) {
+	public void fillItemCategory(ItemGroup pGroup, NonNullList<ItemStack> pItems) {
 	}
 	
 	@Override
@@ -38,7 +38,7 @@ public class VerticalGearboxItem extends BlockItem {
 	}
 
 	@Override
-	public void registerBlocks(Map<Block, Item> p_195946_1_, Item p_195946_2_) {
+	public void registerBlocks(Map<Block, Item> pBlockToItemMap, Item pItemIn) {
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/curiosities/BuildersTeaItem.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/BuildersTeaItem.java
@@ -48,17 +48,17 @@ public class BuildersTeaItem extends Item {
 		return stack;
 	}
 
-	public int getUseDuration(ItemStack p_77626_1_) {
+	public int getUseDuration(ItemStack pStack) {
 		return 42;
 	}
 
-	public UseAction getUseAnimation(ItemStack p_77661_1_) {
+	public UseAction getUseAnimation(ItemStack pStack) {
 		return UseAction.DRINK;
 	}
 
-	public ActionResult<ItemStack> use(World p_77659_1_, PlayerEntity p_77659_2_, Hand p_77659_3_) {
-		p_77659_2_.startUsingItem(p_77659_3_);
-		return ActionResult.success(p_77659_2_.getItemInHand(p_77659_3_));
+	public ActionResult<ItemStack> use(World pWorldIn, PlayerEntity pPlayerIn, Hand pHandIn) {
+		pPlayerIn.startUsingItem(pHandIn);
+		return ActionResult.success(pPlayerIn.getItemInHand(pHandIn));
 	}
 
 }

--- a/src/main/java/com/simibubi/create/content/curiosities/armor/AllArmorMaterials.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/armor/AllArmorMaterials.java
@@ -30,8 +30,8 @@ public enum AllArmorMaterials implements IArmorMaterial {
 	private final float knockbackResistance;
 	private final LazyValue<Ingredient> repairMaterial;
 
-	private AllArmorMaterials(String p_i231593_3_, int p_i231593_4_, int[] p_i231593_5_, int p_i231593_6_,
-		SoundEvent p_i231593_7_, float p_i231593_8_, float p_i231593_9_, Supplier<Ingredient> p_i231593_10_) {
+	AllArmorMaterials(String p_i231593_3_, int p_i231593_4_, int[] p_i231593_5_, int p_i231593_6_,
+					  SoundEvent p_i231593_7_, float p_i231593_8_, float p_i231593_9_, Supplier<Ingredient> p_i231593_10_) {
 		this.name = p_i231593_3_;
 		this.maxDamageFactor = p_i231593_4_;
 		this.damageReductionAmountArray = p_i231593_5_;
@@ -42,12 +42,12 @@ public enum AllArmorMaterials implements IArmorMaterial {
 		this.repairMaterial = new LazyValue<>(p_i231593_10_);
 	}
 
-	public int getDurabilityForSlot(EquipmentSlotType p_200896_1_) {
-		return MAX_DAMAGE_ARRAY[p_200896_1_.getIndex()] * this.maxDamageFactor;
+	public int getDurabilityForSlot(EquipmentSlotType pSlotIn) {
+		return MAX_DAMAGE_ARRAY[pSlotIn.getIndex()] * this.maxDamageFactor;
 	}
 
-	public int getDefenseForSlot(EquipmentSlotType p_200902_1_) {
-		return this.damageReductionAmountArray[p_200902_1_.getIndex()];
+	public int getDefenseForSlot(EquipmentSlotType pSlotIn) {
+		return this.damageReductionAmountArray[pSlotIn.getIndex()];
 	}
 
 	public int getEnchantmentValue() {

--- a/src/main/java/com/simibubi/create/content/curiosities/armor/CopperBacktankArmorLayer.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/armor/CopperBacktankArmorLayer.java
@@ -45,7 +45,7 @@ public class CopperBacktankArmorLayer<T extends LivingEntity, M extends EntityMo
 
 	@Override
 	public void render(MatrixStack ms, IRenderTypeBuffer buffer, int light, LivingEntity entity, float yaw, float pitch,
-		float pt, float p_225628_8_, float p_225628_9_, float p_225628_10_) {
+		float pt, float pAgeInTicks, float pNetHeadYaw, float pHeadPitch) {
 
 		if (entity.getPose() == Pose.SLEEPING)
 			return;

--- a/src/main/java/com/simibubi/create/content/curiosities/armor/CopperBacktankBlock.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/armor/CopperBacktankBlock.java
@@ -67,12 +67,12 @@ public class CopperBacktankBlock extends HorizontalKineticBlock
 	}
 	
 	@Override
-	public boolean hasAnalogOutputSignal(BlockState p_149740_1_) {
+	public boolean hasAnalogOutputSignal(BlockState pState) {
 		return true;
 	}
 	
 	@Override
-	public int getAnalogOutputSignal(BlockState p_180641_1_, World world, BlockPos pos) {
+	public int getAnalogOutputSignal(BlockState pBlockState, World world, BlockPos pos) {
 		return getTileEntityOptional(world, pos).map(CopperBacktankTileEntity::getComparatorOutput)
 			.orElse(0);
 	}
@@ -124,8 +124,8 @@ public class CopperBacktankBlock extends HorizontalKineticBlock
 	}
 
 	@Override
-	public ActionResultType use(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand p_225533_5_,
-		BlockRayTraceResult p_225533_6_) {
+	public ActionResultType use(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand pHandIn,
+		BlockRayTraceResult pHit) {
 		if (player == null)
 			return ActionResultType.PASS;
 		if (player instanceof FakePlayer)
@@ -147,9 +147,9 @@ public class CopperBacktankBlock extends HorizontalKineticBlock
 	}
 
 	@Override
-	public ItemStack getCloneItemStack(IBlockReader p_185473_1_, BlockPos p_185473_2_, BlockState p_185473_3_) {
+	public ItemStack getCloneItemStack(IBlockReader pWorldIn, BlockPos pPos, BlockState pState) {
 		ItemStack item = AllItems.COPPER_BACKTANK.asStack();
-		Optional<CopperBacktankTileEntity> tileEntityOptional = getTileEntityOptional(p_185473_1_, p_185473_2_);
+		Optional<CopperBacktankTileEntity> tileEntityOptional = getTileEntityOptional(pWorldIn, pPos);
 
 		int air = tileEntityOptional.map(CopperBacktankTileEntity::getAirLevel)
 			.orElse(0);
@@ -172,8 +172,8 @@ public class CopperBacktankBlock extends HorizontalKineticBlock
 	}
 
 	@Override
-	public VoxelShape getShape(BlockState p_220053_1_, IBlockReader p_220053_2_, BlockPos p_220053_3_,
-		ISelectionContext p_220053_4_) {
+	public VoxelShape getShape(BlockState pState, IBlockReader pWorldIn, BlockPos pPos,
+		ISelectionContext pContext) {
 		return AllShapes.BACKTANK;
 	}
 

--- a/src/main/java/com/simibubi/create/content/curiosities/armor/CopperBacktankItem.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/armor/CopperBacktankItem.java
@@ -25,8 +25,8 @@ public class CopperBacktankItem extends CopperArmorItem implements ICapacityEnch
 	}
 
 	@Override
-	public ActionResultType useOn(ItemUseContext p_195939_1_) {
-		return blockItem.useOn(p_195939_1_);
+	public ActionResultType useOn(ItemUseContext pContext) {
+		return blockItem.useOn(pContext);
 	}
 
 	@Override
@@ -35,7 +35,7 @@ public class CopperBacktankItem extends CopperArmorItem implements ICapacityEnch
 	}
 	
 	@Override
-	public boolean isEnchantable(ItemStack p_77616_1_) {
+	public boolean isEnchantable(ItemStack pStack) {
 		return true;
 	}
 
@@ -45,15 +45,15 @@ public class CopperBacktankItem extends CopperArmorItem implements ICapacityEnch
 	}
 
 	@Override
-	public void fillItemCategory(ItemGroup p_150895_1_, NonNullList<ItemStack> p_150895_2_) {
-		if (!allowdedIn(p_150895_1_))
+	public void fillItemCategory(ItemGroup pGroup, NonNullList<ItemStack> pItems) {
+		if (!allowdedIn(pGroup))
 			return;
 		
 		ItemStack stack = new ItemStack(this);
 		CompoundNBT nbt = new CompoundNBT();
 		nbt.putInt("Air", BackTankUtil.maxAirWithoutEnchants());
 		stack.setTag(nbt);
-		p_150895_2_.add(stack);
+		pItems.add(stack);
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/curiosities/armor/DivingBootsItem.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/armor/DivingBootsItem.java
@@ -29,7 +29,7 @@ public class DivingBootsItem extends CopperArmorItem {
 			return;
 
 		Vector3d motion = entity.getDeltaMovement();
-		Boolean isJumping = ObfuscationReflectionHelper.getPrivateValue(LivingEntity.class, entity, "field_70703_bu"); // jumping
+		Boolean isJumping = ObfuscationReflectionHelper.getPrivateValue(LivingEntity.class, entity, "jumping"); // jumping
 		entity.onGround |= entity.verticalCollision;
 
 		if (isJumping && entity.onGround) {

--- a/src/main/java/com/simibubi/create/content/curiosities/bell/SoulPulseEffectHandler.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/bell/SoulPulseEffectHandler.java
@@ -42,7 +42,7 @@ public class SoulPulseEffectHandler {
 
 		for (SoulPulseEffect pulse : pulses) {
 			if (pulse.finished() && !pulse.canOverlap())
-				occupied.removeAll(pulse.added);
+				pulse.added.forEach(occupied::remove);
 		}
 		pulses.removeIf(SoulPulseEffect::finished);
 	}

--- a/src/main/java/com/simibubi/create/content/curiosities/symmetry/mirror/CrossPlaneMirror.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/symmetry/mirror/CrossPlaneMirror.java
@@ -19,12 +19,12 @@ import net.minecraft.util.text.ITextComponent;
 
 public class CrossPlaneMirror extends SymmetryMirror {
 
-	public static enum Align implements IStringSerializable {
+	public enum Align implements IStringSerializable {
 		Y("y"), D("d");
 
 		private final String name;
 
-		private Align(String name) {
+		Align(String name) {
 			this.name = name;
 		}
 

--- a/src/main/java/com/simibubi/create/content/curiosities/symmetry/mirror/EmptyMirror.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/symmetry/mirror/EmptyMirror.java
@@ -15,11 +15,11 @@ import net.minecraft.util.text.ITextComponent;
 
 public class EmptyMirror extends SymmetryMirror {
 
-	public static enum Align implements IStringSerializable {
+	public enum Align implements IStringSerializable {
 		None("none");
 
 		private final String name;
-		private Align(String name) { this.name = name; }
+		Align(String name) { this.name = name; }
 		@Override public String getSerializedName() { return name; }
 		@Override public String toString() { return name; }
 	}

--- a/src/main/java/com/simibubi/create/content/curiosities/symmetry/mirror/PlaneMirror.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/symmetry/mirror/PlaneMirror.java
@@ -19,12 +19,12 @@ import net.minecraft.util.text.ITextComponent;
 
 public class PlaneMirror extends SymmetryMirror {
 
-	public static enum Align implements IStringSerializable {
+	public enum Align implements IStringSerializable {
 		XY("xy"), YZ("yz");
 
 		private final String name;
 
-		private Align(String name) {
+		Align(String name) {
 			this.name = name;
 		}
 

--- a/src/main/java/com/simibubi/create/content/curiosities/tools/BlueprintContainer.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/tools/BlueprintContainer.java
@@ -93,17 +93,17 @@ public class BlueprintContainer extends GhostItemContainer<BlueprintSection> {
 	}
 
 	@Override
-	public void setItem(int p_75141_1_, ItemStack p_75141_2_) {
-		if (p_75141_1_ == 36 + 9) {
-			if (p_75141_2_.hasTag()) {
-				contentHolder.inferredIcon = p_75141_2_.getTag()
+	public void setItem(int pSlotID, ItemStack pStack) {
+		if (pSlotID == 36 + 9) {
+			if (pStack.hasTag()) {
+				contentHolder.inferredIcon = pStack.getTag()
 						.getBoolean("InferredFromRecipe");
-				p_75141_2_.getTag()
+				pStack.getTag()
 						.remove("InferredFromRecipe");
 			} else
 				contentHolder.inferredIcon = false;
 		}
-		super.setItem(p_75141_1_, p_75141_2_);
+		super.setItem(pSlotID, pStack);
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/curiosities/tools/BlueprintEntity.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/tools/BlueprintEntity.java
@@ -104,19 +104,19 @@ public class BlueprintEntity extends HangingEntity
 	}
 
 	@Override
-	public void addAdditionalSaveData(CompoundNBT p_213281_1_) {
-		p_213281_1_.putByte("Facing", (byte) this.direction.get3DDataValue());
-		p_213281_1_.putByte("Orientation", (byte) this.verticalOrientation.get3DDataValue());
-		p_213281_1_.putInt("Size", size);
-		super.addAdditionalSaveData(p_213281_1_);
+	public void addAdditionalSaveData(CompoundNBT pCompound) {
+		pCompound.putByte("Facing", (byte) this.direction.get3DDataValue());
+		pCompound.putByte("Orientation", (byte) this.verticalOrientation.get3DDataValue());
+		pCompound.putInt("Size", size);
+		super.addAdditionalSaveData(pCompound);
 	}
 
 	@Override
-	public void readAdditionalSaveData(CompoundNBT p_70037_1_) {
-		this.direction = Direction.from3DDataValue(p_70037_1_.getByte("Facing"));
-		this.verticalOrientation = Direction.from3DDataValue(p_70037_1_.getByte("Orientation"));
-		this.size = p_70037_1_.getInt("Size");
-		super.readAdditionalSaveData(p_70037_1_);
+	public void readAdditionalSaveData(CompoundNBT pCompound) {
+		this.direction = Direction.from3DDataValue(pCompound.getByte("Facing"));
+		this.verticalOrientation = Direction.from3DDataValue(pCompound.getByte("Orientation"));
+		this.size = pCompound.getInt("Size");
+		super.readAdditionalSaveData(pCompound);
 		this.updateFacingWithBoundingBox(this.direction, this.verticalOrientation);
 	}
 
@@ -141,7 +141,7 @@ public class BlueprintEntity extends HangingEntity
 	}
 
 	@Override
-	protected float getEyeHeight(Pose p_213316_1_, EntitySize p_213316_2_) {
+	protected float getEyeHeight(Pose pPoseIn, EntitySize pSizeIn) {
 		return 0;
 	}
 
@@ -277,14 +277,14 @@ public class BlueprintEntity extends HangingEntity
 	}
 
 	@Override
-	public void dropItem(@Nullable Entity p_110128_1_) {
+	public void dropItem(@Nullable Entity pBrokenEntity) {
 		if (!level.getGameRules()
 			.getBoolean(GameRules.RULE_DOENTITYDROPS))
 			return;
 
 		playSound(SoundEvents.PAINTING_BREAK, 1.0F, 1.0F);
-		if (p_110128_1_ instanceof PlayerEntity) {
-			PlayerEntity playerentity = (PlayerEntity) p_110128_1_;
+		if (pBrokenEntity instanceof PlayerEntity) {
+			PlayerEntity playerentity = (PlayerEntity) pBrokenEntity;
 			if (playerentity.abilities.instabuild) {
 				return;
 			}
@@ -309,17 +309,17 @@ public class BlueprintEntity extends HangingEntity
 	}
 
 	@Override
-	public void moveTo(double p_70012_1_, double p_70012_3_, double p_70012_5_, float p_70012_7_,
-		float p_70012_8_) {
-		this.setPos(p_70012_1_, p_70012_3_, p_70012_5_);
+	public void moveTo(double pX, double pY, double pZ, float pYaw,
+		float pPitch) {
+		this.setPos(pX, pY, pZ);
 	}
 
 	@Override
 	@OnlyIn(Dist.CLIENT)
-	public void lerpTo(double p_180426_1_, double p_180426_3_, double p_180426_5_,
-		float p_180426_7_, float p_180426_8_, int p_180426_9_, boolean p_180426_10_) {
+	public void lerpTo(double pX, double pY, double pZ,
+		float pYaw, float pPitch, int pPosRotationIncrements, boolean pTeleport) {
 		BlockPos blockpos =
-			this.pos.offset(p_180426_1_ - this.getX(), p_180426_3_ - this.getY(), p_180426_5_ - this.getZ());
+			this.pos.offset(pX - this.getX(), pY - this.getY(), pZ - this.getZ());
 		this.setPos((double) blockpos.getX(), (double) blockpos.getY(), (double) blockpos.getZ());
 	}
 

--- a/src/main/java/com/simibubi/create/content/curiosities/tools/BlueprintItem.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/tools/BlueprintItem.java
@@ -69,9 +69,9 @@ public class BlueprintItem extends Item {
 		return ActionResultType.sidedSuccess(world.isClientSide);
 	}
 
-	protected boolean canPlace(PlayerEntity p_200127_1_, Direction p_200127_2_, ItemStack p_200127_3_,
-							   BlockPos p_200127_4_) {
-		return p_200127_1_.mayUseItemAt(p_200127_4_, p_200127_2_, p_200127_3_);
+	protected boolean canPlace(PlayerEntity pPlayerIn, Direction pDirectionIn, ItemStack pItemStackIn,
+							   BlockPos pPosIn) {
+		return pPlayerIn.mayUseItemAt(pPosIn, pDirectionIn, pItemStackIn);
 	}
 
 	public static void assignCompleteRecipe(ItemStackHandler inv, IRecipe<?> recipe) {
@@ -95,7 +95,7 @@ public class BlueprintItem extends Item {
 
 	private static ItemStack convertIngredientToFilter(Ingredient ingredient) {
 		Ingredient.IItemList[] acceptedItems =
-				ObfuscationReflectionHelper.getPrivateValue(Ingredient.class, ingredient, "field_199807_b"); // values
+				ObfuscationReflectionHelper.getPrivateValue(Ingredient.class, ingredient, "values"); // values
 		if (acceptedItems == null || acceptedItems.length > 18)
 			return ItemStack.EMPTY;
 		if (acceptedItems.length == 0)

--- a/src/main/java/com/simibubi/create/content/curiosities/tools/BlueprintOverlayRenderer.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/tools/BlueprintOverlayRenderer.java
@@ -268,7 +268,7 @@ public class BlueprintOverlayRenderer {
 					if (!stackInSlot.isEmpty())
 						list.add(stackInSlot);
 				}
-				return list.toArray(new ItemStack[list.size()]);
+				return list.toArray(new ItemStack[0]);
 			}
 
 			if (AllItems.ATTRIBUTE_FILTER.isIn(itemStack)) {

--- a/src/main/java/com/simibubi/create/content/curiosities/tools/BlueprintRenderer.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/tools/BlueprintRenderer.java
@@ -129,7 +129,7 @@ public class BlueprintRenderer extends EntityRenderer<BlueprintEntity> {
 	}
 
 	@Override
-	public ResourceLocation getTextureLocation(BlueprintEntity p_110775_1_) {
+	public ResourceLocation getTextureLocation(BlueprintEntity pEntity) {
 		return null;
 	}
 

--- a/src/main/java/com/simibubi/create/content/curiosities/weapons/PotatoCannonItem.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/weapons/PotatoCannonItem.java
@@ -56,8 +56,8 @@ public class PotatoCannonItem extends ShootableItem {
 	}
 
 	@Override
-	public boolean canAttackBlock(BlockState p_195938_1_, World p_195938_2_, BlockPos p_195938_3_,
-		PlayerEntity p_195938_4_) {
+	public boolean canAttackBlock(BlockState pState, World pWorldIn, BlockPos pPos,
+		PlayerEntity pPlayer) {
 		return false;
 	}
 

--- a/src/main/java/com/simibubi/create/content/curiosities/weapons/PotatoProjectileRenderer.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/weapons/PotatoProjectileRenderer.java
@@ -36,7 +36,7 @@ public class PotatoProjectileRenderer extends EntityRenderer<PotatoProjectileEnt
 	}
 
 	@Override
-	public ResourceLocation getTextureLocation(PotatoProjectileEntity p_110775_1_) {
+	public ResourceLocation getTextureLocation(PotatoProjectileEntity pEntity) {
 		return null;
 	}
 

--- a/src/main/java/com/simibubi/create/content/curiosities/weapons/ProperProjectileEntity.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/weapons/ProperProjectileEntity.java
@@ -20,13 +20,13 @@ public abstract class ProperProjectileEntity extends Entity {
 	}
 
 	@Override
-	protected void readAdditionalSaveData(CompoundNBT p_70037_1_) {
+	protected void readAdditionalSaveData(CompoundNBT pCompound) {
 		// TODO Auto-generated method stub
 		
 	}
 
 	@Override
-	protected void addAdditionalSaveData(CompoundNBT p_213281_1_) {
+	protected void addAdditionalSaveData(CompoundNBT pCompound) {
 		// TODO Auto-generated method stub
 		
 	}

--- a/src/main/java/com/simibubi/create/content/curiosities/zapper/PlacementPatterns.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/zapper/PlacementPatterns.java
@@ -24,7 +24,7 @@ public enum PlacementPatterns {
 	public String translationKey;
 	public AllIcons icon;
 
-	private PlacementPatterns(AllIcons icon) {
+	PlacementPatterns(AllIcons icon) {
 		this.translationKey = Lang.asId(name());
 		this.icon = icon;
 	}
@@ -35,7 +35,7 @@ public enum PlacementPatterns {
 			!tag.contains("Pattern") ? Solid : valueOf(tag.getString("Pattern"));
 		Random r = new Random();
 		Predicate<BlockPos> filter = Predicates.alwaysFalse();
-	
+
 		switch (pattern) {
 		case Chance25:
 			filter = pos -> r.nextBoolean() || r.nextBoolean();
@@ -56,7 +56,7 @@ public enum PlacementPatterns {
 		default:
 			break;
 		}
-	
+
 		blocksIn.removeIf(filter);
 	}
 

--- a/src/main/java/com/simibubi/create/content/curiosities/zapper/terrainzapper/PlacementOptions.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/zapper/terrainzapper/PlacementOptions.java
@@ -12,7 +12,7 @@ public enum PlacementOptions {
 	public String translationKey;
 	public AllIcons icon;
 
-	private PlacementOptions(AllIcons icon) {
+	PlacementOptions(AllIcons icon) {
 		this.translationKey = Lang.asId(name());
 		this.icon = icon;
 	}

--- a/src/main/java/com/simibubi/create/content/curiosities/zapper/terrainzapper/TerrainBrushes.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/zapper/terrainzapper/TerrainBrushes.java
@@ -1,18 +1,18 @@
 package com.simibubi.create.content.curiosities.zapper.terrainzapper;
 
 public enum TerrainBrushes {
-	
+
 	Cuboid(new CuboidBrush()),
 	Sphere(new SphereBrush()),
 	Cylinder(new CylinderBrush()),
 	Surface(new DynamicBrush(true)),
 	Cluster(new DynamicBrush(false)),
-	
+
 	;
-	
+
 	private Brush brush;
 
-	private TerrainBrushes(Brush brush) {
+	TerrainBrushes(Brush brush) {
 		this.brush = brush;
 	}
 

--- a/src/main/java/com/simibubi/create/content/curiosities/zapper/terrainzapper/TerrainTools.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/zapper/terrainzapper/TerrainTools.java
@@ -26,11 +26,11 @@ public enum TerrainTools {
 	Flatten(AllIcons.I_FLATTEN),
 
 	;
-	
+
 	public String translationKey;
 	public AllIcons icon;
 
-	private TerrainTools(AllIcons icon) {
+	TerrainTools(AllIcons icon) {
 		this.translationKey = Lang.asId(name());
 		this.icon = icon;
 	}

--- a/src/main/java/com/simibubi/create/content/logistics/block/belts/tunnel/BeltTunnelBlock.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/belts/tunnel/BeltTunnelBlock.java
@@ -109,7 +109,7 @@ public class BeltTunnelBlock extends Block implements ITE<BeltTunnelTileEntity>,
 	}
 
 	@Override
-	public void onPlace(BlockState state, World world, BlockPos pos, BlockState p_220082_4_, boolean p_220082_5_) {
+	public void onPlace(BlockState state, World world, BlockPos pos, BlockState pOldState, boolean pIsMoving) {
 		if (!(world instanceof WrappedWorld) && !world.isClientSide())
 			withTileEntityDo(world, pos, BeltTunnelTileEntity::updateTunnelConnections);
 	}

--- a/src/main/java/com/simibubi/create/content/logistics/block/belts/tunnel/BeltTunnelItem.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/belts/tunnel/BeltTunnelItem.java
@@ -36,13 +36,13 @@ public class BeltTunnelItem extends BlockItem {
 	}
 
 	@Override
-	protected boolean updateCustomBlockEntityTag(BlockPos pos, World world, PlayerEntity p_195943_3_, ItemStack p_195943_4_,
+	protected boolean updateCustomBlockEntityTag(BlockPos pos, World world, PlayerEntity pPlayer, ItemStack pStack,
 		BlockState state) {
-		boolean flag = super.updateCustomBlockEntityTag(pos, world, p_195943_3_, p_195943_4_, state);
+		boolean flag = super.updateCustomBlockEntityTag(pos, world, pPlayer, pStack, state);
 		if (!world.isClientSide) {
 			BeltTileEntity belt = BeltHelper.getSegmentTE(world, pos.below());
 			if (belt != null) {
-				AllTriggers.triggerFor(AllTriggers.PLACE_TUNNEL, p_195943_3_);
+				AllTriggers.triggerFor(AllTriggers.PLACE_TUNNEL, pPlayer);
 				if (belt.casing == CasingType.NONE)
 					belt.setCasingType(AllBlocks.ANDESITE_TUNNEL.has(state) ? CasingType.ANDESITE : CasingType.BRASS);
 			}

--- a/src/main/java/com/simibubi/create/content/logistics/block/belts/tunnel/BrassTunnelBlock.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/belts/tunnel/BrassTunnelBlock.java
@@ -31,8 +31,8 @@ public class BrassTunnelBlock extends BeltTunnelBlock {
 	}
 
 	@Override
-	public ActionResultType use(BlockState p_225533_1_, World world, BlockPos pos, PlayerEntity player,
-		Hand p_225533_5_, BlockRayTraceResult p_225533_6_) {
+	public ActionResultType use(BlockState pState, World world, BlockPos pos, PlayerEntity player,
+		Hand pHandIn, BlockRayTraceResult pHit) {
 		return onTileEntityUse(world, pos, te -> {
 			if (!(te instanceof BrassTunnelTileEntity))
 				return ActionResultType.PASS;
@@ -62,16 +62,16 @@ public class BrassTunnelBlock extends BeltTunnelBlock {
 	}
 
 	@Override
-	public void onRemove(BlockState p_196243_1_, World p_196243_2_, BlockPos p_196243_3_, BlockState p_196243_4_,
-		boolean p_196243_5_) {
-		if (p_196243_1_.hasTileEntity()
-			&& (p_196243_1_.getBlock() != p_196243_4_.getBlock() || !p_196243_4_.hasTileEntity())) {
-			TileEntityBehaviour.destroy(p_196243_2_, p_196243_3_, FilteringBehaviour.TYPE);
-			withTileEntityDo(p_196243_2_, p_196243_3_, te -> {
+	public void onRemove(BlockState pState, World pWorldIn, BlockPos pPos, BlockState pNewState,
+		boolean pIsMoving) {
+		if (pState.hasTileEntity()
+			&& (pState.getBlock() != pNewState.getBlock() || !pNewState.hasTileEntity())) {
+			TileEntityBehaviour.destroy(pWorldIn, pPos, FilteringBehaviour.TYPE);
+			withTileEntityDo(pWorldIn, pPos, te -> {
 				if (te instanceof BrassTunnelTileEntity)
-					Block.popResource(p_196243_2_, p_196243_3_, ((BrassTunnelTileEntity) te).stackToDistribute);
+					Block.popResource(pWorldIn, pPos, ((BrassTunnelTileEntity) te).stackToDistribute);
 			});
-			p_196243_2_.removeBlockEntity(p_196243_3_);
+			pWorldIn.removeBlockEntity(pPos);
 		}
 	}
 

--- a/src/main/java/com/simibubi/create/content/logistics/block/chute/AbstractChuteBlock.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/chute/AbstractChuteBlock.java
@@ -104,9 +104,9 @@ public abstract class AbstractChuteBlock extends Block implements IWrenchable, I
 	}
 
 	@Override
-	public void onPlace(BlockState state, World world, BlockPos pos, BlockState p_220082_4_, boolean p_220082_5_) {
+	public void onPlace(BlockState state, World world, BlockPos pos, BlockState pOldState, boolean pIsMoving) {
 		withTileEntityDo(world, pos, ChuteTileEntity::onAdded);
-		if (p_220082_5_)
+		if (pIsMoving)
 			return;
 		updateDiagonalNeighbour(state, world, pos);
 	}
@@ -128,14 +128,14 @@ public abstract class AbstractChuteBlock extends Block implements IWrenchable, I
 	}
 
 	@Override
-	public void onRemove(BlockState state, World world, BlockPos pos, BlockState p_196243_4_, boolean p_196243_5_) {
-		boolean differentBlock = state.getBlock() != p_196243_4_.getBlock();
-		if (state.hasTileEntity() && (differentBlock || !p_196243_4_.hasTileEntity())) {
+	public void onRemove(BlockState state, World world, BlockPos pos, BlockState pNewState, boolean pIsMoving) {
+		boolean differentBlock = state.getBlock() != pNewState.getBlock();
+		if (state.hasTileEntity() && (differentBlock || !pNewState.hasTileEntity())) {
 			TileEntityBehaviour.destroy(world, pos, FilteringBehaviour.TYPE);
 			withTileEntityDo(world, pos, c -> c.onRemoved(state));
 			world.removeBlockEntity(pos);
 		}
-		if (p_196243_5_ || !differentBlock)
+		if (pIsMoving || !differentBlock)
 			return;
 
 		updateDiagonalNeighbour(state, world, pos);
@@ -155,15 +155,15 @@ public abstract class AbstractChuteBlock extends Block implements IWrenchable, I
 
 	@Override
 	public BlockState updateShape(BlockState state, Direction direction, BlockState above, IWorld world,
-		BlockPos pos, BlockPos p_196271_6_) {
+		BlockPos pos, BlockPos pFacingPos) {
 		if (direction != Direction.UP)
 			return state;
 		return updateChuteState(state, above, world, pos);
 	}
 
 	@Override
-	public void neighborChanged(BlockState p_220069_1_, World world, BlockPos pos, Block p_220069_4_,
-		BlockPos neighbourPos, boolean p_220069_6_) {
+	public void neighborChanged(BlockState pState, World world, BlockPos pos, Block pBlockIn,
+		BlockPos neighbourPos, boolean pIsMoving) {
 		if (pos.below()
 			.equals(neighbourPos))
 			withTileEntityDo(world, pos, ChuteTileEntity::blockBelowChanged);
@@ -182,15 +182,15 @@ public abstract class AbstractChuteBlock extends Block implements IWrenchable, I
 	}
 
 	@Override
-	public VoxelShape getShape(BlockState p_220053_1_, IBlockReader p_220053_2_, BlockPos p_220053_3_,
-		ISelectionContext p_220053_4_) {
-		return ChuteShapes.getShape(p_220053_1_);
+	public VoxelShape getShape(BlockState pState, IBlockReader pWorldIn, BlockPos pPos,
+		ISelectionContext pContext) {
+		return ChuteShapes.getShape(pState);
 	}
 
 	@Override
-	public VoxelShape getCollisionShape(BlockState p_220071_1_, IBlockReader p_220071_2_, BlockPos p_220071_3_,
-		ISelectionContext p_220071_4_) {
-		return ChuteShapes.getCollisionShape(p_220071_1_);
+	public VoxelShape getCollisionShape(BlockState pState, IBlockReader pWorldIn, BlockPos pPos,
+		ISelectionContext pContext) {
+		return ChuteShapes.getCollisionShape(pState);
 	}
 
 	@Override
@@ -199,8 +199,8 @@ public abstract class AbstractChuteBlock extends Block implements IWrenchable, I
 	}
 
 	@Override
-	public ActionResultType use(BlockState p_225533_1_, World world, BlockPos pos, PlayerEntity player, Hand hand,
-		BlockRayTraceResult p_225533_6_) {
+	public ActionResultType use(BlockState pState, World world, BlockPos pos, PlayerEntity player, Hand hand,
+		BlockRayTraceResult pHit) {
 		if (!player.getItemInHand(hand)
 				.isEmpty())
 			return ActionResultType.PASS;

--- a/src/main/java/com/simibubi/create/content/logistics/block/chute/ChuteBlock.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/chute/ChuteBlock.java
@@ -95,8 +95,8 @@ public class ChuteBlock extends AbstractChuteBlock {
 	}
 
 	@Override
-	protected void createBlockStateDefinition(Builder<Block, BlockState> p_206840_1_) {
-		super.createBlockStateDefinition(p_206840_1_.add(SHAPE, FACING));
+	protected void createBlockStateDefinition(Builder<Block, BlockState> pBuilder) {
+		super.createBlockStateDefinition(pBuilder.add(SHAPE, FACING));
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/logistics/block/chute/SmartChuteBlock.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/chute/SmartChuteBlock.java
@@ -48,9 +48,9 @@ public class SmartChuteBlock extends AbstractChuteBlock {
 	}
 
 	@Override
-	public BlockState getStateForPlacement(BlockItemUseContext p_196258_1_) {
-		return super.getStateForPlacement(p_196258_1_).setValue(POWERED, p_196258_1_.getLevel()
-			.hasNeighborSignal(p_196258_1_.getClickedPos()));
+	public BlockState getStateForPlacement(BlockItemUseContext pContext) {
+		return super.getStateForPlacement(pContext).setValue(POWERED, pContext.getLevel()
+			.hasNeighborSignal(pContext.getClickedPos()));
 	}
 
 	@Override
@@ -64,8 +64,8 @@ public class SmartChuteBlock extends AbstractChuteBlock {
 	}
 
 	@Override
-	protected void createBlockStateDefinition(Builder<Block, BlockState> p_206840_1_) {
-		super.createBlockStateDefinition(p_206840_1_.add(POWERED));
+	protected void createBlockStateDefinition(Builder<Block, BlockState> pBuilder) {
+		super.createBlockStateDefinition(pBuilder.add(POWERED));
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/logistics/block/depot/DepotBlock.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/depot/DepotBlock.java
@@ -34,8 +34,8 @@ public class DepotBlock extends Block implements ITE<DepotTileEntity>, IWrenchab
 	}
 
 	@Override
-	public VoxelShape getShape(BlockState p_220053_1_, IBlockReader p_220053_2_, BlockPos p_220053_3_,
-		ISelectionContext p_220053_4_) {
+	public VoxelShape getShape(BlockState pState, IBlockReader pWorldIn, BlockPos pPos,
+		ISelectionContext pContext) {
 		return AllShapes.DEPOT;
 	}
 

--- a/src/main/java/com/simibubi/create/content/logistics/block/depot/EjectorBlock.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/depot/EjectorBlock.java
@@ -41,8 +41,8 @@ public class EjectorBlock extends HorizontalKineticBlock implements ITE<EjectorT
 	}
 
 	@Override
-	public VoxelShape getShape(BlockState p_220053_1_, IBlockReader p_220053_2_, BlockPos p_220053_3_,
-		ISelectionContext p_220053_4_) {
+	public VoxelShape getShape(BlockState pState, IBlockReader pWorldIn, BlockPos pPos,
+		ISelectionContext pContext) {
 		return AllShapes.DEPOT;
 	}
 
@@ -54,19 +54,19 @@ public class EjectorBlock extends HorizontalKineticBlock implements ITE<EjectorT
 	}
 
 	@Override
-	public void neighborChanged(BlockState state, World world, BlockPos pos, Block p_220069_4_,
-		BlockPos p_220069_5_, boolean p_220069_6_) {
+	public void neighborChanged(BlockState state, World world, BlockPos pos, Block pBlockIn,
+		BlockPos pFromPos, boolean pIsMoving) {
 		withTileEntityDo(world, pos, EjectorTileEntity::updateSignal);
 	}
 	
 	@Override
-	public void fallOn(World p_180658_1_, BlockPos p_180658_2_, Entity p_180658_3_, float p_180658_4_) {
-		Optional<EjectorTileEntity> tileEntityOptional = getTileEntityOptional(p_180658_1_, p_180658_2_);
-		if (tileEntityOptional.isPresent() && !p_180658_3_.isSuppressingBounce()) {
-			p_180658_3_.causeFallDamage(p_180658_4_, 0.0F);
+	public void fallOn(World pWorldIn, BlockPos pPos, Entity pEntityIn, float pFallDistance) {
+		Optional<EjectorTileEntity> tileEntityOptional = getTileEntityOptional(pWorldIn, pPos);
+		if (tileEntityOptional.isPresent() && !pEntityIn.isSuppressingBounce()) {
+			pEntityIn.causeFallDamage(pFallDistance, 0.0F);
 			return;
 		}
-		super.fallOn(p_180658_1_, p_180658_2_, p_180658_3_, p_180658_4_);
+		super.fallOn(pWorldIn, pPos, pEntityIn, pFallDistance);
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/logistics/block/depot/EjectorItem.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/depot/EjectorItem.java
@@ -32,23 +32,23 @@ public class EjectorItem extends BlockItem {
 	}
 
 	@Override
-	protected BlockState getPlacementState(BlockItemUseContext p_195945_1_) {
-		BlockState stateForPlacement = super.getPlacementState(p_195945_1_);
+	protected BlockState getPlacementState(BlockItemUseContext pContext) {
+		BlockState stateForPlacement = super.getPlacementState(pContext);
 		return stateForPlacement;
 	}
 
 	@Override
-	protected boolean updateCustomBlockEntityTag(BlockPos pos, World world, PlayerEntity p_195943_3_, ItemStack p_195943_4_,
-		BlockState p_195943_5_) {
+	protected boolean updateCustomBlockEntityTag(BlockPos pos, World world, PlayerEntity pPlayer, ItemStack pStack,
+		BlockState pState) {
 		if (world.isClientSide)
 			DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> EjectorTargetHandler.flushSettings(pos));
-		return super.updateCustomBlockEntityTag(pos, world, p_195943_3_, p_195943_4_, p_195943_5_);
+		return super.updateCustomBlockEntityTag(pos, world, pPlayer, pStack, pState);
 	}
 
 	@Override
 	public boolean canAttackBlock(BlockState state, World world, BlockPos pos,
-		PlayerEntity p_195938_4_) {
-		return !p_195938_4_.isShiftKeyDown();
+		PlayerEntity pPlayer) {
+		return !pPlayer.isShiftKeyDown();
 	}
 
 }

--- a/src/main/java/com/simibubi/create/content/logistics/block/depot/EjectorRenderer.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/depot/EjectorRenderer.java
@@ -31,7 +31,7 @@ public class EjectorRenderer extends KineticTileEntityRenderer {
 	}
 
 	@Override
-	public boolean shouldRenderOffScreen(KineticTileEntity p_188185_1_) {
+	public boolean shouldRenderOffScreen(KineticTileEntity pTe) {
 		return true;
 	}
 

--- a/src/main/java/com/simibubi/create/content/logistics/block/diodes/AdjustableRepeaterBlock.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/diodes/AdjustableRepeaterBlock.java
@@ -52,7 +52,7 @@ public class AdjustableRepeaterBlock extends AbstractDiodeBlock {
 	}
 
 	@Override
-	protected int getDelay(BlockState p_196346_1_) {
+	protected int getDelay(BlockState pState) {
 		return 0;
 	}
 

--- a/src/main/java/com/simibubi/create/content/logistics/block/funnel/AbstractFunnelBlock.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/funnel/AbstractFunnelBlock.java
@@ -141,12 +141,12 @@ public abstract class AbstractFunnelBlock extends Block implements ITE<FunnelTil
 	protected abstract Direction getFacing(BlockState state);
 
 	@Override
-	public void onRemove(BlockState p_196243_1_, World p_196243_2_, BlockPos p_196243_3_, BlockState p_196243_4_,
-		boolean p_196243_5_) {
-		if (p_196243_1_.hasTileEntity() && (p_196243_1_.getBlock() != p_196243_4_.getBlock() && !isFunnel(p_196243_4_)
-			|| !p_196243_4_.hasTileEntity())) {
-			TileEntityBehaviour.destroy(p_196243_2_, p_196243_3_, FilteringBehaviour.TYPE);
-			p_196243_2_.removeBlockEntity(p_196243_3_);
+	public void onRemove(BlockState pState, World pWorldIn, BlockPos pPos, BlockState pNewState,
+		boolean pIsMoving) {
+		if (pState.hasTileEntity() && (pState.getBlock() != pNewState.getBlock() && !isFunnel(pNewState)
+			|| !pNewState.hasTileEntity())) {
+			TileEntityBehaviour.destroy(pWorldIn, pPos, FilteringBehaviour.TYPE);
+			pWorldIn.removeBlockEntity(pPos);
 		}
 	}
 

--- a/src/main/java/com/simibubi/create/content/logistics/block/funnel/AbstractHorizontalFunnelBlock.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/funnel/AbstractHorizontalFunnelBlock.java
@@ -30,13 +30,13 @@ public abstract class AbstractHorizontalFunnelBlock extends AbstractFunnelBlock 
 	}
 	
 	@Override
-	public BlockState rotate(BlockState p_185499_1_, Rotation p_185499_2_) {
-		return p_185499_1_.setValue(HORIZONTAL_FACING, p_185499_2_.rotate(p_185499_1_.getValue(HORIZONTAL_FACING)));
+	public BlockState rotate(BlockState pState, Rotation pRot) {
+		return pState.setValue(HORIZONTAL_FACING, pRot.rotate(pState.getValue(HORIZONTAL_FACING)));
 	}
 
 	@Override
-	public BlockState mirror(BlockState p_185471_1_, Mirror p_185471_2_) {
-		return p_185471_1_.rotate(p_185471_2_.getRotation(p_185471_1_.getValue(HORIZONTAL_FACING)));
+	public BlockState mirror(BlockState pState, Mirror pMirrorIn) {
+		return pState.rotate(pMirrorIn.getRotation(pState.getValue(HORIZONTAL_FACING)));
 	}
 
 }

--- a/src/main/java/com/simibubi/create/content/logistics/block/funnel/BeltFunnelBlock.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/funnel/BeltFunnelBlock.java
@@ -51,7 +51,7 @@ public class BeltFunnelBlock extends AbstractHorizontalFunnelBlock implements IS
 
 		VoxelShaper shaper;
 
-		private Shape(VoxelShaper shaper) {
+		Shape(VoxelShaper shaper) {
 			this.shaper = shaper;
 		}
 
@@ -68,23 +68,23 @@ public class BeltFunnelBlock extends AbstractHorizontalFunnelBlock implements IS
 	}
 
 	@Override
-	protected void createBlockStateDefinition(Builder<Block, BlockState> p_206840_1_) {
-		super.createBlockStateDefinition(p_206840_1_.add(SHAPE));
+	protected void createBlockStateDefinition(Builder<Block, BlockState> pBuilder) {
+		super.createBlockStateDefinition(pBuilder.add(SHAPE));
 	}
 
 	@Override
-	public VoxelShape getShape(BlockState state, IBlockReader p_220053_2_, BlockPos p_220053_3_,
-		ISelectionContext p_220053_4_) {
+	public VoxelShape getShape(BlockState state, IBlockReader pWorldIn, BlockPos pPos,
+		ISelectionContext pContext) {
 		return state.getValue(SHAPE).shaper.get(state.getValue(HORIZONTAL_FACING));
 	}
 
 	@Override
-	public VoxelShape getCollisionShape(BlockState p_220071_1_, IBlockReader p_220071_2_, BlockPos p_220071_3_,
-		ISelectionContext p_220071_4_) {
-		if (p_220071_4_.getEntity() instanceof ItemEntity
-			&& (p_220071_1_.getValue(SHAPE) == Shape.PULLING || p_220071_1_.getValue(SHAPE) == Shape.PUSHING))
-			return AllShapes.FUNNEL_COLLISION.get(getFacing(p_220071_1_));
-		return getShape(p_220071_1_, p_220071_2_, p_220071_3_, p_220071_4_);
+	public VoxelShape getCollisionShape(BlockState pState, IBlockReader pWorldIn, BlockPos pPos,
+		ISelectionContext pContext) {
+		if (pContext.getEntity() instanceof ItemEntity
+			&& (pState.getValue(SHAPE) == Shape.PULLING || pState.getValue(SHAPE) == Shape.PUSHING))
+			return AllShapes.FUNNEL_COLLISION.get(getFacing(pState));
+		return getShape(pState, pWorldIn, pPos, pContext);
 	}
 
 	@Override
@@ -120,7 +120,7 @@ public class BeltFunnelBlock extends AbstractHorizontalFunnelBlock implements IS
 
 	@Override
 	public BlockState updateShape(BlockState state, Direction direction, BlockState neighbour, IWorld world,
-		BlockPos pos, BlockPos p_196271_6_) {
+		BlockPos pos, BlockPos pFacingPos) {
 		if (!isOnValidBelt(state, world, pos)) {
 			BlockState parentState = parent.getDefaultState();
 			if (state.getOptionalValue(POWERED).orElse(false))

--- a/src/main/java/com/simibubi/create/content/logistics/block/funnel/FunnelBlock.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/funnel/FunnelBlock.java
@@ -145,8 +145,8 @@ public abstract class FunnelBlock extends AbstractDirectionalFunnelBlock {
 	}
 
 	@Override
-	public BlockState updateShape(BlockState state, Direction direction, BlockState p_196271_3_, IWorld world,
-		BlockPos pos, BlockPos p_196271_6_) {
+	public BlockState updateShape(BlockState state, Direction direction, BlockState pFacingState, IWorld world,
+		BlockPos pos, BlockPos pFacingPos) {
 		if (getFacing(state).getAxis()
 			.isVertical() || direction != Direction.DOWN)
 			return state;

--- a/src/main/java/com/simibubi/create/content/logistics/block/funnel/FunnelTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/funnel/FunnelTileEntity.java
@@ -46,7 +46,7 @@ public class FunnelTileEntity extends SmartTileEntity implements IHaveHoveringIn
 
 	InterpolatedChasingValue flap;
 
-	static enum Mode {
+	enum Mode {
 		INVALID, PAUSED, COLLECT, PUSHING_TO_BELT, TAKING_FROM_BELT, EXTRACT
 	}
 

--- a/src/main/java/com/simibubi/create/content/logistics/block/mechanicalArm/ArmBlock.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/mechanicalArm/ArmBlock.java
@@ -41,8 +41,8 @@ public class ArmBlock extends KineticBlock implements ITE<ArmTileEntity>, ICogWh
 	}
 
 	@Override
-	protected void createBlockStateDefinition(Builder<Block, BlockState> p_206840_1_) {
-		super.createBlockStateDefinition(p_206840_1_.add(CEILING));
+	protected void createBlockStateDefinition(Builder<Block, BlockState> pBuilder) {
+		super.createBlockStateDefinition(pBuilder.add(CEILING));
 	}
 
 	@Override
@@ -51,8 +51,8 @@ public class ArmBlock extends KineticBlock implements ITE<ArmTileEntity>, ICogWh
 	}
 
 	@Override
-	public VoxelShape getShape(BlockState state, IBlockReader p_220053_2_, BlockPos p_220053_3_,
-		ISelectionContext p_220053_4_) {
+	public VoxelShape getShape(BlockState state, IBlockReader pWorldIn, BlockPos pPos,
+		ISelectionContext pContext) {
 		return state.getValue(CEILING) ? AllShapes.MECHANICAL_ARM_CEILING : AllShapes.MECHANICAL_ARM;
 	}
 	
@@ -63,8 +63,8 @@ public class ArmBlock extends KineticBlock implements ITE<ArmTileEntity>, ICogWh
 	}
 	
 	@Override
-	public void neighborChanged(BlockState state, World world, BlockPos pos, Block p_220069_4_,
-		BlockPos p_220069_5_, boolean p_220069_6_) {
+	public void neighborChanged(BlockState state, World world, BlockPos pos, Block pBlockIn,
+		BlockPos pFromPos, boolean pIsMoving) {
 		withTileEntityDo(world, pos, ArmTileEntity::redstoneUpdate);
 	}
 
@@ -84,10 +84,10 @@ public class ArmBlock extends KineticBlock implements ITE<ArmTileEntity>, ICogWh
 	}
 
 	@Override
-	public void onRemove(BlockState p_196243_1_, World world, BlockPos pos, BlockState p_196243_4_,
-		boolean p_196243_5_) {
-		if (p_196243_1_.hasTileEntity()
-			&& (p_196243_1_.getBlock() != p_196243_4_.getBlock() || !p_196243_4_.hasTileEntity())) {
+	public void onRemove(BlockState pState, World world, BlockPos pos, BlockState pNewState,
+		boolean pIsMoving) {
+		if (pState.hasTileEntity()
+			&& (pState.getBlock() != pNewState.getBlock() || !pNewState.hasTileEntity())) {
 			withTileEntityDo(world, pos, te -> {
 				if (!te.heldItem.isEmpty())
 					InventoryHelper.dropItemStack(world, pos.getX(), pos.getY(), pos.getZ(), te.heldItem);
@@ -97,8 +97,8 @@ public class ArmBlock extends KineticBlock implements ITE<ArmTileEntity>, ICogWh
 	}
 
 	@Override
-	public ActionResultType use(BlockState p_225533_1_, World world, BlockPos pos, PlayerEntity player,
-		Hand p_225533_5_, BlockRayTraceResult p_225533_6_) {
+	public ActionResultType use(BlockState pState, World world, BlockPos pos, PlayerEntity player,
+		Hand pHandIn, BlockRayTraceResult pHit) {
 		MutableBoolean success = new MutableBoolean(false);
 		withTileEntityDo(world, pos, te -> {
 			if (te.heldItem.isEmpty())

--- a/src/main/java/com/simibubi/create/content/logistics/block/mechanicalArm/ArmItem.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/mechanicalArm/ArmItem.java
@@ -32,16 +32,16 @@ public class ArmItem extends BlockItem {
 	}
 
 	@Override
-	protected boolean updateCustomBlockEntityTag(BlockPos pos, World world, PlayerEntity p_195943_3_, ItemStack p_195943_4_,
-		BlockState p_195943_5_) {
+	protected boolean updateCustomBlockEntityTag(BlockPos pos, World world, PlayerEntity pPlayer, ItemStack pStack,
+		BlockState pState) {
 		if (world.isClientSide)
 			DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> ArmInteractionPointHandler.flushSettings(pos));
-		return super.updateCustomBlockEntityTag(pos, world, p_195943_3_, p_195943_4_, p_195943_5_);
+		return super.updateCustomBlockEntityTag(pos, world, pPlayer, pStack, pState);
 	}
 
 	@Override
 	public boolean canAttackBlock(BlockState state, World world, BlockPos pos,
-		PlayerEntity p_195938_4_) {
+		PlayerEntity pPlayer) {
 		return !ArmInteractionPoint.isInteractable(world, pos, state);
 	}
 

--- a/src/main/java/com/simibubi/create/content/logistics/block/redstone/ContentObserverBlock.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/redstone/ContentObserverBlock.java
@@ -44,8 +44,8 @@ public class ContentObserverBlock extends HorizontalBlock implements ITE<Content
 	}
 
 	@Override
-	public VoxelShape getShape(BlockState state, IBlockReader p_220053_2_, BlockPos p_220053_3_,
-		ISelectionContext p_220053_4_) {
+	public VoxelShape getShape(BlockState state, IBlockReader pWorldIn, BlockPos pPos,
+		ISelectionContext pContext) {
 		return AllShapes.CONTENT_OBSERVER.get(state.getValue(FACING));
 	}
 

--- a/src/main/java/com/simibubi/create/content/logistics/block/redstone/NixieTubeBlock.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/redstone/NixieTubeBlock.java
@@ -122,14 +122,14 @@ public class NixieTubeBlock extends HorizontalBlock
 	}
 
 	@Override
-	public void onRemove(BlockState p_196243_1_, World p_196243_2_, BlockPos p_196243_3_, BlockState p_196243_4_,
-		boolean p_196243_5_) {
-		if (!(p_196243_4_.getBlock() instanceof NixieTubeBlock))
-			p_196243_2_.removeBlockEntity(p_196243_3_);
+	public void onRemove(BlockState pState, World pWorldIn, BlockPos pPos, BlockState pNewState,
+		boolean pIsMoving) {
+		if (!(pNewState.getBlock() instanceof NixieTubeBlock))
+			pWorldIn.removeBlockEntity(pPos);
 	}
 
 	@Override
-	public ItemStack getCloneItemStack(IBlockReader p_185473_1_, BlockPos p_185473_2_, BlockState p_185473_3_) {
+	public ItemStack getCloneItemStack(IBlockReader pWorldIn, BlockPos pPos, BlockState pState) {
 		return AllBlocks.ORANGE_NIXIE_TUBE.asStack();
 	}
 	
@@ -140,8 +140,8 @@ public class NixieTubeBlock extends HorizontalBlock
 	}
 
 	@Override
-	public VoxelShape getShape(BlockState state, IBlockReader p_220053_2_, BlockPos p_220053_3_,
-		ISelectionContext p_220053_4_) {
+	public VoxelShape getShape(BlockState state, IBlockReader pWorldIn, BlockPos pPos,
+		ISelectionContext pContext) {
 		return (state.getValue(CEILING) ? AllShapes.NIXIE_TUBE_CEILING : AllShapes.NIXIE_TUBE)
 			.get(state.getValue(FACING)
 				.getAxis());
@@ -169,8 +169,8 @@ public class NixieTubeBlock extends HorizontalBlock
 	}
 
 	@Override
-	public void neighborChanged(BlockState state, World worldIn, BlockPos pos, Block p_220069_4_, BlockPos p_220069_5_,
-		boolean p_220069_6_) {
+	public void neighborChanged(BlockState state, World worldIn, BlockPos pos, Block pBlockIn, BlockPos pFromPos,
+		boolean pIsMoving) {
 		if (worldIn.isClientSide)
 			return;
 		if (!worldIn.getBlockTicks()

--- a/src/main/java/com/simibubi/create/content/logistics/block/redstone/NixieTubeTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/redstone/NixieTubeTileEntity.java
@@ -193,10 +193,10 @@ public class NixieTubeTileEntity extends SmartTileEntity {
 	}
 
 	// From SignTileEntity
-	public CommandSource getCommandSource(@Nullable ServerPlayerEntity p_195539_1_) {
-		String s = p_195539_1_ == null ? "Nixie Tube" : p_195539_1_.getName().getString();
-		ITextComponent itextcomponent = (ITextComponent)(p_195539_1_ == null ? new StringTextComponent("Nixie Tube") : p_195539_1_.getDisplayName());
-		return new CommandSource(ICommandSource.NULL, Vector3d.atCenterOf(this.worldPosition), Vector2f.ZERO, (ServerWorld)this.level, 2, s, itextcomponent, this.level.getServer(), p_195539_1_);
+	public CommandSource getCommandSource(@Nullable ServerPlayerEntity pPlayerIn) {
+		String s = pPlayerIn == null ? "Nixie Tube" : pPlayerIn.getName().getString();
+		ITextComponent itextcomponent = (ITextComponent)(pPlayerIn == null ? new StringTextComponent("Nixie Tube") : pPlayerIn.getDisplayName());
+		return new CommandSource(ICommandSource.NULL, Vector3d.atCenterOf(this.worldPosition), Vector2f.ZERO, (ServerWorld)this.level, 2, s, itextcomponent, this.level.getServer(), pPlayerIn);
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/logistics/block/redstone/StockpileSwitchBlock.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/redstone/StockpileSwitchBlock.java
@@ -60,8 +60,8 @@ public class StockpileSwitchBlock extends HorizontalBlock implements ITE<Stockpi
 	}
 
 	@Override
-	public VoxelShape getShape(BlockState state, IBlockReader p_220053_2_, BlockPos p_220053_3_,
-		ISelectionContext p_220053_4_) {
+	public VoxelShape getShape(BlockState state, IBlockReader pWorldIn, BlockPos pPos,
+		ISelectionContext pContext) {
 		return AllShapes.STOCKPILE_SWITCH.get(state.getValue(FACING));
 	}
 

--- a/src/main/java/com/simibubi/create/content/logistics/item/LecternControllerBlock.java
+++ b/src/main/java/com/simibubi/create/content/logistics/item/LecternControllerBlock.java
@@ -36,7 +36,7 @@ public class LecternControllerBlock extends LecternBlock implements ITE<LecternC
 
 	@Nullable
 	@Override
-	public TileEntity newBlockEntity(IBlockReader p_196283_1_) {
+	public TileEntity newBlockEntity(IBlockReader pWorldIn) {
 		return null;
 	}
 

--- a/src/main/java/com/simibubi/create/content/logistics/item/filter/AttributeFilterScreen.java
+++ b/src/main/java/com/simibubi/create/content/logistics/item/filter/AttributeFilterScreen.java
@@ -2,6 +2,7 @@ package com.simibubi.create.content.logistics.item.filter;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -91,7 +92,7 @@ public class AttributeFilterScreen extends AbstractFilterScreen<AttributeFilterC
 		attributeSelectorLabel = new Label(x + 43, y + 26, StringTextComponent.EMPTY).colored(0xF3EBDE)
 			.withShadow();
 		attributeSelector = new SelectionScrollInput(x + 39, y + 21, 137, 18);
-		attributeSelector.forOptions(Arrays.asList(StringTextComponent.EMPTY));
+		attributeSelector.forOptions(Collections.singletonList(StringTextComponent.EMPTY));
 		attributeSelector.removeCallback();
 		referenceItemChanged(menu.ghostInventory.getStackInSlot(0));
 

--- a/src/main/java/com/simibubi/create/content/logistics/item/filter/ItemAttribute.java
+++ b/src/main/java/com/simibubi/create/content/logistics/item/filter/ItemAttribute.java
@@ -124,7 +124,7 @@ public interface ItemAttribute {
 			getTranslationParameters());
 	}
 
-	public static enum StandardTraits implements ItemAttribute {
+	public enum StandardTraits implements ItemAttribute {
 
 		DUMMY(s -> false),
 		PLACEABLE(s -> s.getItem() instanceof BlockItem),
@@ -149,7 +149,7 @@ public interface ItemAttribute {
 		private Predicate<ItemStack> test;
 		private BiPredicate<ItemStack, World> testWithWorld;
 
-		private StandardTraits(Predicate<ItemStack> test) {
+		StandardTraits(Predicate<ItemStack> test) {
 			this.test = test;
 		}
 
@@ -167,7 +167,7 @@ public interface ItemAttribute {
 				.anyMatch(e -> e.getKey().getMaxLevel() <= e.getValue());
 		}
 
-		private StandardTraits(BiPredicate<ItemStack, World> test) {
+		StandardTraits(BiPredicate<ItemStack, World> test) {
 			this.testWithWorld = test;
 		}
 
@@ -287,7 +287,7 @@ public interface ItemAttribute {
 		public List<ItemAttribute> listAttributesOf(ItemStack stack) {
 			ItemGroup group = stack.getItem()
 				.getItemCategory();
-			return group == null ? Collections.emptyList() : Arrays.asList(new InItemGroup(group));
+			return group == null ? Collections.emptyList() : Collections.singletonList(new InItemGroup(group));
 		}
 
 		@Override
@@ -337,7 +337,7 @@ public interface ItemAttribute {
 		public List<ItemAttribute> listAttributesOf(ItemStack stack) {
 			String id = stack.getItem()
 				.getCreatorModId(stack);
-			return id == null ? Collections.emptyList() : Arrays.asList(new AddedBy(id));
+			return id == null ? Collections.emptyList() : Collections.singletonList(new AddedBy(id));
 		}
 
 		@Override

--- a/src/main/java/com/simibubi/create/content/palettes/PaletteBlockPartial.java
+++ b/src/main/java/com/simibubi/create/content/palettes/PaletteBlockPartial.java
@@ -1,6 +1,7 @@
 package com.simibubi.create.content.palettes;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.function.Supplier;
 
 import com.simibubi.create.Create;
@@ -106,12 +107,12 @@ public abstract class PaletteBlockPartial<B extends Block> {
 
 		@Override
 		protected Iterable<ITag.INamedTag<Block>> getBlockTags() {
-			return Arrays.asList(BlockTags.STAIRS);
+			return Collections.singletonList(BlockTags.STAIRS);
 		}
 
 		@Override
 		protected Iterable<ITag.INamedTag<Item>> getItemTags() {
-			return Arrays.asList(ItemTags.STAIRS);
+			return Collections.singletonList(ItemTags.STAIRS);
 		}
 
 		@Override
@@ -166,12 +167,12 @@ public abstract class PaletteBlockPartial<B extends Block> {
 
 		@Override
 		protected Iterable<ITag.INamedTag<Block>> getBlockTags() {
-			return Arrays.asList(BlockTags.SLABS);
+			return Collections.singletonList(BlockTags.SLABS);
 		}
 
 		@Override
 		protected Iterable<ITag.INamedTag<Item>> getItemTags() {
-			return Arrays.asList(ItemTags.SLABS);
+			return Collections.singletonList(ItemTags.SLABS);
 		}
 
 		@Override
@@ -219,12 +220,12 @@ public abstract class PaletteBlockPartial<B extends Block> {
 
 		@Override
 		protected Iterable<ITag.INamedTag<Block>> getBlockTags() {
-			return Arrays.asList(BlockTags.WALLS);
+			return Collections.singletonList(BlockTags.WALLS);
 		}
 
 		@Override
 		protected Iterable<ITag.INamedTag<Item>> getItemTags() {
-			return Arrays.asList(ItemTags.WALLS);
+			return Collections.singletonList(ItemTags.WALLS);
 		}
 
 		@Override

--- a/src/main/java/com/simibubi/create/content/palettes/PaletteBlockPattern.java
+++ b/src/main/java/com/simibubi/create/content/palettes/PaletteBlockPattern.java
@@ -300,7 +300,7 @@ public class PaletteBlockPattern {
 
 	// Textures with connectability, used by Spriteshifter
 
-	public static enum CTs {
+	public enum CTs {
 
 		POLISHED(CTType.OMNIDIRECTIONAL), LAYERED(CTType.HORIZONTAL)
 
@@ -308,7 +308,7 @@ public class PaletteBlockPattern {
 
 		public CTType type;
 
-		private CTs(CTType type) {
+		CTs(CTType type) {
 			this.type = type;
 		}
 

--- a/src/main/java/com/simibubi/create/content/palettes/PaletteStoneVariants.java
+++ b/src/main/java/com/simibubi/create/content/palettes/PaletteStoneVariants.java
@@ -22,7 +22,7 @@ public enum PaletteStoneVariants {
 	private Supplier<Supplier<Block>> baseBlock;
 	private Supplier<PalettesVariantEntry> variants;
 
-	private PaletteStoneVariants(Supplier<Supplier<Block>> baseBlock, Supplier<PalettesVariantEntry> variants) {
+	PaletteStoneVariants(Supplier<Supplier<Block>> baseBlock, Supplier<PalettesVariantEntry> variants) {
 		this.baseBlock = baseBlock;
 		this.variants = variants;
 	}

--- a/src/main/java/com/simibubi/create/content/schematics/ClientSchematicLoader.java
+++ b/src/main/java/com/simibubi/create/content/schematics/ClientSchematicLoader.java
@@ -59,7 +59,7 @@ public class ClientSchematicLoader {
 		Path path = Paths.get("schematics", schematic);
 
 		if (!Files.exists(path)) {
-			Create.LOGGER.fatal("Missing Schematic file: " + path.toString());
+			Create.LOGGER.fatal("Missing Schematic file: " + path);
 			return;
 		}
 

--- a/src/main/java/com/simibubi/create/content/schematics/ItemRequirement.java
+++ b/src/main/java/com/simibubi/create/content/schematics/ItemRequirement.java
@@ -2,6 +2,7 @@ package com.simibubi.create.content.schematics;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -59,7 +60,7 @@ public class ItemRequirement {
 	}
 
 	public ItemRequirement(ItemUseType usage, ItemStack items) {
-		this(Arrays.asList(new StackRequirement(usage, items)));
+		this(Collections.singletonList(new StackRequirement(usage, items)));
 	}
 
 	public ItemRequirement(ItemUseType usage, Item item) {
@@ -96,17 +97,17 @@ public class ItemRequirement {
 
 		// double slab needs two items
 		if (state.hasProperty(BlockStateProperties.SLAB_TYPE) && state.getValue(BlockStateProperties.SLAB_TYPE) == SlabType.DOUBLE)
-			return new ItemRequirement(ItemUseType.CONSUME, Arrays.asList(new ItemStack(item, 2)));
+			return new ItemRequirement(ItemUseType.CONSUME, Collections.singletonList(new ItemStack(item, 2)));
 		if (block instanceof TurtleEggBlock)
-			return new ItemRequirement(ItemUseType.CONSUME, Arrays.asList(new ItemStack(item, state.getValue(TurtleEggBlock.EGGS).intValue())));
+			return new ItemRequirement(ItemUseType.CONSUME, Collections.singletonList(new ItemStack(item, state.getValue(TurtleEggBlock.EGGS))));
 		if (block instanceof SeaPickleBlock)
-			return new ItemRequirement(ItemUseType.CONSUME, Arrays.asList(new ItemStack(item, state.getValue(SeaPickleBlock.PICKLES).intValue())));
+			return new ItemRequirement(ItemUseType.CONSUME, Collections.singletonList(new ItemStack(item, state.getValue(SeaPickleBlock.PICKLES))));
 		if (block instanceof SnowBlock)
-			return new ItemRequirement(ItemUseType.CONSUME, Arrays.asList(new ItemStack(item, state.getValue(SnowBlock.LAYERS).intValue())));
+			return new ItemRequirement(ItemUseType.CONSUME, Collections.singletonList(new ItemStack(item, state.getValue(SnowBlock.LAYERS))));
 		if (block instanceof GrassPathBlock)
-			return new ItemRequirement(ItemUseType.CONSUME, Arrays.asList(new ItemStack(Items.GRASS_BLOCK)));
+			return new ItemRequirement(ItemUseType.CONSUME, Collections.singletonList(new ItemStack(Items.GRASS_BLOCK)));
 		if (block instanceof FarmlandBlock)
-			return new ItemRequirement(ItemUseType.CONSUME, Arrays.asList(new ItemStack(Items.DIRT)));
+			return new ItemRequirement(ItemUseType.CONSUME, Collections.singletonList(new ItemStack(Items.DIRT)));
 
 		return item == Items.AIR ? INVALID : new ItemRequirement(ItemUseType.CONSUME, item);
 	}

--- a/src/main/java/com/simibubi/create/content/schematics/SchematicWorld.java
+++ b/src/main/java/com/simibubi/create/content/schematics/SchematicWorld.java
@@ -140,7 +140,7 @@ public class SchematicWorld extends WrappedWorld implements IServerWorld {
 	}
 
 	@Override
-	public int getBrightness(LightType p_226658_1_, BlockPos p_226658_2_) {
+	public int getBrightness(LightType pLightTypeIn, BlockPos pBlockPosIn) {
 		return 10;
 	}
 

--- a/src/main/java/com/simibubi/create/content/schematics/block/SchematicannonRenderer.java
+++ b/src/main/java/com/simibubi/create/content/schematics/block/SchematicannonRenderer.java
@@ -34,7 +34,7 @@ public class SchematicannonRenderer extends SafeTileEntityRenderer<Schematicanno
 	}
 
 	@Override
-	public boolean shouldRenderOffScreen(SchematicannonTileEntity p_188185_1_) {
+	public boolean shouldRenderOffScreen(SchematicannonTileEntity pTe) {
 		return true;
 	}
 

--- a/src/main/java/com/simibubi/create/content/schematics/client/SchematicAndQuillHandler.java
+++ b/src/main/java/com/simibubi/create/content/schematics/client/SchematicAndQuillHandler.java
@@ -126,7 +126,7 @@ public class SchematicAndQuillHandler {
 		firstPos = selectedPos;
 		Lang.sendStatus(player, "schematicAndQuill.firstPos");
 	}
-	
+
 	public void discard() {
 		ClientPlayerEntity player = Minecraft.getInstance().player;
 		firstPos = null;
@@ -239,7 +239,7 @@ public class SchematicAndQuillHandler {
 		if (!convertImmediately)
 			return;
 		if (!Files.exists(path)) {
-			Create.LOGGER.fatal("Missing Schematic file: " + path.toString());
+			Create.LOGGER.fatal("Missing Schematic file: " + path);
 			return;
 		}
 		try {
@@ -248,7 +248,7 @@ public class SchematicAndQuillHandler {
 			AllPackets.channel.sendToServer(new InstantSchematicPacket(filename, origin, bounds));
 
 		} catch (IOException e) {
-			Create.LOGGER.fatal("Error finding Schematic file: " + path.toString());
+			Create.LOGGER.fatal("Error finding Schematic file: " + path);
 			e.printStackTrace();
 			return;
 		}

--- a/src/main/java/com/simibubi/create/content/schematics/client/SchematicRenderer.java
+++ b/src/main/java/com/simibubi/create/content/schematics/client/SchematicRenderer.java
@@ -88,7 +88,6 @@ public class SchematicRenderer {
 		final SchematicWorld blockAccess = schematic;
 		final BlockRendererDispatcher blockRendererDispatcher = minecraft.getBlockRenderer();
 
-		List<BlockState> blockstates = new LinkedList<>();
 		Map<RenderType, BufferBuilder> buffers = new HashMap<>();
 		MatrixStack ms = new MatrixStack();
 
@@ -118,7 +117,6 @@ public class SchematicRenderer {
 						tileEntity != null ? tileEntity.getModelData() : EmptyModelData.INSTANCE)) {
 						usedBlockRenderLayers.add(blockRenderLayer);
 					}
-					blockstates.add(state);
 				}
 
 				ForgeHooksClient.setRenderLayer(null);

--- a/src/main/java/com/simibubi/create/content/schematics/client/tools/Tools.java
+++ b/src/main/java/com/simibubi/create/content/schematics/client/tools/Tools.java
@@ -22,7 +22,7 @@ public enum Tools {
 	private ISchematicTool tool;
 	private AllIcons icon;
 
-	private Tools(ISchematicTool tool, AllIcons icon) {
+	Tools(ISchematicTool tool, AllIcons icon) {
 		this.tool = tool;
 		this.icon = icon;
 	}

--- a/src/main/java/com/simibubi/create/content/schematics/packet/ConfigureSchematicannonPacket.java
+++ b/src/main/java/com/simibubi/create/content/schematics/packet/ConfigureSchematicannonPacket.java
@@ -13,7 +13,7 @@ import net.minecraftforge.fml.network.NetworkEvent.Context;
 
 public class ConfigureSchematicannonPacket extends SimplePacketBase {
 
-	public static enum Option {
+	public enum Option {
 		DONT_REPLACE, REPLACE_SOLID, REPLACE_ANY, REPLACE_EMPTY, SKIP_MISSING, SKIP_TILES, PLAY, PAUSE, STOP;
 	}
 

--- a/src/main/java/com/simibubi/create/foundation/advancement/AllAdvancements.java
+++ b/src/main/java/com/simibubi/create/foundation/advancement/AllAdvancements.java
@@ -363,7 +363,7 @@ public class AllAdvancements implements IDataProvider {
 		Advancement deployer =
 			kinecticAdvancement("deployer", AllBlocks.DEPLOYER.get(), TaskType.MILESTONE).parent(brass_casing)
 				.save(t, id + ":deployer");
-		
+
 		Advancement clockwork_component =
 			itemAdvancement("precision_mechanism", AllItems.PRECISION_MECHANISM, TaskType.NORMAL).parent(deployer)
 				.save(t, id + ":precision_mechanism");
@@ -371,7 +371,7 @@ public class AllAdvancements implements IDataProvider {
 		Advancement clockwork_component_eob = deadEnd().parent(clockwork_component)
 			.addCriterion("0", itemGathered(AllItems.PRECISION_MECHANISM.get()))
 			.save(t, id + ":clockwork_component_eob");
-		
+
 		Advancement extendo_grip =
 			advancement("extendo_grip", AllItems.EXTENDO_GRIP.get(), TaskType.NORMAL).parent(clockwork_component)
 				.addCriterion("0", AllTriggers.EXTENDO.instance())
@@ -491,7 +491,7 @@ public class AllAdvancements implements IDataProvider {
 		return InventoryChangeTrigger.Instance.hasItems(itemprovider);
 	}
 
-	static enum TaskType {
+	enum TaskType {
 
 		NORMAL(FrameType.TASK, true, false, false),
 		MILESTONE(FrameType.TASK, true, true, false),
@@ -507,7 +507,7 @@ public class AllAdvancements implements IDataProvider {
 		private boolean announce;
 		private boolean hide;
 
-		private TaskType(FrameType frame, boolean toast, boolean announce, boolean hide) {
+		TaskType(FrameType frame, boolean toast, boolean announce, boolean hide) {
 			this.frame = frame;
 			this.toast = toast;
 			this.announce = announce;

--- a/src/main/java/com/simibubi/create/foundation/advancement/StringSerializableTrigger.java
+++ b/src/main/java/com/simibubi/create/foundation/advancement/StringSerializableTrigger.java
@@ -91,8 +91,8 @@ public abstract class StringSerializableTrigger<T> extends CriterionTriggerBase<
 		}
 
 		@Override
-		public JsonObject serializeToJson(ConditionArraySerializer p_230240_1_) {
-			JsonObject jsonobject = super.serializeToJson(p_230240_1_);
+		public JsonObject serializeToJson(ConditionArraySerializer pConditions) {
+			JsonObject jsonobject = super.serializeToJson(pConditions);
 			JsonArray elements = new JsonArray();
 
 			if (entries == null) {

--- a/src/main/java/com/simibubi/create/foundation/command/ChunkUtil.java
+++ b/src/main/java/com/simibubi/create/foundation/command/ChunkUtil.java
@@ -35,8 +35,7 @@ public class ChunkUtil {
 				(_0, _1, _2, _3, _4, future, _6, chunk) -> future.apply(chunk), (_0, _1, _2, _3, future, chunk) -> {
 					if (markedChunks.contains(chunk.getPos()
 						.toLong())) {
-						LOGGER.debug("trying to load unforced chunk " + chunk.getPos()
-							.toString() + ", returning chunk loading error");
+						LOGGER.debug("trying to load unforced chunk " + chunk.getPos() + ", returning chunk loading error");
 						// this.reloadChunk(world.getChunkProvider(), chunk.getPos());
 						return ChunkHolder.UNLOADED_CHUNK_FUTURE;
 					} else {
@@ -89,8 +88,7 @@ public class ChunkUtil {
 			.getPos()
 			.toLong())) {
 			LOGGER.info("Interesting Chunk Unload: " + event.getChunk()
-				.getPos()
-				.toString());
+				.getPos());
 		}
 	}
 
@@ -101,7 +99,7 @@ public class ChunkUtil {
 		ChunkPos pos = event.getChunk()
 			.getPos();
 		if (interestingChunks.contains(pos.toLong())) {
-			LOGGER.info("Interesting Chunk Load: " + pos.toString());
+			LOGGER.info("Interesting Chunk Load: " + pos);
 			if (!markedChunks.contains(pos.toLong()))
 				interestingChunks.remove(pos.toLong());
 		}

--- a/src/main/java/com/simibubi/create/foundation/command/ChunkUtilCommand.java
+++ b/src/main/java/com/simibubi/create/foundation/command/ChunkUtilCommand.java
@@ -31,13 +31,13 @@ public class ChunkUtilCommand {
 						if (success) {
 							ctx.getSource()
 									.sendSuccess(new StringTextComponent("scheduled unload for chunk "
-											+ chunkPos.toString() + ", might need to repeat command"), true);
+											+ chunkPos + ", might need to repeat command"), true);
 							return 1;
 						} else {
 							ctx.getSource()
 									.sendSuccess(
 											new StringTextComponent(
-										"unable to schedule unload, is chunk " + chunkPos.toString() + " loaded?"),
+										"unable to schedule unload, is chunk " + chunkPos + " loaded?"),
 									true);
 							return 0;
 						}
@@ -55,19 +55,19 @@ public class ChunkUtilCommand {
 						boolean success = Create.CHUNK_UTIL.unloadChunk(chunkProvider, chunkPos);
 						ctx.getSource()
 								.sendSuccess(
-										new StringTextComponent("added chunk " + chunkPos.toString() + " to unload list"),
+										new StringTextComponent("added chunk " + chunkPos + " to unload list"),
 										true);
 
 						if (success) {
 							ctx.getSource()
 									.sendSuccess(new StringTextComponent("scheduled unload for chunk "
-											+ chunkPos.toString() + ", might need to repeat command"), true);
+											+ chunkPos + ", might need to repeat command"), true);
 							return 1;
 						} else {
 							ctx.getSource()
 								.sendSuccess(
 									new StringTextComponent(
-										"unable to schedule unload, is chunk " + chunkPos.toString() + " loaded?"),
+										"unable to schedule unload, is chunk " + chunkPos + " loaded?"),
 									true);
 							return 0;
 						}

--- a/src/main/java/com/simibubi/create/foundation/command/FlySpeedCommand.java
+++ b/src/main/java/com/simibubi/create/foundation/command/FlySpeedCommand.java
@@ -36,7 +36,7 @@ public class FlySpeedCommand {
 	private static int sendFlySpeedUpdate(CommandContext<CommandSource> ctx, ServerPlayerEntity player, float speed) {
 		SPlayerAbilitiesPacket packet = new SPlayerAbilitiesPacket(player.abilities);
 		// packet.setFlySpeed(speed);
-		ObfuscationReflectionHelper.setPrivateValue(SPlayerAbilitiesPacket.class, packet, speed, "field_149116_e"); // flyingSpeed
+		ObfuscationReflectionHelper.setPrivateValue(SPlayerAbilitiesPacket.class, packet, speed, "flyingSpeed"); // flyingSpeed
 		player.connection.send(packet);
 
 		ctx.getSource()

--- a/src/main/java/com/simibubi/create/foundation/config/ui/ConfigScreenList.java
+++ b/src/main/java/com/simibubi/create/foundation/config/ui/ConfigScreenList.java
@@ -49,11 +49,11 @@ public class ConfigScreenList extends ExtendedList<ConfigScreenList.Entry> {
 	}
 
 	@Override
-	protected void renderList(MatrixStack p_238478_1_, int p_238478_2_, int p_238478_3_, int p_238478_4_, int p_238478_5_, float p_238478_6_) {
+	protected void renderList(MatrixStack pMatrixStack, int pX, int pY, int pMouseX, int pMouseY, float pPartialTicks) {
 		MainWindow window = Minecraft.getInstance().getWindow();
 		double d0 = window.getGuiScale();
 		RenderSystem.enableScissor((int) (this.x0 * d0), (int) (window.getHeight() - (this.y1 * d0)), (int) (this.width * d0), (int) (this.height * d0));
-		super.renderList(p_238478_1_, p_238478_2_, p_238478_3_, p_238478_4_, p_238478_5_, p_238478_6_);
+		super.renderList(pMatrixStack, pX, pY, pMouseX, pMouseY, pPartialTicks);
 		RenderSystem.disableScissor();
 	}
 
@@ -134,7 +134,7 @@ public class ConfigScreenList extends ExtendedList<ConfigScreenList.Entry> {
 		}
 
 		@Override
-		public void render(MatrixStack ms, int index, int y, int x, int width, int height, int mouseX, int mouseY, boolean p_230432_9_, float partialTicks) {
+		public void render(MatrixStack ms, int index, int y, int x, int width, int height, int mouseX, int mouseY, boolean pIsMouseOver, float partialTicks) {
 			UIRenderHelper.streak(ms, 0, x - 10, y + height / 2, height - 6, width / 8 * 7, 0xdd_000000);
 			UIRenderHelper.streak(ms, 180, x + (int) (width * 1.35f) + 10, y + height / 2, height - 6, width / 8 * 7, 0xdd_000000);
 			IFormattableTextComponent component = label.getComponent();

--- a/src/main/java/com/simibubi/create/foundation/config/ui/entries/BooleanEntry.java
+++ b/src/main/java/com/simibubi/create/foundation/config/ui/entries/BooleanEntry.java
@@ -47,8 +47,8 @@ public class BooleanEntry extends ValueEntry<Boolean> {
 
 	@Override
 	public void render(MatrixStack ms, int index, int y, int x, int width, int height, int mouseX, int mouseY,
-		boolean p_230432_9_, float partialTicks) {
-		super.render(ms, index, y, x, width, height, mouseX, mouseY, p_230432_9_, partialTicks);
+		boolean pIsMouseOver, float partialTicks) {
+		super.render(ms, index, y, x, width, height, mouseX, mouseY, pIsMouseOver, partialTicks);
 
 		button.x = x + width - 80 - resetWidth;
 		button.y = y + 10;

--- a/src/main/java/com/simibubi/create/foundation/config/ui/entries/EnumEntry.java
+++ b/src/main/java/com/simibubi/create/foundation/config/ui/entries/EnumEntry.java
@@ -77,8 +77,8 @@ public class EnumEntry extends ValueEntry<Enum<?>> {
 
 	@Override
 	public void render(MatrixStack ms, int index, int y, int x, int width, int height, int mouseX, int mouseY,
-		boolean p_230432_9_, float partialTicks) {
-		super.render(ms, index, y, x, width, height, mouseX, mouseY, p_230432_9_, partialTicks);
+		boolean pIsMouseOver, float partialTicks) {
+		super.render(ms, index, y, x, width, height, mouseX, mouseY, pIsMouseOver, partialTicks);
 
 		cycleLeft.x = x + getLabelWidth(width) + 4;
 		cycleLeft.y = y + 10;

--- a/src/main/java/com/simibubi/create/foundation/config/ui/entries/NumberEntry.java
+++ b/src/main/java/com/simibubi/create/foundation/config/ui/entries/NumberEntry.java
@@ -121,8 +121,8 @@ public abstract class NumberEntry<T extends Number> extends ValueEntry<T> {
 	}
 
 	@Override
-	public void render(MatrixStack ms, int index, int y, int x, int width, int height, int mouseX, int mouseY, boolean p_230432_9_, float partialTicks) {
-		super.render(ms, index, y, x, width, height, mouseX, mouseY, p_230432_9_, partialTicks);
+	public void render(MatrixStack ms, int index, int y, int x, int width, int height, int mouseX, int mouseY, boolean pIsMouseOver, float partialTicks) {
+		super.render(ms, index, y, x, width, height, mouseX, mouseY, pIsMouseOver, partialTicks);
 
 		textField.x = x + width - 82 - resetWidth;
 		textField.y = y + 8;

--- a/src/main/java/com/simibubi/create/foundation/config/ui/entries/SubMenuEntry.java
+++ b/src/main/java/com/simibubi/create/foundation/config/ui/entries/SubMenuEntry.java
@@ -33,8 +33,8 @@ public class SubMenuEntry extends ConfigScreenList.LabeledEntry {
 	}
 
 	@Override
-	public void render(MatrixStack ms, int index, int y, int x, int width, int height, int mouseX, int mouseY, boolean p_230432_9_, float partialTicks) {
-		super.render(ms, index, y, x, width, height, mouseX, mouseY, p_230432_9_, partialTicks);
+	public void render(MatrixStack ms, int index, int y, int x, int width, int height, int mouseX, int mouseY, boolean pIsMouseOver, float partialTicks) {
+		super.render(ms, index, y, x, width, height, mouseX, mouseY, pIsMouseOver, partialTicks);
 
 		button.x = x + width - 108;
 		button.y = y + 10;

--- a/src/main/java/com/simibubi/create/foundation/config/ui/entries/ValueEntry.java
+++ b/src/main/java/com/simibubi/create/foundation/config/ui/entries/ValueEntry.java
@@ -102,15 +102,15 @@ public class ValueEntry<T> extends ConfigScreenList.LabeledEntry {
 	}
 
 	@Override
-	public void render(MatrixStack ms, int index, int y, int x, int width, int height, int mouseX, int mouseY, boolean p_230432_9_, float partialTicks) {
+	public void render(MatrixStack ms, int index, int y, int x, int width, int height, int mouseX, int mouseY, boolean pIsMouseOver, float partialTicks) {
 		if (isCurrentValueChanged()) {
 			IFormattableTextComponent original = label.getComponent();
 			IFormattableTextComponent changed = modComponent.plainCopy().append(original);
 			label.withText(changed);
-			super.render(ms, index, y, x, width, height, mouseX, mouseY, p_230432_9_, partialTicks);
+			super.render(ms, index, y, x, width, height, mouseX, mouseY, pIsMouseOver, partialTicks);
 			label.withText(original);
 		} else {
-			super.render(ms, index, y, x, width, height, mouseX, mouseY, p_230432_9_, partialTicks);
+			super.render(ms, index, y, x, width, height, mouseX, mouseY, pIsMouseOver, partialTicks);
 		}
 
 		resetButton.x = x + width - resetWidth + 6;

--- a/src/main/java/com/simibubi/create/foundation/data/AllLangPartials.java
+++ b/src/main/java/com/simibubi/create/foundation/data/AllLangPartials.java
@@ -21,12 +21,12 @@ public enum AllLangPartials {
 	private String display;
 	private Supplier<JsonElement> provider;
 
-	private AllLangPartials(String display) {
+	AllLangPartials(String display) {
 		this.display = display;
 		this.provider = this::fromResource;
 	}
 
-	private AllLangPartials(String display, Supplier<JsonElement> customProvider) {
+	AllLangPartials(String display, Supplier<JsonElement> customProvider) {
 		this.display = display;
 		this.provider = customProvider;
 	}

--- a/src/main/java/com/simibubi/create/foundation/data/LangMerger.java
+++ b/src/main/java/com/simibubi/create/foundation/data/LangMerger.java
@@ -60,7 +60,7 @@ public class LangMerger implements IDataProvider {
 	private void populateLangIgnore() {
 		// Key prefixes added here will NOT be transferred to lang templates
 		langIgnore.add("create.ponder.debug_"); // Ponder debug scene text
-		langIgnore.add("create.gui.chromatic_projector"); 
+		langIgnore.add("create.gui.chromatic_projector");
 	}
 
 	private boolean shouldIgnore(String key) {
@@ -251,7 +251,7 @@ public class LangMerger implements IDataProvider {
 		StringBuilder builder = new StringBuilder();
 		builder.append("{\n");
 		if (missingKeys != -1)
-			builder.append("\t\"_\": \"Missing Localizations: " + missingKeys + "\",\n");
+			builder.append("\t\"_\": \"Missing Localizations: ").append(missingKeys).append("\",\n");
 		data.forEach(builder::append);
 		builder.append("\t\"_\": \"Thank you for translating Create!\"\n\n");
 		builder.append("}");

--- a/src/main/java/com/simibubi/create/foundation/data/NamedTag.java
+++ b/src/main/java/com/simibubi/create/foundation/data/NamedTag.java
@@ -27,10 +27,10 @@ public class NamedTag<T> implements ITag.INamedTag<T> {
 	}
 
 	@Override
-	public boolean contains(T p_230235_1_) {
+	public boolean contains(T pElement) {
 		if (tag == null)
 			return false;
-		return tag.contains(p_230235_1_);
+		return tag.contains(pElement);
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/foundation/data/WindowGen.java
+++ b/src/main/java/com/simibubi/create/foundation/data/WindowGen.java
@@ -50,12 +50,12 @@ public class WindowGen {
 			.isViewBlocking(WindowGen::never);
 	}
 
-	private static boolean never(BlockState p_235436_0_, IBlockReader p_235436_1_, BlockPos p_235436_2_) {
+	private static boolean never(BlockState pState, IBlockReader pReader, BlockPos pPos) {
 		return false;
 	}
 
-	private static Boolean never(BlockState p_235427_0_, IBlockReader p_235427_1_, BlockPos p_235427_2_,
-		EntityType<?> p_235427_3_) {
+	private static Boolean never(BlockState pState, IBlockReader pReader, BlockPos pPos,
+		EntityType<?> pEntity) {
 		return false;
 	}
 

--- a/src/main/java/com/simibubi/create/foundation/data/recipe/CreateRecipeProvider.java
+++ b/src/main/java/com/simibubi/create/foundation/data/recipe/CreateRecipeProvider.java
@@ -27,8 +27,8 @@ public abstract class CreateRecipeProvider extends RecipeProvider {
 	}
 
 	@Override
-	protected void buildShapelessRecipes(Consumer<IFinishedRecipe> p_200404_1_) {
-		all.forEach(c -> c.register(p_200404_1_));
+	protected void buildShapelessRecipes(Consumer<IFinishedRecipe> pConsumer2) {
+		all.forEach(c -> c.register(pConsumer2));
 		Create.LOGGER.info(getName() + " registered " + all.size() + " recipe" + (all.size() == 1 ? "" : "s"));
 	}
 

--- a/src/main/java/com/simibubi/create/foundation/data/recipe/MechanicalCraftingRecipeBuilder.java
+++ b/src/main/java/com/simibubi/create/foundation/data/recipe/MechanicalCraftingRecipeBuilder.java
@@ -39,41 +39,41 @@ public class MechanicalCraftingRecipeBuilder {
 	/**
 	 * Creates a new builder for a shaped recipe.
 	 */
-	public static MechanicalCraftingRecipeBuilder shapedRecipe(IItemProvider p_200470_0_) {
-		return shapedRecipe(p_200470_0_, 1);
+	public static MechanicalCraftingRecipeBuilder shapedRecipe(IItemProvider pResultIn) {
+		return shapedRecipe(pResultIn, 1);
 	}
 
 	/**
 	 * Creates a new builder for a shaped recipe.
 	 */
-	public static MechanicalCraftingRecipeBuilder shapedRecipe(IItemProvider p_200468_0_, int p_200468_1_) {
-		return new MechanicalCraftingRecipeBuilder(p_200468_0_, p_200468_1_);
+	public static MechanicalCraftingRecipeBuilder shapedRecipe(IItemProvider pResultIn, int pCountIn) {
+		return new MechanicalCraftingRecipeBuilder(pResultIn, pCountIn);
 	}
 
 	/**
 	 * Adds a key to the recipe pattern.
 	 */
-	public MechanicalCraftingRecipeBuilder key(Character p_200469_1_, Tag<Item> p_200469_2_) {
-		return this.key(p_200469_1_, Ingredient.of(p_200469_2_));
+	public MechanicalCraftingRecipeBuilder key(Character pSymbol, Tag<Item> pTagIn) {
+		return this.key(pSymbol, Ingredient.of(pTagIn));
 	}
 
 	/**
 	 * Adds a key to the recipe pattern.
 	 */
-	public MechanicalCraftingRecipeBuilder key(Character p_200462_1_, IItemProvider p_200462_2_) {
-		return this.key(p_200462_1_, Ingredient.of(p_200462_2_));
+	public MechanicalCraftingRecipeBuilder key(Character pSymbol, IItemProvider pItemIn) {
+		return this.key(pSymbol, Ingredient.of(pItemIn));
 	}
 
 	/**
 	 * Adds a key to the recipe pattern.
 	 */
-	public MechanicalCraftingRecipeBuilder key(Character p_200471_1_, Ingredient p_200471_2_) {
-		if (this.key.containsKey(p_200471_1_)) {
-			throw new IllegalArgumentException("Symbol '" + p_200471_1_ + "' is already defined!");
-		} else if (p_200471_1_ == ' ') {
+	public MechanicalCraftingRecipeBuilder key(Character pSymbol, Ingredient pIngredientIn) {
+		if (this.key.containsKey(pSymbol)) {
+			throw new IllegalArgumentException("Symbol '" + pSymbol + "' is already defined!");
+		} else if (pSymbol == ' ') {
 			throw new IllegalArgumentException("Symbol ' ' (whitespace) is reserved and cannot be defined");
 		} else {
-			this.key.put(p_200471_1_, p_200471_2_);
+			this.key.put(pSymbol, pIngredientIn);
 			return this;
 		}
 	}
@@ -81,12 +81,12 @@ public class MechanicalCraftingRecipeBuilder {
 	/**
 	 * Adds a new entry to the patterns for this recipe.
 	 */
-	public MechanicalCraftingRecipeBuilder patternLine(String p_200472_1_) {
-		if (!this.pattern.isEmpty() && p_200472_1_.length() != this.pattern.get(0)
+	public MechanicalCraftingRecipeBuilder patternLine(String pPatternIn) {
+		if (!this.pattern.isEmpty() && pPatternIn.length() != this.pattern.get(0)
 			.length()) {
 			throw new IllegalArgumentException("Pattern must be the same width on every line!");
 		} else {
-			this.pattern.add(p_200472_1_);
+			this.pattern.add(pPatternIn);
 			return this;
 		}
 	}
@@ -94,37 +94,37 @@ public class MechanicalCraftingRecipeBuilder {
 	/**
 	 * Builds this recipe into an {@link IFinishedRecipe}.
 	 */
-	public void build(Consumer<IFinishedRecipe> p_200464_1_) {
-		this.build(p_200464_1_, ForgeRegistries.ITEMS.getKey(this.result));
+	public void build(Consumer<IFinishedRecipe> pConsumerIn) {
+		this.build(pConsumerIn, ForgeRegistries.ITEMS.getKey(this.result));
 	}
 
 	/**
 	 * Builds this recipe into an {@link IFinishedRecipe}. Use
 	 * {@link #build(Consumer)} if save is the same as the ID for the result.
 	 */
-	public void build(Consumer<IFinishedRecipe> p_200466_1_, String p_200466_2_) {
+	public void build(Consumer<IFinishedRecipe> pConsumerIn, String pSave) {
 		ResourceLocation resourcelocation = ForgeRegistries.ITEMS.getKey(this.result);
-		if ((new ResourceLocation(p_200466_2_)).equals(resourcelocation)) {
-			throw new IllegalStateException("Shaped Recipe " + p_200466_2_ + " should remove its 'save' argument");
+		if ((new ResourceLocation(pSave)).equals(resourcelocation)) {
+			throw new IllegalStateException("Shaped Recipe " + pSave + " should remove its 'save' argument");
 		} else {
-			this.build(p_200466_1_, new ResourceLocation(p_200466_2_));
+			this.build(pConsumerIn, new ResourceLocation(pSave));
 		}
 	}
 
 	/**
 	 * Builds this recipe into an {@link IFinishedRecipe}.
 	 */
-	public void build(Consumer<IFinishedRecipe> p_200467_1_, ResourceLocation p_200467_2_) {
-		validate(p_200467_2_);
-		p_200467_1_.accept(new MechanicalCraftingRecipeBuilder.Result(p_200467_2_, result, count, pattern, key));
+	public void build(Consumer<IFinishedRecipe> pConsumerIn, ResourceLocation pId) {
+		validate(pId);
+		pConsumerIn.accept(new MechanicalCraftingRecipeBuilder.Result(pId, result, count, pattern, key));
 	}
 
 	/**
 	 * Makes sure that this recipe is valid.
 	 */
-	private void validate(ResourceLocation p_200463_1_) {
+	private void validate(ResourceLocation pId) {
 		if (pattern.isEmpty()) {
-			throw new IllegalStateException("No pattern is defined for shaped recipe " + p_200463_1_ + "!");
+			throw new IllegalStateException("No pattern is defined for shaped recipe " + pId + "!");
 		} else {
 			Set<Character> set = Sets.newHashSet(key.keySet());
 			set.remove(' ');
@@ -134,14 +134,14 @@ public class MechanicalCraftingRecipeBuilder {
 					char c0 = s.charAt(i);
 					if (!key.containsKey(c0) && c0 != ' ')
 						throw new IllegalStateException(
-							"Pattern in recipe " + p_200463_1_ + " uses undefined symbol '" + c0 + "'");
+							"Pattern in recipe " + pId + " uses undefined symbol '" + c0 + "'");
 					set.remove(c0);
 				}
 			}
 
 			if (!set.isEmpty())
 				throw new IllegalStateException(
-					"Ingredients are defined but not used in pattern for recipe " + p_200463_1_);
+					"Ingredients are defined but not used in pattern for recipe " + pId);
 		}
 	}
 
@@ -161,25 +161,25 @@ public class MechanicalCraftingRecipeBuilder {
 			this.key = p_i48271_7_;
 		}
 
-		public void serializeRecipeData(JsonObject p_218610_1_) {
+		public void serializeRecipeData(JsonObject pJson) {
 			JsonArray jsonarray = new JsonArray();
 			for (String s : this.pattern)
 				jsonarray.add(s);
 
-			p_218610_1_.add("pattern", jsonarray);
+			pJson.add("pattern", jsonarray);
 			JsonObject jsonobject = new JsonObject();
 			for (Entry<Character, Ingredient> entry : this.key.entrySet())
 				jsonobject.add(String.valueOf(entry.getKey()), entry.getValue()
 					.toJson());
 
-			p_218610_1_.add("key", jsonobject);
+			pJson.add("key", jsonobject);
 			JsonObject jsonobject1 = new JsonObject();
 			jsonobject1.addProperty("item", ForgeRegistries.ITEMS.getKey(this.result)
 				.toString());
 			if (this.count > 1)
 				jsonobject1.addProperty("count", this.count);
 
-			p_218610_1_.add("result", jsonobject1);
+			pJson.add("result", jsonobject1);
 		}
 
 		public IRecipeSerializer<?> getType() {

--- a/src/main/java/com/simibubi/create/foundation/data/recipe/Mods.java
+++ b/src/main/java/com/simibubi/create/foundation/data/recipe/Mods.java
@@ -4,10 +4,10 @@ import net.minecraft.util.ResourceLocation;
 
 public enum Mods {
 
-	MEK("mekanism", true), 
-	TH("thermal", false), 
-	MW("mysticalworld", false), 
-	SM("silents_mechanisms", false), 
+	MEK("mekanism", true),
+	TH("thermal", false),
+	MW("mysticalworld", false),
+	SM("silents_mechanisms", false),
 	IE("immersiveengineering", true),
 	EID("eidolon", false),
 	INF("iceandfire", false)
@@ -17,20 +17,20 @@ public enum Mods {
 	private String id;
 	private boolean reversedPrefix;
 
-	private Mods(String id, boolean reversedPrefix) {
+	Mods(String id, boolean reversedPrefix) {
 		this.id = id;
 		this.reversedPrefix = reversedPrefix;}
 
 	public ResourceLocation ingotOf(String type) {
 		return new ResourceLocation(id, reversedPrefix ? "ingot_" + type : type + "_ingot");
 	}
-	
+
 	public ResourceLocation nuggetOf(String type) {
 		return new ResourceLocation(id, reversedPrefix ? "nugget_" + type : type + "_nugget");
 	}
-	
+
 	public String getId() {
 		return id;
 	}
-	
+
 }

--- a/src/main/java/com/simibubi/create/foundation/fluid/FluidHelper.java
+++ b/src/main/java/com/simibubi/create/foundation/fluid/FluidHelper.java
@@ -35,7 +35,7 @@ import net.minecraftforge.registries.ForgeRegistries;
 
 public class FluidHelper {
 
-	public static enum FluidExchange {
+	public enum FluidExchange {
 		ITEM_TO_TANK, TANK_TO_ITEM;
 	}
 

--- a/src/main/java/com/simibubi/create/foundation/gui/AbstractSimiContainerScreen.java
+++ b/src/main/java/com/simibubi/create/foundation/gui/AbstractSimiContainerScreen.java
@@ -61,7 +61,7 @@ public abstract class AbstractSimiContainerScreen<T extends Container> extends C
 	}
 
 	@Override
-	protected void renderLabels(MatrixStack p_230451_1_, int p_230451_2_, int p_230451_3_) {
+	protected void renderLabels(MatrixStack pMatrixStack, int pX, int pY) {
 		// no-op to prevent screen- and inventory-title from being rendered at incorrect location
 		// could also set this.titleX/Y and this.playerInventoryTitleX/Y to the proper values instead
 	}
@@ -146,7 +146,7 @@ public abstract class AbstractSimiContainerScreen<T extends Container> extends C
 	protected abstract void renderWindow(MatrixStack ms, int mouseX, int mouseY, float partialTicks);
 
 	@Override
-	protected void renderBg(MatrixStack p_230450_1_, float p_230450_2_, int p_230450_3_, int p_230450_4_) {
+	protected void renderBg(MatrixStack pMatrixStack, float pPartialTicks, int pX, int pY) {
 	}
 
 	protected void renderWindowForeground(MatrixStack matrixStack, int mouseX, int mouseY, float partialTicks) {

--- a/src/main/java/com/simibubi/create/foundation/gui/AllGuiTextures.java
+++ b/src/main/java/com/simibubi/create/foundation/gui/AllGuiTextures.java
@@ -112,15 +112,15 @@ public enum AllGuiTextures implements IScreenRenderable {
 	public int width, height;
 	public int startX, startY;
 
-	private AllGuiTextures(String location, int width, int height) {
+	AllGuiTextures(String location, int width, int height) {
 		this(location, 0, 0, width, height);
 	}
 
-	private AllGuiTextures(int startX, int startY) {
+	AllGuiTextures(int startX, int startY) {
 		this("icons.png", startX * 16, startY * 16, 16, 16);
 	}
 
-	private AllGuiTextures(String location, int startX, int startY, int width, int height) {
+	AllGuiTextures(String location, int startX, int startY, int width, int height) {
 		this.location = new ResourceLocation(Create.ID, "textures/gui/" + location);
 		this.width = width;
 		this.height = height;

--- a/src/main/java/com/simibubi/create/foundation/item/HiddenIngredientItem.java
+++ b/src/main/java/com/simibubi/create/foundation/item/HiddenIngredientItem.java
@@ -14,10 +14,10 @@ public class HiddenIngredientItem extends Item {
 	}
 
 	@Override
-	public void fillItemCategory(ItemGroup p_150895_1_, NonNullList<ItemStack> p_150895_2_) {
-		if (p_150895_1_ != ItemGroup.TAB_SEARCH)
+	public void fillItemCategory(ItemGroup pGroup, NonNullList<ItemStack> pItems) {
+		if (pGroup != ItemGroup.TAB_SEARCH)
 			return;
-		super.fillItemCategory(p_150895_1_, p_150895_2_);
+		super.fillItemCategory(pGroup, pItems);
 	}
 
 }

--- a/src/main/java/com/simibubi/create/foundation/item/ItemDescription.java
+++ b/src/main/java/com/simibubi/create/foundation/item/ItemDescription.java
@@ -64,7 +64,7 @@ public class ItemDescription {
 
 		;
 
-		private Palette(TextFormatting primary, TextFormatting highlight) {
+		Palette(TextFormatting primary, TextFormatting highlight) {
 			color = primary;
 			hColor = highlight;
 		}

--- a/src/main/java/com/simibubi/create/foundation/item/ItemHelper.java
+++ b/src/main/java/com/simibubi/create/foundation/item/ItemHelper.java
@@ -129,7 +129,7 @@ public class ItemHelper {
 		return false;
 	}
 
-	public static enum ExtractionCountMode {
+	public enum ExtractionCountMode {
 		EXACTLY, UPTO
 	}
 

--- a/src/main/java/com/simibubi/create/foundation/item/TagDependentIngredientItem.java
+++ b/src/main/java/com/simibubi/create/foundation/item/TagDependentIngredientItem.java
@@ -20,9 +20,9 @@ public class TagDependentIngredientItem extends Item {
 	}
 
 	@Override
-	public void fillItemCategory(ItemGroup p_150895_1_, NonNullList<ItemStack> p_150895_2_) {
+	public void fillItemCategory(ItemGroup pGroup, NonNullList<ItemStack> pItems) {
 		if (!shouldHide())
-			super.fillItemCategory(p_150895_1_, p_150895_2_);
+			super.fillItemCategory(pGroup, pItems);
 	}
 
 	public boolean shouldHide() {

--- a/src/main/java/com/simibubi/create/foundation/item/render/PartialItemModelRenderer.java
+++ b/src/main/java/com/simibubi/create/foundation/item/render/PartialItemModelRenderer.java
@@ -79,7 +79,7 @@ public class PartialItemModelRenderer {
 		ms.popPose();
 	}
 
-	private void renderBakedItemModel(IBakedModel model, int light, MatrixStack ms, IVertexBuilder p_229114_6_) {
+	private void renderBakedItemModel(IBakedModel model, int light, MatrixStack ms, IVertexBuilder pBufferIn) {
 		ItemRenderer ir = Minecraft.getInstance()
 			.getItemRenderer();
 		Random random = new Random();
@@ -87,12 +87,12 @@ public class PartialItemModelRenderer {
 
 		for (Direction direction : Iterate.directions) {
 			random.setSeed(42L);
-			ir.renderQuadList(ms, p_229114_6_, model.getQuads(null, direction, random, data), stack, light,
+			ir.renderQuadList(ms, pBufferIn, model.getQuads(null, direction, random, data), stack, light,
 				overlay);
 		}
 
 		random.setSeed(42L);
-		ir.renderQuadList(ms, p_229114_6_, model.getQuads(null, null, random, data), stack, light, overlay);
+		ir.renderQuadList(ms, pBufferIn, model.getQuads(null, null, random, data), stack, light, overlay);
 	}
 
 }

--- a/src/main/java/com/simibubi/create/foundation/mixin/EntityContraptionInteractionMixin.java
+++ b/src/main/java/com/simibubi/create/foundation/mixin/EntityContraptionInteractionMixin.java
@@ -53,7 +53,7 @@ public abstract class EntityContraptionInteractionMixin extends CapabilityProvid
 	protected abstract float nextStep();
 
 	@Shadow
-	protected abstract void playStepSound(BlockPos p_180429_1_, BlockState p_180429_2_);
+	protected abstract void playStepSound(BlockPos pPos, BlockState pBlockIn);
 
 	private Set<AbstractContraptionEntity> getIntersectingContraptions() {
 		Set<AbstractContraptionEntity> contraptions = ContraptionHandler.loadedContraptions.get(self.level)

--- a/src/main/java/com/simibubi/create/foundation/ponder/PonderWorld.java
+++ b/src/main/java/com/simibubi/create/foundation/ponder/PonderWorld.java
@@ -136,7 +136,7 @@ public class PonderWorld extends SchematicWorld {
 	}
 
 	@Override
-	public int getBrightness(LightType p_226658_1_, BlockPos p_226658_2_) {
+	public int getBrightness(LightType pLightTypeIn, BlockPos pBlockPosIn) {
 		return overrideLight == -1 ? 15 : overrideLight;
 	}
 
@@ -156,7 +156,7 @@ public class PonderWorld extends SchematicWorld {
 	}
 
 	@Override // For particle collision
-	public IBlockReader getChunkForCollisions(int p_225522_1_, int p_225522_2_) {
+	public IBlockReader getChunkForCollisions(int pChunkX, int pChunkZ) {
 		return this;
 	}
 
@@ -350,7 +350,7 @@ public class PonderWorld extends SchematicWorld {
 	}
 
 	@Override
-	public boolean hasNearbyAlivePlayer(double p_217358_1_, double p_217358_3_, double p_217358_5_, double p_217358_7_) {
+	public boolean hasNearbyAlivePlayer(double pX, double pY, double pZ, double pDistance) {
 		return true; // always enable spawner animations
 	}
 }

--- a/src/main/java/com/simibubi/create/foundation/ponder/PonderWorldParticles.java
+++ b/src/main/java/com/simibubi/create/foundation/ponder/PonderWorldParticles.java
@@ -46,11 +46,11 @@ public class PonderWorldParticles {
 				.add(particle);
 	}
 
-	private void tickParticleList(Collection<Particle> p_187240_1_) {
-		if (p_187240_1_.isEmpty())
+	private void tickParticleList(Collection<Particle> pParticlesIn) {
+		if (pParticlesIn.isEmpty())
 			return;
 
-		Iterator<Particle> iterator = p_187240_1_.iterator();
+		Iterator<Particle> iterator = pParticlesIn.iterator();
 		while (iterator.hasNext()) {
 			Particle particle = iterator.next();
 			particle.tick();

--- a/src/main/java/com/simibubi/create/foundation/ponder/content/PonderPalette.java
+++ b/src/main/java/com/simibubi/create/foundation/ponder/content/PonderPalette.java
@@ -4,23 +4,23 @@ public enum PonderPalette {
 
 	WHITE(0xFF_eeeeee),
 	BLACK(0xFF_221111),
-	
+
 	RED(0xFF_ff5d6c),
 	GREEN(0xFF_8cba51),
 	BLUE(0xFF_5f6caf),
-	
+
 	SLOW(0xFF_22ff22),
 	MEDIUM(0xFF_0084ff),
 	FAST(0xFF_ff55ff),
-	
+
 	INPUT(0xFF_4f8a8b),
 	OUTPUT(0xFF_ffcb74),
-	
+
 	;
 
 	private int color;
 
-	private PonderPalette(int color) {
+	PonderPalette(int color) {
 		this.color = color;
 	}
 

--- a/src/main/java/com/simibubi/create/foundation/ponder/elements/ParrotElement.java
+++ b/src/main/java/com/simibubi/create/foundation/ponder/elements/ParrotElement.java
@@ -209,11 +209,11 @@ public class ParrotElement extends AnimatedSceneElement {
 
 		@Override
 		void tick(PonderScene scene, ParrotEntity entity, Vector3d location) {
-			Vector3d p_200602_2_ = getFacedVec(scene);
+			Vector3d pTarget = getFacedVec(scene);
 			Vector3d Vector3d = location.add(entity.getEyePosition(0));
-			double d0 = p_200602_2_.x - Vector3d.x;
-			double d1 = p_200602_2_.y - Vector3d.y;
-			double d2 = p_200602_2_.z - Vector3d.z;
+			double d0 = pTarget.x - Vector3d.x;
+			double d1 = pTarget.y - Vector3d.y;
+			double d2 = pTarget.z - Vector3d.z;
 			double d3 = (double) MathHelper.sqrt(d0 * d0 + d2 * d2);
 			float targetPitch =
 				MathHelper.wrapDegrees((float) -(MathHelper.atan2(d1, d3) * (double) (180F / (float) Math.PI)));

--- a/src/main/java/com/simibubi/create/foundation/render/ShadowRenderHelper.java
+++ b/src/main/java/com/simibubi/create/foundation/render/ShadowRenderHelper.java
@@ -25,9 +25,9 @@ public class ShadowRenderHelper {
 	private static final RenderType SHADOW_LAYER =
 		RenderType.entityNoOutline(new ResourceLocation("textures/misc/shadow.png"));
 
-	public static void renderShadow(MatrixStack p_229096_0_, IRenderTypeBuffer p_229096_1_, Vector3d pos,
-		float p_229096_3_, float p_229096_6_) {
-		float f = p_229096_6_;
+	public static void renderShadow(MatrixStack pMatrixStackIn, IRenderTypeBuffer pBufferIn, Vector3d pos,
+		float pWeightIn, float pSizeIn) {
+		float f = pSizeIn;
 
 		double d2 = pos.x();
 		double d0 = pos.y();
@@ -38,52 +38,52 @@ public class ShadowRenderHelper {
 		int l = MathHelper.floor(d0);
 		int i1 = MathHelper.floor(d1 - (double) f);
 		int j1 = MathHelper.floor(d1 + (double) f);
-		MatrixStack.Entry matrixstack$entry = p_229096_0_.last();
-		IVertexBuilder ivertexbuilder = p_229096_1_.getBuffer(SHADOW_LAYER);
+		MatrixStack.Entry matrixstack$entry = pMatrixStackIn.last();
+		IVertexBuilder ivertexbuilder = pBufferIn.getBuffer(SHADOW_LAYER);
 
 		for (BlockPos blockpos : BlockPos.betweenClosed(new BlockPos(i, k, i1), new BlockPos(j, l, j1))) {
 			renderShadowPart(matrixstack$entry, ivertexbuilder, Minecraft.getInstance().level, blockpos, d2, d0, d1, f,
-				p_229096_3_);
+				pWeightIn);
 		}
 
 	}
 
-	private static void renderShadowPart(MatrixStack.Entry p_229092_0_, IVertexBuilder p_229092_1_,
-		IWorldReader p_229092_2_, BlockPos p_229092_3_, double p_229092_4_, double p_229092_6_, double p_229092_8_,
-		float p_229092_10_, float p_229092_11_) {
-		BlockPos blockpos = p_229092_3_.below();
-		BlockState blockstate = p_229092_2_.getBlockState(blockpos);
-		if (blockstate.getRenderShape() != BlockRenderType.INVISIBLE && p_229092_2_.getMaxLocalRawBrightness(p_229092_3_) > 3) {
-			if (blockstate.isCollisionShapeFullBlock(p_229092_2_, blockpos)) {
-				VoxelShape voxelshape = blockstate.getShape(p_229092_2_, p_229092_3_.below());
+	private static void renderShadowPart(MatrixStack.Entry pMatrixEntryIn, IVertexBuilder pBufferIn,
+		IWorldReader pWorldIn, BlockPos pBlockPosIn, double pXIn, double pYIn, double pZIn,
+		float pSizeIn, float pWeightIn) {
+		BlockPos blockpos = pBlockPosIn.below();
+		BlockState blockstate = pWorldIn.getBlockState(blockpos);
+		if (blockstate.getRenderShape() != BlockRenderType.INVISIBLE && pWorldIn.getMaxLocalRawBrightness(pBlockPosIn) > 3) {
+			if (blockstate.isCollisionShapeFullBlock(pWorldIn, blockpos)) {
+				VoxelShape voxelshape = blockstate.getShape(pWorldIn, pBlockPosIn.below());
 				if (!voxelshape.isEmpty()) {
 					@SuppressWarnings("deprecation")
-					float f = (float) (((double) p_229092_11_ - (p_229092_6_ - (double) p_229092_3_.getY()) / 2.0D)
-						* 0.5D * (double) p_229092_2_.getBrightness(p_229092_3_));
+					float f = (float) (((double) pWeightIn - (pYIn - (double) pBlockPosIn.getY()) / 2.0D)
+						* 0.5D * (double) pWorldIn.getBrightness(pBlockPosIn));
 					if (f >= 0.0F) {
 						if (f > 1.0F) {
 							f = 1.0F;
 						}
 
 						AxisAlignedBB axisalignedbb = voxelshape.bounds();
-						double d0 = (double) p_229092_3_.getX() + axisalignedbb.minX;
-						double d1 = (double) p_229092_3_.getX() + axisalignedbb.maxX;
-						double d2 = (double) p_229092_3_.getY() + axisalignedbb.minY;
-						double d3 = (double) p_229092_3_.getZ() + axisalignedbb.minZ;
-						double d4 = (double) p_229092_3_.getZ() + axisalignedbb.maxZ;
-						float f1 = (float) (d0 - p_229092_4_);
-						float f2 = (float) (d1 - p_229092_4_);
-						float f3 = (float) (d2 - p_229092_6_ + 0.015625D);
-						float f4 = (float) (d3 - p_229092_8_);
-						float f5 = (float) (d4 - p_229092_8_);
-						float f6 = -f1 / 2.0F / p_229092_10_ + 0.5F;
-						float f7 = -f2 / 2.0F / p_229092_10_ + 0.5F;
-						float f8 = -f4 / 2.0F / p_229092_10_ + 0.5F;
-						float f9 = -f5 / 2.0F / p_229092_10_ + 0.5F;
-						shadowVertex(p_229092_0_, p_229092_1_, f, f1, f3, f4, f6, f8);
-						shadowVertex(p_229092_0_, p_229092_1_, f, f1, f3, f5, f6, f9);
-						shadowVertex(p_229092_0_, p_229092_1_, f, f2, f3, f5, f7, f9);
-						shadowVertex(p_229092_0_, p_229092_1_, f, f2, f3, f4, f7, f8);
+						double d0 = (double) pBlockPosIn.getX() + axisalignedbb.minX;
+						double d1 = (double) pBlockPosIn.getX() + axisalignedbb.maxX;
+						double d2 = (double) pBlockPosIn.getY() + axisalignedbb.minY;
+						double d3 = (double) pBlockPosIn.getZ() + axisalignedbb.minZ;
+						double d4 = (double) pBlockPosIn.getZ() + axisalignedbb.maxZ;
+						float f1 = (float) (d0 - pXIn);
+						float f2 = (float) (d1 - pXIn);
+						float f3 = (float) (d2 - pYIn + 0.015625D);
+						float f4 = (float) (d3 - pZIn);
+						float f5 = (float) (d4 - pZIn);
+						float f6 = -f1 / 2.0F / pSizeIn + 0.5F;
+						float f7 = -f2 / 2.0F / pSizeIn + 0.5F;
+						float f8 = -f4 / 2.0F / pSizeIn + 0.5F;
+						float f9 = -f5 / 2.0F / pSizeIn + 0.5F;
+						shadowVertex(pMatrixEntryIn, pBufferIn, f, f1, f3, f4, f6, f8);
+						shadowVertex(pMatrixEntryIn, pBufferIn, f, f1, f3, f5, f6, f9);
+						shadowVertex(pMatrixEntryIn, pBufferIn, f, f2, f3, f5, f7, f9);
+						shadowVertex(pMatrixEntryIn, pBufferIn, f, f2, f3, f4, f7, f8);
 					}
 
 				}
@@ -91,14 +91,14 @@ public class ShadowRenderHelper {
 		}
 	}
 
-	private static void shadowVertex(MatrixStack.Entry p_229091_0_, IVertexBuilder p_229091_1_, float p_229091_2_,
-		float p_229091_3_, float p_229091_4_, float p_229091_5_, float p_229091_6_, float p_229091_7_) {
-		p_229091_1_.vertex(p_229091_0_.pose(), p_229091_3_, p_229091_4_, p_229091_5_)
-			.color(1.0F, 1.0F, 1.0F, p_229091_2_)
-			.uv(p_229091_6_, p_229091_7_)
+	private static void shadowVertex(MatrixStack.Entry pMatrixEntryIn, IVertexBuilder pBufferIn, float pAlphaIn,
+		float pXIn, float pYIn, float pZIn, float pTexU, float pTexV) {
+		pBufferIn.vertex(pMatrixEntryIn.pose(), pXIn, pYIn, pZIn)
+			.color(1.0F, 1.0F, 1.0F, pAlphaIn)
+			.uv(pTexU, pTexV)
 			.overlayCoords(OverlayTexture.NO_OVERLAY)
 			.uv2(15728880)
-			.normal(p_229091_0_.normal(), 0.0F, 1.0F, 0.0F)
+			.normal(pMatrixEntryIn.normal(), 0.0F, 1.0F, 0.0F)
 			.endVertex();
 	}
 }

--- a/src/main/java/com/simibubi/create/foundation/sound/SoundScapes.java
+++ b/src/main/java/com/simibubi/create/foundation/sound/SoundScapes.java
@@ -37,7 +37,7 @@ public class SoundScapes {
 
 		private BiFunction<Float, AmbienceGroup, SoundScape> factory;
 
-		private AmbienceGroup(BiFunction<Float, AmbienceGroup, SoundScape> factory) {
+		AmbienceGroup(BiFunction<Float, AmbienceGroup, SoundScape> factory) {
 			this.factory = factory;
 		}
 
@@ -60,7 +60,7 @@ public class SoundScapes {
 			.repeating(AllSoundEvents.CRUSHING_2.getMainEvent(), 0.425f, .75f, 2)
 			.repeating(AllSoundEvents.CRUSHING_3.getMainEvent(), 2f, 1.75f, 2);
 	}
-	
+
 	private static SoundScape milling(float pitch, AmbienceGroup group) {
 		return new SoundScape(pitch, group).repeating(AllSoundEvents.CRUSHING_1.getMainEvent(), 1.545f, .75f, 1)
 			.repeating(AllSoundEvents.CRUSHING_2.getMainEvent(), 0.425f, .75f, 2);

--- a/src/main/java/com/simibubi/create/foundation/tileEntity/behaviour/belt/BeltProcessingBehaviour.java
+++ b/src/main/java/com/simibubi/create/foundation/tileEntity/behaviour/belt/BeltProcessingBehaviour.java
@@ -19,7 +19,7 @@ public class BeltProcessingBehaviour extends TileEntityBehaviour {
 
 	public static BehaviourType<BeltProcessingBehaviour> TYPE = new BehaviourType<>();
 
-	public static enum ProcessingResult {
+	public enum ProcessingResult {
 		PASS, HOLD, REMOVE;
 	}
 

--- a/src/main/java/com/simibubi/create/foundation/utility/EmptyNamedTag.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/EmptyNamedTag.java
@@ -29,7 +29,7 @@ public class EmptyNamedTag<T> implements Tags.IOptionalNamedTag<T> {
 	}
 
 	@Override
-	public boolean contains(Object p_230235_1_) {
+	public boolean contains(Object pElement) {
 		return false;
 	}
 

--- a/src/main/java/com/simibubi/create/foundation/utility/FontHelper.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/FontHelper.java
@@ -70,14 +70,14 @@ public final class FontHelper {
 		}
 	}
 
-	private static int draw(FontRenderer font, String p_228078_1_, float p_228078_2_, float p_228078_3_,
-		int p_228078_4_, Matrix4f p_228078_5_, boolean p_228078_6_) {
-		if (p_228078_1_ == null) {
+	private static int draw(FontRenderer font, String pText, float pX, float pY,
+		int pColor, Matrix4f pMatrix, boolean pDropShadow) {
+		if (pText == null) {
 			return 0;
 		} else {
 			IRenderTypeBuffer.Impl irendertypebuffer$impl = IRenderTypeBuffer.immediate(Tessellator.getInstance()
 				.getBuilder());
-			int i = font.drawInBatch(p_228078_1_, p_228078_2_, p_228078_3_, p_228078_4_, p_228078_6_, p_228078_5_,
+			int i = font.drawInBatch(pText, pX, pY, pColor, pDropShadow, pMatrix,
 				irendertypebuffer$impl, false, 0, 15728880);
 			irendertypebuffer$impl.endBatch();
 			return i;

--- a/src/main/java/com/simibubi/create/foundation/utility/Pointing.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/Pointing.java
@@ -10,7 +10,7 @@ public enum Pointing implements IStringSerializable {
 
 	private int xRotation;
 
-	private Pointing(int xRotation) {
+	Pointing(int xRotation) {
 		this.xRotation = xRotation;
 	}
 

--- a/src/main/java/com/simibubi/create/foundation/utility/ghost/GhostBlockRenderer.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/ghost/GhostBlockRenderer.java
@@ -114,57 +114,57 @@ public abstract class GhostBlockRenderer {
 
 		// BlockModelRenderer
 		public void renderModel(GhostBlockParams params, MatrixStack.Entry entry, IVertexBuilder vb,
-			@Nullable BlockState state, IBakedModel model, float p_228804_5_, float p_228804_6_, float p_228804_7_,
-			int p_228804_8_, int p_228804_9_, net.minecraftforge.client.model.data.IModelData modelData) {
+			@Nullable BlockState state, IBakedModel model, float pRed, float pGreen, float pBlue,
+			int pCombinedLightIn, int pCombinedOverlayIn, net.minecraftforge.client.model.data.IModelData modelData) {
 			Random random = new Random();
 
 			for (Direction direction : Direction.values()) {
 				random.setSeed(42L);
-				renderQuad(params, entry, vb, p_228804_5_, p_228804_6_, p_228804_7_,
-					model.getQuads(state, direction, random, modelData), p_228804_8_, p_228804_9_);
+				renderQuad(params, entry, vb, pRed, pGreen, pBlue,
+					model.getQuads(state, direction, random, modelData), pCombinedLightIn, pCombinedOverlayIn);
 			}
 
 			random.setSeed(42L);
-			renderQuad(params, entry, vb, p_228804_5_, p_228804_6_, p_228804_7_,
-				model.getQuads(state, (Direction) null, random, modelData), p_228804_8_, p_228804_9_);
+			renderQuad(params, entry, vb, pRed, pGreen, pBlue,
+				model.getQuads(state, (Direction) null, random, modelData), pCombinedLightIn, pCombinedOverlayIn);
 		}
 
 		// BlockModelRenderer
-		private static void renderQuad(GhostBlockParams params, MatrixStack.Entry p_228803_0_,
-			IVertexBuilder p_228803_1_, float p_228803_2_, float p_228803_3_, float p_228803_4_,
-			List<BakedQuad> p_228803_5_, int p_228803_6_, int p_228803_7_) {
-			Float alpha = params.alphaSupplier.get() * .75f * PlacementHelpers.getCurrentAlpha();
+		private static void renderQuad(GhostBlockParams params, MatrixStack.Entry pMatrixEntry,
+			IVertexBuilder pBuffer, float pRed, float pGreen, float pBlue,
+			List<BakedQuad> pListQuads, int pCombinedLightIn, int pCombinedOverlayIn) {
+			float alpha = params.alphaSupplier.get() * .75f * PlacementHelpers.getCurrentAlpha();
 
-			for (BakedQuad bakedquad : p_228803_5_) {
+			for (BakedQuad bakedquad : pListQuads) {
 				float f;
 				float f1;
 				float f2;
 				if (bakedquad.isTinted()) {
-					f = MathHelper.clamp(p_228803_2_, 0.0F, 1.0F);
-					f1 = MathHelper.clamp(p_228803_3_, 0.0F, 1.0F);
-					f2 = MathHelper.clamp(p_228803_4_, 0.0F, 1.0F);
+					f = MathHelper.clamp(pRed, 0.0F, 1.0F);
+					f1 = MathHelper.clamp(pGreen, 0.0F, 1.0F);
+					f2 = MathHelper.clamp(pBlue, 0.0F, 1.0F);
 				} else {
 					f = 1.0F;
 					f1 = 1.0F;
 					f2 = 1.0F;
 				}
 
-				quad(alpha, p_228803_1_, p_228803_0_, bakedquad, new float[] { 1f, 1f, 1f, 1f }, f, f1, f2,
-					new int[] { p_228803_6_, p_228803_6_, p_228803_6_, p_228803_6_ }, p_228803_7_);
+				quad(alpha, pBuffer, pMatrixEntry, bakedquad, new float[] { 1f, 1f, 1f, 1f }, f, f1, f2,
+					new int[] { pCombinedLightIn, pCombinedLightIn, pCombinedLightIn, pCombinedLightIn }, pCombinedOverlayIn);
 			}
 
 		}
 
 		// IVertexBuilder
-		static void quad(float alpha, IVertexBuilder vb, MatrixStack.Entry p_227890_1_, BakedQuad p_227890_2_,
-			float[] p_227890_3_, float p_227890_4_, float p_227890_5_, float p_227890_6_, int[] p_227890_7_,
-			int p_227890_8_) {
-			int[] aint = p_227890_2_.getVertices();
-			Vector3i Vector3i = p_227890_2_.getDirection()
+		static void quad(float alpha, IVertexBuilder vb, MatrixStack.Entry pMatrixEntryIn, BakedQuad pQuadIn,
+			float[] pColorMuls, float pRedIn, float pGreenIn, float pBlueIn, int[] pCombinedLightsIn,
+			int pCombinedOverlayIn) {
+			int[] aint = pQuadIn.getVertices();
+			Vector3i Vector3i = pQuadIn.getDirection()
 				.getNormal();
 			Vector3f vector3f = new Vector3f((float) Vector3i.getX(), (float) Vector3i.getY(), (float) Vector3i.getZ());
-			Matrix4f matrix4f = p_227890_1_.pose();
-			vector3f.transform(p_227890_1_.normal());
+			Matrix4f matrix4f = pMatrixEntryIn.pose();
+			vector3f.transform(pMatrixEntryIn.normal());
 			int vertexSize = DefaultVertexFormats.BLOCK.getIntegerSize();
 			int j = aint.length / vertexSize;
 
@@ -182,17 +182,17 @@ public abstract class GhostBlockRenderer {
 					float g;
 					float b;
 
-					r = p_227890_3_[k] * p_227890_4_;
-					g = p_227890_3_[k] * p_227890_5_;
-					b = p_227890_3_[k] * p_227890_6_;
+					r = pColorMuls[k] * pRedIn;
+					g = pColorMuls[k] * pGreenIn;
+					b = pColorMuls[k] * pBlueIn;
 
-					int l = vb.applyBakedLighting(p_227890_7_[k], bytebuffer);
+					int l = vb.applyBakedLighting(pCombinedLightsIn[k], bytebuffer);
 					float f9 = bytebuffer.getFloat(16);
 					float f10 = bytebuffer.getFloat(20);
 					Vector4f vector4f = new Vector4f(f, f1, f2, 1.0F);
 					vector4f.transform(matrix4f);
-					vb.applyBakedNormals(vector3f, bytebuffer, p_227890_1_.normal());
-					vb.vertex(vector4f.x(), vector4f.y(), vector4f.z(), r, g, b, alpha, f9, f10, p_227890_8_,
+					vb.applyBakedNormals(vector3f, bytebuffer, pMatrixEntryIn.normal());
+					vb.vertex(vector4f.x(), vector4f.y(), vector4f.z(), r, g, b, alpha, f9, f10, pCombinedOverlayIn,
 						l, vector3f.x(), vector3f.y(), vector3f.z());
 				}
 			}

--- a/src/main/java/com/simibubi/create/foundation/utility/worldWrappers/WrappedChunkProvider.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/worldWrappers/WrappedChunkProvider.java
@@ -49,7 +49,7 @@ public class WrappedChunkProvider extends AbstractChunkProvider {
 
     @Nullable
     @Override
-    public IChunk getChunk(int x, int z, ChunkStatus status, boolean p_212849_4_) {
+    public IChunk getChunk(int x, int z, ChunkStatus status, boolean pLoad) {
         return getChunk(x, z);
     }
 

--- a/src/main/java/com/simibubi/create/foundation/utility/worldWrappers/WrappedClientWorld.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/worldWrappers/WrappedClientWorld.java
@@ -91,52 +91,52 @@ public class WrappedClientWorld extends ClientWorld {
 
 	@Nullable
 	@Override
-	public  <T extends LivingEntity> T getNearestEntity(List<? extends T> p_217361_1_, EntityPredicate p_217361_2_, @Nullable LivingEntity p_217361_3_, double p_217361_4_, double p_217361_6_, double p_217361_8_) {
-		return world.getNearestEntity(p_217361_1_, p_217361_2_, p_217361_3_, p_217361_4_, p_217361_6_, p_217361_8_);
+	public  <T extends LivingEntity> T getNearestEntity(List<? extends T> pEntities, EntityPredicate pPredicate, @Nullable LivingEntity pTarget, double pX, double pY, double pZ) {
+		return world.getNearestEntity(pEntities, pPredicate, pTarget, pX, pY, pZ);
 	}
 
 	@Override
-	public int getBlockTint(BlockPos p_225525_1_, ColorResolver p_225525_2_) {
-		return world.getBlockTint(p_225525_1_, p_225525_2_);
+	public int getBlockTint(BlockPos pBlockPosIn, ColorResolver pColorResolverIn) {
+		return world.getBlockTint(pBlockPosIn, pColorResolverIn);
 	}
 
 	// FIXME: Emissive Lighting might not light stuff properly
 
 
 	@Override
-	public void addParticle(IParticleData p_195594_1_, double p_195594_2_, double p_195594_4_, double p_195594_6_, double p_195594_8_, double p_195594_10_, double p_195594_12_) {
-		world.addParticle(p_195594_1_, p_195594_2_, p_195594_4_, p_195594_6_, p_195594_8_, p_195594_10_, p_195594_12_);
+	public void addParticle(IParticleData pParticleData, double pX, double pY, double pZ, double pXSpeed, double pYSpeed, double pZSpeed) {
+		world.addParticle(pParticleData, pX, pY, pZ, pXSpeed, pYSpeed, pZSpeed);
 	}
 
 	@Override
-	public void addParticle(IParticleData p_195590_1_, boolean p_195590_2_, double p_195590_3_, double p_195590_5_, double p_195590_7_, double p_195590_9_, double p_195590_11_, double p_195590_13_) {
-		world.addParticle(p_195590_1_, p_195590_2_, p_195590_3_, p_195590_5_, p_195590_7_, p_195590_9_, p_195590_11_, p_195590_13_);
+	public void addParticle(IParticleData pParticleData, boolean pForceAlwaysRender, double pX, double pY, double pZ, double pXSpeed, double pYSpeed, double pZSpeed) {
+		world.addParticle(pParticleData, pForceAlwaysRender, pX, pY, pZ, pXSpeed, pYSpeed, pZSpeed);
 	}
 
 	@Override
-	public void addAlwaysVisibleParticle(IParticleData p_195589_1_, double p_195589_2_, double p_195589_4_, double p_195589_6_, double p_195589_8_, double p_195589_10_, double p_195589_12_) {
-		world.addAlwaysVisibleParticle(p_195589_1_, p_195589_2_, p_195589_4_, p_195589_6_, p_195589_8_, p_195589_10_, p_195589_12_);
+	public void addAlwaysVisibleParticle(IParticleData pParticleData, double pX, double pY, double pZ, double pXSpeed, double pYSpeed, double pZSpeed) {
+		world.addAlwaysVisibleParticle(pParticleData, pX, pY, pZ, pXSpeed, pYSpeed, pZSpeed);
 	}
 
 	@Override
-	public void addAlwaysVisibleParticle(IParticleData p_217404_1_, boolean p_217404_2_, double p_217404_3_, double p_217404_5_, double p_217404_7_, double p_217404_9_, double p_217404_11_, double p_217404_13_) {
-		world.addAlwaysVisibleParticle(p_217404_1_, p_217404_2_, p_217404_3_, p_217404_5_, p_217404_7_, p_217404_9_, p_217404_11_, p_217404_13_);
+	public void addAlwaysVisibleParticle(IParticleData pParticleData, boolean pIgnoreRange, double pX, double pY, double pZ, double pXSpeed, double pYSpeed, double pZSpeed) {
+		world.addAlwaysVisibleParticle(pParticleData, pIgnoreRange, pX, pY, pZ, pXSpeed, pYSpeed, pZSpeed);
 	}
 
 	@Override
-	public void playLocalSound(double p_184134_1_, double p_184134_3_, double p_184134_5_, SoundEvent p_184134_7_, SoundCategory p_184134_8_, float p_184134_9_, float p_184134_10_, boolean p_184134_11_) {
-		world.playLocalSound(p_184134_1_, p_184134_3_, p_184134_5_, p_184134_7_,p_184134_8_, p_184134_9_, p_184134_10_, p_184134_11_);
+	public void playLocalSound(double pX, double pY, double pZ, SoundEvent pSoundIn, SoundCategory pCategory, float pVolume, float pPitch, boolean pDistanceDelay) {
+		world.playLocalSound(pX, pY, pZ, pSoundIn,pCategory, pVolume, pPitch, pDistanceDelay);
 	}
 
 	@Override
-	public void playSound(@Nullable PlayerEntity p_184148_1_, double p_184148_2_, double p_184148_4_, double p_184148_6_, SoundEvent p_184148_8_, SoundCategory p_184148_9_, float p_184148_10_, float p_184148_11_) {
-		world.playSound(p_184148_1_, p_184148_2_, p_184148_4_, p_184148_6_, p_184148_8_, p_184148_9_, p_184148_10_, p_184148_11_);
+	public void playSound(@Nullable PlayerEntity pPlayer, double pX, double pY, double pZ, SoundEvent pSoundIn, SoundCategory pCategory, float pVolume, float pPitch) {
+		world.playSound(pPlayer, pX, pY, pZ, pSoundIn, pCategory, pVolume, pPitch);
 	}
 
 	@Nullable
 	@Override
-	public TileEntity getBlockEntity(BlockPos p_175625_1_) {
-		return world.getBlockEntity(p_175625_1_);
+	public TileEntity getBlockEntity(BlockPos pPos) {
+		return world.getBlockEntity(pPos);
 	}
 	public World getWrappedWorld() {
 		return world;

--- a/src/main/java/com/simibubi/create/foundation/utility/worldWrappers/WrappedServerWorld.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/worldWrappers/WrappedServerWorld.java
@@ -88,8 +88,8 @@ public class WrappedServerWorld extends ServerWorld {
 	}
 
 	@Override
-	public void playSound(PlayerEntity p_217384_1_, Entity p_217384_2_, SoundEvent p_217384_3_,
-			SoundCategory p_217384_4_, float p_217384_5_, float p_217384_6_) {
+	public void playSound(PlayerEntity pPlayerIn, Entity pEntityIn, SoundEvent pEventIn,
+			SoundCategory pCategoryIn, float pVolume, float pPitch) {
 	}
 
 	@Override
@@ -132,11 +132,11 @@ public class WrappedServerWorld extends ServerWorld {
 	}
 
 	@Override
-	public Biome getUncachedNoiseBiome(int p_225604_1_, int p_225604_2_, int p_225604_3_) {
-		return world.getUncachedNoiseBiome(p_225604_1_, p_225604_2_, p_225604_3_);
+	public Biome getUncachedNoiseBiome(int pX, int pY, int pZ) {
+		return world.getUncachedNoiseBiome(pX, pY, pZ);
 	}
 
 	private static SaveFormat.LevelSave getLevelSaveFromWorld(World world) {
-		return ObfuscationReflectionHelper.getPrivateValue(MinecraftServer.class, world.getServer(), "field_71310_m"); // storageSource
+		return ObfuscationReflectionHelper.getPrivateValue(MinecraftServer.class, world.getServer(), "storageSource"); // storageSource
 	}
 }

--- a/src/main/java/com/simibubi/create/foundation/utility/worldWrappers/WrappedWorld.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/worldWrappers/WrappedWorld.java
@@ -63,8 +63,8 @@ public class WrappedWorld extends World {
 	}
 
 	@Override
-	public boolean isStateAtPosition(@Nullable BlockPos p_217375_1_, @Nullable Predicate<BlockState> p_217375_2_) {
-		return world.isStateAtPosition(p_217375_1_, p_217375_2_);
+	public boolean isStateAtPosition(@Nullable BlockPos pPos, @Nullable Predicate<BlockState> pState) {
+		return world.isStateAtPosition(pPos, pState);
 	}
 
 	@Override
@@ -115,8 +115,8 @@ public class WrappedWorld extends World {
 		SoundCategory category, float volume, float pitch) {}
 
 	@Override
-	public void playSound(@Nullable PlayerEntity p_217384_1_, Entity p_217384_2_, SoundEvent p_217384_3_,
-		SoundCategory p_217384_4_, float p_217384_5_, float p_217384_6_) {}
+	public void playSound(@Nullable PlayerEntity pPlayerIn, Entity pEntityIn, SoundEvent pEventIn,
+		SoundCategory pCategoryIn, float pVolume, float pPitch) {}
 
 	@Override
 	public Entity getEntity(int id) {
@@ -163,8 +163,8 @@ public class WrappedWorld extends World {
 	}
 
 	@Override
-	public Biome getUncachedNoiseBiome(int p_225604_1_, int p_225604_2_, int p_225604_3_) {
-		return world.getUncachedNoiseBiome(p_225604_1_, p_225604_2_, p_225604_3_);
+	public Biome getUncachedNoiseBiome(int pX, int pY, int pZ) {
+		return world.getUncachedNoiseBiome(pX, pY, pZ);
 	}
 
 	@Override
@@ -178,16 +178,16 @@ public class WrappedWorld extends World {
 	}
 
 	@Override
-	public void blockEntityChanged(BlockPos p_175646_1_, TileEntity p_175646_2_) {
+	public void blockEntityChanged(BlockPos pPos, TileEntity pUnusedTileEntity) {
 	}
 
 	@Override
-	public boolean hasChunkAt(BlockPos p_175667_1_) {
+	public boolean hasChunkAt(BlockPos pPos) {
 		return true;
 	}
 
 	@Override
-	public void updateNeighbourForOutputSignal(BlockPos p_175666_1_, Block p_175666_2_) {
+	public void updateNeighbourForOutputSignal(BlockPos pPos, Block pBlockIn) {
 		return;
 	}
 }

--- a/src/main/java/com/simibubi/create/foundation/utility/worldWrappers/chunk/EmptierChunk.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/worldWrappers/chunk/EmptierChunk.java
@@ -23,16 +23,16 @@ public class EmptierChunk extends Chunk {
 		super(null, null, null);
 	}
 
-	public BlockState getBlockState(BlockPos p_180495_1_) {
+	public BlockState getBlockState(BlockPos pPos) {
 		return Blocks.VOID_AIR.defaultBlockState();
 	}
 
 	@Nullable
-	public BlockState setBlockState(BlockPos p_177436_1_, BlockState p_177436_2_, boolean p_177436_3_) {
+	public BlockState setBlockState(BlockPos pPos, BlockState pState, boolean pIsMoving) {
 		return null;
 	}
 
-	public FluidState getFluidState(BlockPos p_204610_1_) {
+	public FluidState getFluidState(BlockPos pPos) {
 		return Fluids.EMPTY.defaultFluidState();
 	}
 
@@ -41,38 +41,38 @@ public class EmptierChunk extends Chunk {
 		return null;
 	}
 
-	public int getLightEmission(BlockPos p_217298_1_) {
+	public int getLightEmission(BlockPos pPos) {
 		return 0;
 	}
 
-	public void addEntity(Entity p_76612_1_) { }
+	public void addEntity(Entity pEntityIn) { }
 
-	public void removeEntity(Entity p_76622_1_) { }
+	public void removeEntity(Entity pEntityIn) { }
 
-	public void removeEntity(Entity p_76608_1_, int p_76608_2_) { }
+	public void removeEntity(Entity pEntityIn, int pIndex) { }
 
 	@Nullable
-	public TileEntity getBlockEntity(BlockPos p_177424_1_, Chunk.CreateEntityType p_177424_2_) {
+	public TileEntity getBlockEntity(BlockPos pPos, Chunk.CreateEntityType pCreationMode) {
 		return null;
 	}
 
-	public void addBlockEntity(TileEntity p_150813_1_) { }
+	public void addBlockEntity(TileEntity pTileEntityIn) { }
 
-	public void setBlockEntity(BlockPos p_177426_1_, TileEntity p_177426_2_) { }
+	public void setBlockEntity(BlockPos pPos, TileEntity pTileEntityIn) { }
 
-	public void removeBlockEntity(BlockPos p_177425_1_) { }
+	public void removeBlockEntity(BlockPos pPos) { }
 
 	public void markUnsaved() { }
 
-	public void getEntities(@Nullable Entity p_177414_1_, AxisAlignedBB p_177414_2_, List<Entity> p_177414_3_, Predicate<? super Entity> p_177414_4_) { }
+	public void getEntities(@Nullable Entity pEntityIn, AxisAlignedBB pAabb, List<Entity> pListToFill, Predicate<? super Entity> pFilter) { }
 
-	public <T extends Entity> void getEntitiesOfClass(Class<? extends T> p_177430_1_, AxisAlignedBB p_177430_2_, List<T> p_177430_3_, Predicate<? super T> p_177430_4_) { }
+	public <T extends Entity> void getEntitiesOfClass(Class<? extends T> pEntityClass, AxisAlignedBB pAabb, List<T> pListToFill, Predicate<? super T> pFilter) { }
 
 	public boolean isEmpty() {
 		return true;
 	}
 
-	public boolean isYSpaceEmpty(int p_76606_1_, int p_76606_2_) {
+	public boolean isYSpaceEmpty(int pStartY, int pEndY) {
 		return true;
 	}
 

--- a/src/main/java/com/simibubi/create/foundation/utility/worldWrappers/chunk/WrappedChunk.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/worldWrappers/chunk/WrappedChunk.java
@@ -79,17 +79,17 @@ public class WrappedChunk implements IChunk {
 
     @Nullable
     @Override
-    public BlockState setBlockState(BlockPos p_177436_1_, BlockState p_177436_2_, boolean p_177436_3_) {
+    public BlockState setBlockState(BlockPos pPos, BlockState pState, boolean pIsMoving) {
         return null;
     }
 
     @Override
-    public void setBlockEntity(BlockPos p_177426_1_, TileEntity p_177426_2_) {
+    public void setBlockEntity(BlockPos pPos, TileEntity pTileEntityIn) {
 
     }
 
     @Override
-    public void addEntity(Entity p_76612_1_) {
+    public void addEntity(Entity pEntityIn) {
 
     }
 
@@ -104,17 +104,17 @@ public class WrappedChunk implements IChunk {
     }
 
     @Override
-    public void setHeightmap(Heightmap.Type p_201607_1_, long[] p_201607_2_) {
+    public void setHeightmap(Heightmap.Type pType, long[] pData) {
 
     }
 
     @Override
-    public Heightmap getOrCreateHeightmapUnprimed(Heightmap.Type p_217303_1_) {
+    public Heightmap getOrCreateHeightmapUnprimed(Heightmap.Type pTypeIn) {
         return null;
     }
 
     @Override
-    public int getHeight(Heightmap.Type p_201576_1_, int p_201576_2_, int p_201576_3_) {
+    public int getHeight(Heightmap.Type pHeightmapType, int pX, int pZ) {
         return 0;
     }
 
@@ -124,7 +124,7 @@ public class WrappedChunk implements IChunk {
     }
 
     @Override
-    public void setLastSaveTime(long p_177432_1_) {
+    public void setLastSaveTime(long pSaveTime) {
 
     }
 
@@ -135,7 +135,7 @@ public class WrappedChunk implements IChunk {
     }
 
     @Override
-    public void setUnsaved(boolean p_177427_1_) {
+    public void setUnsaved(boolean pModified) {
 
     }
 
@@ -145,7 +145,7 @@ public class WrappedChunk implements IChunk {
     }
 
     @Override
-    public void removeBlockEntity(BlockPos p_177425_1_) {
+    public void removeBlockEntity(BlockPos pPos) {
 
     }
 
@@ -156,13 +156,13 @@ public class WrappedChunk implements IChunk {
 
     @Nullable
     @Override
-    public CompoundNBT getBlockEntityNbt(BlockPos p_201579_1_) {
+    public CompoundNBT getBlockEntityNbt(BlockPos pPos) {
         return null;
     }
 
     @Nullable
     @Override
-    public CompoundNBT getBlockEntityNbtForSaving(BlockPos p_223134_1_) {
+    public CompoundNBT getBlockEntityNbtForSaving(BlockPos pPos) {
         return null;
     }
 
@@ -182,7 +182,7 @@ public class WrappedChunk implements IChunk {
     }
 
     @Override
-    public void setInhabitedTime(long p_177415_1_) {
+    public void setInhabitedTime(long pNewInhabitedTime) {
 
     }
 
@@ -213,7 +213,7 @@ public class WrappedChunk implements IChunk {
     }
 
 	@Override
-	public FluidState getFluidState(BlockPos p_204610_1_) {
+	public FluidState getFluidState(BlockPos pPos) {
 		return null;
 	}
 
@@ -248,7 +248,7 @@ public class WrappedChunk implements IChunk {
 	}
 
 	@Override
-	public void setAllStarts(Map<Structure<?>, StructureStart<?>> p_201612_1_) {
+	public void setAllStarts(Map<Structure<?>, StructureStart<?>> pStructureStartsIn) {
 
 	}
 

--- a/src/main/java/com/simibubi/create/foundation/utility/worldWrappers/chunk/WrappedChunkSection.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/worldWrappers/chunk/WrappedChunkSection.java
@@ -26,7 +26,7 @@ public class WrappedChunkSection extends ChunkSection {
     }
 
     @Override
-    public BlockState setBlockState(int p_177484_1_, int p_177484_2_, int p_177484_3_, BlockState p_177484_4_, boolean p_177484_5_) {
+    public BlockState setBlockState(int pX, int pY, int pZ, BlockState pState, boolean pUseLocks) {
         throw new IllegalStateException("Chunk sections should not be mutated in a fake world.");
     }
 }

--- a/src/main/java/com/simibubi/create/foundation/worldgen/ConfigDrivenOreFeature.java
+++ b/src/main/java/com/simibubi/create/foundation/worldgen/ConfigDrivenOreFeature.java
@@ -22,28 +22,28 @@ public class ConfigDrivenOreFeature extends Feature<ConfigDrivenOreFeatureConfig
 
 	// From OreFeature, slight adjustments
 
-	public boolean place(ISeedReader p_241855_1_, ChunkGenerator p_241855_2_, Random p_241855_3_,
-		BlockPos p_241855_4_, ConfigDrivenOreFeatureConfig p_241855_5_) {
-		float f = p_241855_3_.nextFloat() * (float) Math.PI;
-		float size = p_241855_5_.getSize();
+	public boolean place(ISeedReader pReader, ChunkGenerator pGenerator, Random pRand,
+		BlockPos pPos, ConfigDrivenOreFeatureConfig pConfig) {
+		float f = pRand.nextFloat() * (float) Math.PI;
+		float size = pConfig.getSize();
 		float f1 = size / 8.0F;
 		int i = MathHelper.ceil((size / 16.0F * 2.0F + 1.0F) / 2.0F);
-		double d0 = (double) p_241855_4_.getX() + Math.sin((double) f) * (double) f1;
-		double d1 = (double) p_241855_4_.getX() - Math.sin((double) f) * (double) f1;
-		double d2 = (double) p_241855_4_.getZ() + Math.cos((double) f) * (double) f1;
-		double d3 = (double) p_241855_4_.getZ() - Math.cos((double) f) * (double) f1;
-		double d4 = (double) (p_241855_4_.getY() + p_241855_3_.nextInt(3) - 2);
-		double d5 = (double) (p_241855_4_.getY() + p_241855_3_.nextInt(3) - 2);
-		int k = p_241855_4_.getX() - MathHelper.ceil(f1) - i;
-		int l = p_241855_4_.getY() - 2 - i;
-		int i1 = p_241855_4_.getZ() - MathHelper.ceil(f1) - i;
+		double d0 = (double) pPos.getX() + Math.sin((double) f) * (double) f1;
+		double d1 = (double) pPos.getX() - Math.sin((double) f) * (double) f1;
+		double d2 = (double) pPos.getZ() + Math.cos((double) f) * (double) f1;
+		double d3 = (double) pPos.getZ() - Math.cos((double) f) * (double) f1;
+		double d4 = (double) (pPos.getY() + pRand.nextInt(3) - 2);
+		double d5 = (double) (pPos.getY() + pRand.nextInt(3) - 2);
+		int k = pPos.getX() - MathHelper.ceil(f1) - i;
+		int l = pPos.getY() - 2 - i;
+		int i1 = pPos.getZ() - MathHelper.ceil(f1) - i;
 		int j1 = 2 * (MathHelper.ceil(f1) + i);
 		int k1 = 2 * (2 + i);
 
 		for (int l1 = k; l1 <= k + j1; ++l1) {
 			for (int i2 = i1; i2 <= i1 + j1; ++i2) {
-				if (l <= p_241855_1_.getHeight(Heightmap.Type.OCEAN_FLOOR_WG, l1, i2)) {
-					return this.doPlace(p_241855_1_, p_241855_3_, p_241855_5_, d0, d1, d2, d3, d4, d5, k, l, i1,
+				if (l <= pReader.getHeight(Heightmap.Type.OCEAN_FLOOR_WG, l1, i2)) {
+					return this.doPlace(pReader, pRand, pConfig, d0, d1, d2, d3, d4, d5, k, l, i1,
 						j1, k1);
 				}
 			}


### PR DESCRIPTION
Converted to parchment mappings + applied some code suggestions from IntelliJ.

Parchment are new mappings that introduce javadocs and parameter names to functions. It's still in early development, so some parameter names are incorrect. I used release export of parchment which probably has some parameter mismatched names (for example drawCenteredString has incorrect parameters for shadow color and padding). From what I saw bleeding edge and nightly are already fixed, which means that this project is very active and worth considering.

Additionally I applied some suggestions recommended by the IDE:
- redundant implicit `static` modifiers on enums
- boxed network ID comparison in KineticTileEntity
- optional uuid in OrientedContraptionEntity cannot be null
- parameterized collection constructors instead of addAll calls
- addAll instead of for()... add calls on collections
- "possibly costly removeAll" in SoulPulseEffectHandler
- unnecessary toString() calls
- string concatenation instead of append when using string builder
- SingletonLists for single element lists instead of ArrayLists

This is just a proof that parchment mappings work and are hassle free when converting from mojmaps. Everything compiled and worked without any manual tinkering. I doubt that it will be merged as updating mappings probably should be done in a single transaction by some project head. Nevertheless, this proves the point, that it's easy to switch and it can potentially significantly improve productivity. To switch to parchment follow K9's `??parchmentfg` trick on Modded Minecraft discord by adding repository, switching dependency and changing mappings channel and version, followed by the `updateMappings` gradle task with appropriate arguments for channel and version.