### PR TITLE
Integration support for Furnace Engine speed modifiers

### DIFF
--- a/src/main/java/com/simibubi/create/Create.java
+++ b/src/main/java/com/simibubi/create/Create.java
@@ -9,6 +9,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.simibubi.create.content.CreateItemGroup;
 import com.simibubi.create.content.contraptions.TorquePropagator;
+import com.simibubi.create.content.contraptions.components.flywheel.engine.FurnaceEngineModifiers;
 import com.simibubi.create.content.contraptions.components.structureMovement.train.capability.CapabilityMinecartController;
 import com.simibubi.create.content.curiosities.weapons.PotatoCannonProjectileTypes;
 import com.simibubi.create.content.logistics.RedstoneLinkNetworkHandler;
@@ -92,6 +93,7 @@ public class Create {
 		AllWorldFeatures.register();
 		AllEnchantments.register();
 		AllConfigs.register(ModLoadingContext.get());
+		FurnaceEngineModifiers.register();
 
 		ForgeMod.enableMilkFluid();
 

--- a/src/main/java/com/simibubi/create/content/contraptions/components/flywheel/engine/FurnaceEngineModifiers.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/flywheel/engine/FurnaceEngineModifiers.java
@@ -1,0 +1,39 @@
+package com.simibubi.create.content.contraptions.components.flywheel.engine;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+
+public class FurnaceEngineModifiers {
+	
+	public final static FurnaceEngineModifiers INSTANCE = new FurnaceEngineModifiers();
+	
+	protected Map<Block, Float> blockModifiers;
+	
+	public FurnaceEngineModifiers(Map<Block, Float> blockModifiers) {
+		this.blockModifiers = blockModifiers;
+	}
+	
+	public FurnaceEngineModifiers() {
+		this(new HashMap<>());
+	}
+	
+	public void set(Block block, float modifier) {
+		this.blockModifiers.put(block, modifier);
+	}
+	
+	public float getModifier(BlockState state, float def) {
+		return blockModifiers.getOrDefault(state.getBlock(), def);
+	}
+	
+	public float getModifier(BlockState state) {
+		return getModifier(state, 1f);
+	}
+	
+	public static void register() {
+		INSTANCE.set(Blocks.BLAST_FURNACE, 2f);
+	}
+}

--- a/src/main/java/com/simibubi/create/content/contraptions/components/flywheel/engine/FurnaceEngineTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/flywheel/engine/FurnaceEngineTileEntity.java
@@ -25,7 +25,7 @@ public class FurnaceEngineTileEntity extends EngineTileEntity {
 		if (!(state.getBlock() instanceof AbstractFurnaceBlock))
 			return;
 
-		float modifier = state.getBlock() == Blocks.BLAST_FURNACE ? 2 : 1;
+		float modifier = FurnaceEngineModifiers.INSTANCE.getModifier(state);
 		boolean active = state.hasProperty(AbstractFurnaceBlock.LIT) && state.getValue(AbstractFurnaceBlock.LIT);
 		float speed = active ? 16 * modifier : 0;
 		float capacity =


### PR DESCRIPTION
+ Added FurnaceEngineModifiers which hold a Block -> float map of modifiers
+ Changed FurnaceEngineTileEntity to use the FurnaceEngineModifiers map instead of hardcoded modifier for the Blast Furnace.
This will allow addon modders to change the speed modifier of a Furnace block.