### PR TITLE
Fix #2033

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/processing/InWorldProcessing.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/processing/InWorldProcessing.java
@@ -242,9 +242,9 @@ public class InWorldProcessing {
 		if (recalculateTime) {
 			processing.putString("Type", type.name());
 			int timeModifierForStackSize = ((entity.getItem()
-					.getCount() - 1) / 16) + 1;
+				.getCount() - 1) / 16) + 1;
 			int processingTime =
-					(int) (AllConfigs.SERVER.kinetics.inWorldProcessingTime.get() * timeModifierForStackSize) + 1;
+				(int) (AllConfigs.SERVER.kinetics.inWorldProcessingTime.get() * timeModifierForStackSize) + 1;
 			processing.putInt("Time", processingTime);
 		}
 

--- a/src/main/java/com/simibubi/create/content/contraptions/processing/InWorldProcessing.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/processing/InWorldProcessing.java
@@ -229,18 +229,28 @@ public class InWorldProcessing {
 			createData.put("Processing", new CompoundNBT());
 		CompoundNBT processing = createData.getCompound("Processing");
 
-		if (!processing.contains("Type") || Type.valueOf(processing.getString("Type")) != type) {
+		boolean recalculateTime = false;
+
+		if (processing.contains("Type")) {
+			if (Type.valueOf(processing.getString("Type")) != type || processing.getInt("Time") < 0) {
+				recalculateTime = true;
+			}
+		} else {
+			recalculateTime = true;
+		}
+
+		if (recalculateTime) {
 			processing.putString("Type", type.name());
 			int timeModifierForStackSize = ((entity.getItem()
-				.getCount() - 1) / 16) + 1;
+					.getCount() - 1) / 16) + 1;
 			int processingTime =
-				(int) (AllConfigs.SERVER.kinetics.inWorldProcessingTime.get() * timeModifierForStackSize) + 1;
+					(int) (AllConfigs.SERVER.kinetics.inWorldProcessingTime.get() * timeModifierForStackSize) + 1;
 			processing.putInt("Time", processingTime);
 		}
 
-		int value = processing.getInt("Time") - 1;
-		processing.putInt("Time", value);
-		return value;
+		int timeValue = processing.getInt("Time") - 1;
+		processing.putInt("Time", timeValue);
+		return timeValue;
 	}
 
 	public static void applyRecipeOn(ItemEntity entity, IRecipe<?> recipe) {


### PR DESCRIPTION
This PR aims to fix #2033 by forcing a time recalculation if the time value in InWorldProcessing#decrementProcessingTime is less than 0. The only negative value set intentionally is -1 for items which do not apply to the processing type, so having any other negative value can continuously be decreased, causing a break in mechanics. This is outlined in the attached issue.