### PR TITLE
Configurable worldgen filters

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/worldgen/AllWorldFeatures.java
+++ b/src/main/java/com/simibubi/create/foundation/worldgen/AllWorldFeatures.java
@@ -72,12 +72,10 @@ public class AllWorldFeatures {
 	public static void reload(BiomeLoadingEvent event) {
 		entries.values()
 			.forEach(entry -> {
-				if (event.getName() == Biomes.THE_VOID.getRegistryName())
-					return;
-				if (event.getCategory() == Category.NETHER)
-					return;
-				event.getGeneration()
-					.addFeature(GenerationStage.Decoration.UNDERGROUND_ORES, entry.getFeature());
+				if(entry.biomeMatches(event.getName()) && entry.categoryMatches(event.getCategory().getName())) {
+					event.getGeneration()
+							.addFeature(GenerationStage.Decoration.UNDERGROUND_ORES, entry.getFeature());
+				}
 			});
 	}
 

--- a/src/main/java/com/simibubi/create/foundation/worldgen/ConfigDrivenFeatureEntry.java
+++ b/src/main/java/com/simibubi/create/foundation/worldgen/ConfigDrivenFeatureEntry.java
@@ -34,7 +34,9 @@ public class ConfigDrivenFeatureEntry extends ConfigBase {
 		public String[] getBlacklistDescritpion() {
 			return new String[]{"Whether or not this filter is a blacklist instead of a whitelist"};
 		}
-		public abstract String[] getListDescription();
+		public String[] getListDescription() {
+			return new String[]{"The list for this filter"};
+		}
 		public abstract List<String> getDefaultList();
 		public boolean validateEntry(Object e) {
 			return e instanceof String;
@@ -93,11 +95,6 @@ public class ConfigDrivenFeatureEntry extends ConfigBase {
 			}
 
 			@Override
-			public String[] getListDescription() {
-				return new String[0];
-			}
-
-			@Override
 			public List<String> getDefaultList() {
 				return Collections.emptyList();
 			}
@@ -113,11 +110,6 @@ public class ConfigDrivenFeatureEntry extends ConfigBase {
 			}
 
 			@Override
-			public String[] getListDescription() {
-				return new String[0];
-			}
-
-			@Override
 			public List<String> getDefaultList() {
 				return Collections.singletonList("#" + BlockTags.BASE_STONE_OVERWORLD.getName());
 			}
@@ -130,11 +122,6 @@ public class ConfigDrivenFeatureEntry extends ConfigBase {
 			@Override
 			public boolean isBlacklistByDefault() {
 				return true;
-			}
-
-			@Override
-			public String[] getListDescription() {
-				return new String[0];
 			}
 
 			@Override
@@ -183,7 +170,7 @@ public class ConfigDrivenFeatureEntry extends ConfigBase {
 
 	private ConfiguredFeature<?, ?> createFeature() {
 		ConfigDrivenOreFeatureConfig config =
-			new ConfigDrivenOreFeatureConfig(FillerBlockType.NATURAL_STONE, block.get()
+			new ConfigDrivenOreFeatureConfig(createTest(), block.get()
 				.defaultBlockState(), id);
 
 		return ConfigDrivenOreFeature.INSTANCE.configured(config)
@@ -203,11 +190,8 @@ public class ConfigDrivenFeatureEntry extends ConfigBase {
 	protected void registerAll(ForgeConfigSpec.Builder builder) {
 		biomes = addFilter(builder, biomeFilter, "The biomes this ore spawns in");
 		blocks = addFilter(builder, blockFilter, "The blocks this ore can generate in, start with # if it is a tag");
-		Biome.Category[] categoryList = Biome.Category.values();
-		String[] categoryComments = new String[categoryList.length + 1];
-		categoryComments[0] = "The biome categories this ore can spawn in. Options: ";
-		System.arraycopy(Arrays.stream(categoryList).map(Biome.Category::getName).toArray(String[]::new), 0, categoryComments, 1, categoryList.length);
-		categories = addFilter(builder, categoryFilter, categoryComments);
+		categories = addFilter(builder, categoryFilter, "The biome categories this ore can spawn in", "Options:",
+				Arrays.stream(Biome.Category.values()).map(Biome.Category::getName).collect(Collectors.joining(", ")));
 		super.registerAll(builder);
 	}
 

--- a/src/main/java/com/simibubi/create/foundation/worldgen/ConfigDrivenFeatureEntry.java
+++ b/src/main/java/com/simibubi/create/foundation/worldgen/ConfigDrivenFeatureEntry.java
@@ -1,21 +1,66 @@
 package com.simibubi.create.foundation.worldgen;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
+import java.util.Random;
+import java.util.Set;
+import java.util.function.IntFunction;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import com.simibubi.create.foundation.config.ConfigBase;
+import com.sun.jna.StringArray;
 import com.tterrag.registrate.util.nullness.NonNullSupplier;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.biome.Biome;
 import net.minecraft.world.gen.feature.ConfiguredFeature;
 import net.minecraft.world.gen.feature.OreFeatureConfig.FillerBlockType;
+import net.minecraft.world.gen.feature.template.BlockMatchRuleTest;
+import net.minecraft.world.gen.feature.template.IRuleTestType;
+import net.minecraft.world.gen.feature.template.RuleTest;
 import net.minecraftforge.common.ForgeConfigSpec;
+import net.minecraftforge.common.Tags;
 
 public class ConfigDrivenFeatureEntry extends ConfigBase {
+	public abstract static class FilterConfig extends ConfigBase {
+		public abstract boolean isBlacklistByDefault();
+		public String[] getBlacklistDescritpion() {
+			return new String[]{"Whether or not this filter is a blacklist instead of a whitelist"};
+		}
+		public abstract String[] getListDescription();
+		public abstract List<String> getDefaultList();
+		public boolean validateEntry(Object e) {
+			return e instanceof String;
+		}
+
+		public ConfigBool blacklist = b(isBlacklistByDefault(), "blacklist", getBlacklistDescritpion());
+		public ForgeConfigSpec.ConfigValue<List<? extends String>> list;
+
+		@Override
+		protected void registerAll(ForgeConfigSpec.Builder builder) {
+			builder.comment(getListDescription());
+			list = builder.defineList("list", this::getDefaultList, this::validateEntry);
+			super.registerAll(builder);
+		}
+	}
 
 	public final String id;
 	public final NonNullSupplier<? extends Block> block;
 
 	protected ConfigInt clusterSize;
+	protected final Supplier<FilterConfig> biomeFilter;
+	protected final Supplier<FilterConfig> blockFilter;
+	protected final Supplier<FilterConfig> categoryFilter;
+	protected FilterConfig biomes;
+	protected FilterConfig blocks;
+	protected FilterConfig categories;
 	protected ConfigInt minHeight;
 	protected ConfigInt maxHeight;
 	protected ConfigFloat frequency;
@@ -23,14 +68,85 @@ public class ConfigDrivenFeatureEntry extends ConfigBase {
 	Optional<ConfiguredFeature<?, ?>> feature = Optional.empty();
 
 	public ConfigDrivenFeatureEntry(String id, NonNullSupplier<? extends Block> block, int clusterSize,
-		float frequency) {
+									float frequency,
+									Supplier<FilterConfig> biomeFilter,
+									Supplier<FilterConfig> blockFilter,
+									Supplier<FilterConfig> categoryFilter) {
 		this.id = id;
 		this.block = block;
 		this.clusterSize = i(clusterSize, 0, "clusterSize");
+		this.biomeFilter = biomeFilter;
+		this.blockFilter = blockFilter;
+		this.categoryFilter = categoryFilter;
 		this.minHeight = i(0, 0, "minHeight");
 		this.maxHeight = i(256, 0, "maxHeight");
 		this.frequency = f(frequency, 0, 512, "frequency", "Amount of clusters generated per Chunk.",
 			"  >1 to spawn multiple.", "  <1 to make it a chance.", "  0 to disable.");
+	}
+
+	public ConfigDrivenFeatureEntry(String id, NonNullSupplier<? extends Block> block, int clusterSize,
+									float frequency) {
+		this(id, block, clusterSize, frequency, () -> new FilterConfig() {
+			@Override
+			public boolean isBlacklistByDefault() {
+				return true;
+			}
+
+			@Override
+			public String[] getListDescription() {
+				return new String[0];
+			}
+
+			@Override
+			public List<String> getDefaultList() {
+				return Collections.emptyList();
+			}
+
+			@Override
+			public String getName() {
+				return "biomes";
+			}
+		}, () -> new FilterConfig() {
+			@Override
+			public boolean isBlacklistByDefault() {
+				return false;
+			}
+
+			@Override
+			public String[] getListDescription() {
+				return new String[0];
+			}
+
+			@Override
+			public List<String> getDefaultList() {
+				return Collections.singletonList("#" + BlockTags.BASE_STONE_OVERWORLD.getName());
+			}
+
+			@Override
+			public String getName() {
+				return "blocks";
+			}
+		}, () -> new FilterConfig() {
+			@Override
+			public boolean isBlacklistByDefault() {
+				return true;
+			}
+
+			@Override
+			public String[] getListDescription() {
+				return new String[0];
+			}
+
+			@Override
+			public List<String> getDefaultList() {
+				return Arrays.asList(Biome.Category.NETHER.getName(), Biome.Category.THEEND.getName());
+			}
+
+			@Override
+			public String getName() {
+				return "categories";
+			}
+		});
 	}
 
 	public ConfigDrivenFeatureEntry between(int minHeight, int maxHeight) {
@@ -47,6 +163,24 @@ public class ConfigDrivenFeatureEntry extends ConfigBase {
 		return feature.get();
 	}
 
+	public boolean blockMatches(ResourceLocation id, Set<ResourceLocation> tags) {
+		return blocks.list.get().stream().anyMatch(l -> {
+			if (l.startsWith("#")) {
+				return tags.contains(new ResourceLocation(l.replace("#", "")));
+			}
+			return new ResourceLocation(l).equals(id);
+		}) != blocks.blacklist.get();
+	}
+
+	protected RuleTest createTest() {
+		return new BlockMatchRuleTest(Blocks.AIR) {
+			@Override
+			public boolean test(BlockState state, Random random) {
+				return blockMatches(state.getBlock().getRegistryName(), state.getBlock().getTags());
+			}
+		};
+	}
+
 	private ConfiguredFeature<?, ?> createFeature() {
 		ConfigDrivenOreFeatureConfig config =
 			new ConfigDrivenOreFeatureConfig(FillerBlockType.NATURAL_STONE, block.get()
@@ -54,6 +188,27 @@ public class ConfigDrivenFeatureEntry extends ConfigBase {
 
 		return ConfigDrivenOreFeature.INSTANCE.configured(config)
 			.decorated(ConfigDrivenDecorator.INSTANCE.configured(config));
+	}
+
+	protected FilterConfig addFilter(ForgeConfigSpec.Builder builder, Supplier<FilterConfig> c, String... comments) {
+		FilterConfig config = c.get();
+		builder.comment(comments);
+		builder.push(config.getName());
+		config.registerAll(builder);
+		builder.pop();
+		return config;
+	}
+
+	@Override
+	protected void registerAll(ForgeConfigSpec.Builder builder) {
+		biomes = addFilter(builder, biomeFilter, "The biomes this ore spawns in");
+		blocks = addFilter(builder, blockFilter, "The blocks this ore can generate in, start with # if it is a tag");
+		Biome.Category[] categoryList = Biome.Category.values();
+		String[] categoryComments = new String[categoryList.length + 1];
+		categoryComments[0] = "The biome categories this ore can spawn in. Options: ";
+		System.arraycopy(Arrays.stream(categoryList).map(Biome.Category::getName).toArray(String[]::new), 0, categoryComments, 1, categoryList.length);
+		categories = addFilter(builder, categoryFilter, categoryComments);
+		super.registerAll(builder);
 	}
 
 	public void addToConfig(ForgeConfigSpec.Builder builder) {
@@ -65,4 +220,11 @@ public class ConfigDrivenFeatureEntry extends ConfigBase {
 		return id;
 	}
 
+	public boolean biomeMatches(ResourceLocation name) {
+		return biomes.list.get().stream().anyMatch(l -> new ResourceLocation(l).equals(name)) != biomes.blacklist.get();
+	}
+
+	public boolean categoryMatches(String name) {
+		return categories.list.get().stream().anyMatch(s -> s.equals(name)) != categories.blacklist.get();
+	}
 }


### PR DESCRIPTION
Makes the biomes, blocks, and biome categories ores spawn in configurable 

i attempted to rewrite [the thing i wrote for create automated](https://github.com/Create-Additions/CreateAutomated/blob/6f8329f70090394051f0a4409fed029235fcc971/src/main/java/com/kotakotik/createautomated/content/worldgen/DimensionalConfigDrivenFeatureEntry.java#L27) more in create's code style but i think i failed in that 