### PR TITLE
Fix damage tooltip for potato cannon using outdated damage calculations when enchanted with power (and fix mismatching floor operation on damage calc)

### DIFF
--- a/src/main/java/com/simibubi/create/content/curiosities/weapons/PotatoCannonItem.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/weapons/PotatoCannonItem.java
@@ -244,8 +244,7 @@ public class PotatoCannonItem extends ShootableItem {
 			TextFormatting darkGreen = TextFormatting.DARK_GREEN;
 
 			float damageF = type.getDamage() * additionalDamageMult;
-			IFormattableTextComponent damage = new StringTextComponent(
-				damageF == MathHelper.floor(damageF) ? "" + MathHelper.floor(damageF) : "" + damageF);
+			IFormattableTextComponent damage = new StringTextComponent("" + MathHelper.floor(damageF));
 			IFormattableTextComponent reloadTicks = new StringTextComponent("" + type.getReloadTicks());
 			IFormattableTextComponent knockback =
 				new StringTextComponent("" + (type.getKnockback() + additionalKnockback));

--- a/src/main/java/com/simibubi/create/content/curiosities/weapons/PotatoCannonItem.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/weapons/PotatoCannonItem.java
@@ -244,7 +244,8 @@ public class PotatoCannonItem extends ShootableItem {
 			TextFormatting darkGreen = TextFormatting.DARK_GREEN;
 
 			float damageF = type.getDamage() * additionalDamageMult;
-			IFormattableTextComponent damage = new StringTextComponent("" + MathHelper.floor(damageF));
+			IFormattableTextComponent damage = new StringTextComponent(
+				damageF == MathHelper.floor(damageF) ? "" + MathHelper.floor(damageF) : "" + damageF);
 			IFormattableTextComponent reloadTicks = new StringTextComponent("" + type.getReloadTicks());
 			IFormattableTextComponent knockback =
 				new StringTextComponent("" + (type.getKnockback() + additionalKnockback));

--- a/src/main/java/com/simibubi/create/content/curiosities/weapons/PotatoCannonItem.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/weapons/PotatoCannonItem.java
@@ -161,7 +161,7 @@ public class PotatoCannonItem extends ShootableItem {
 					Vector3d sprayOffset = VecHelper.rotate(sprayBase, i * sprayChange + imperfection, Axis.Z);
 					splitMotion = splitMotion.add(VecHelper.lookAt(sprayOffset, motion));
 				}
-				
+
 				if (i != 0)
 					projectile.recoveryChance = 0;
 
@@ -226,9 +226,9 @@ public class PotatoCannonItem extends ShootableItem {
 	public void appendHoverText(ItemStack stack, World world, List<ITextComponent> tooltip, ITooltipFlag flag) {
 		int power = EnchantmentHelper.getItemEnchantmentLevel(Enchantments.POWER_ARROWS, stack);
 		int punch = EnchantmentHelper.getItemEnchantmentLevel(Enchantments.PUNCH_ARROWS, stack);
-		final float additionalDamage = power * 2;
+		final float additionalDamageMult = 1 + power * .2f;
 		final float additionalKnockback = punch * .5f;
-		
+
 		getAmmoforPreview(stack).ifPresent(ammo -> {
 			String _attack = "potato_cannon.ammo.attack_damage";
 			String _reload = "potato_cannon.ammo.reload_ticks";
@@ -243,14 +243,14 @@ public class PotatoCannonItem extends ShootableItem {
 			TextFormatting green = TextFormatting.GREEN;
 			TextFormatting darkGreen = TextFormatting.DARK_GREEN;
 
-			float damageF = type.getDamage() + additionalDamage;
+			float damageF = type.getDamage() * additionalDamageMult;
 			IFormattableTextComponent damage = new StringTextComponent(
 				damageF == MathHelper.floor(damageF) ? "" + MathHelper.floor(damageF) : "" + damageF);
 			IFormattableTextComponent reloadTicks = new StringTextComponent("" + type.getReloadTicks());
 			IFormattableTextComponent knockback =
 				new StringTextComponent("" + (type.getKnockback() + additionalKnockback));
 
-			damage = damage.withStyle(additionalDamage > 0 ? green : darkGreen);
+			damage = damage.withStyle(additionalDamageMult > 1 ? green : darkGreen);
 			knockback = knockback.withStyle(additionalKnockback > 0 ? green : darkGreen);
 			reloadTicks = reloadTicks.withStyle(darkGreen);
 

--- a/src/main/java/com/simibubi/create/content/curiosities/weapons/PotatoProjectileEntity.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/weapons/PotatoProjectileEntity.java
@@ -176,7 +176,7 @@ public class PotatoProjectileEntity extends DamagingProjectileEntity implements 
 		Vector3d hit = ray.getLocation();
 		Entity target = ray.getEntity();
 		PotatoCannonProjectileTypes projectileType = getProjectileType();
-		float damage = MathHelper.floor(projectileType.getDamage() * additionalDamageMult);
+		float damage = projectileType.getDamage() * additionalDamageMult;
 		float knockback = projectileType.getKnockback() + additionalKnockback;
 		Entity owner = this.getOwner();
 


### PR DESCRIPTION
The damage calculation for the tooltip of the potato cannon with the power enchantment is wildly incorrect (and listed as such in the wiki but not as an issue) even in the most recent dev version. This fixes that.

I have also removed the floor operation on the damage calculation as it does not fall in line with the way damage is displayed (where it is not floored), and kinda makes the lower level power enchantments useless for some ammo types.

