### PR TITLE
"Interactor Framework" - player actions on contraption components

### DIFF
--- a/src/main/java/com/simibubi/create/AllInteractionBehaviours.java
+++ b/src/main/java/com/simibubi/create/AllInteractionBehaviours.java
@@ -1,0 +1,45 @@
+package com.simibubi.create;
+
+import com.simibubi.create.content.contraptions.components.structureMovement.LeverMovingInteraction;
+import com.simibubi.create.content.contraptions.components.structureMovement.MovingInteractionBehaviour;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.Blocks;
+import net.minecraft.util.ResourceLocation;
+
+import javax.annotation.Nullable;
+
+import java.util.HashMap;
+
+public class AllInteractionBehaviours {
+	private static final HashMap<ResourceLocation, MovingInteractionBehaviour> INTERACT_BEHAVIOURS = new HashMap<>();
+
+	public static void addInteractionBehaviour (ResourceLocation loc, MovingInteractionBehaviour behaviour) {
+		if (INTERACT_BEHAVIOURS.containsKey(loc)) {
+			Create.LOGGER.warn("Interaction behaviour for " + loc.toString() + " was overridden");
+		}
+		INTERACT_BEHAVIOURS.put(loc, behaviour);
+	}
+
+	public static void addInteractionBehavioiur (Block block, MovingInteractionBehaviour behaviour) {
+		addInteractionBehaviour(block.getRegistryName(), behaviour);
+	}
+
+	@Nullable
+	public static MovingInteractionBehaviour of (ResourceLocation loc) {
+		return INTERACT_BEHAVIOURS.getOrDefault(loc, null);
+	}
+
+	@Nullable
+	public static MovingInteractionBehaviour of (Block block) {
+		return of(block.getRegistryName());
+	}
+
+	public static boolean contains (Block block) {
+		return INTERACT_BEHAVIOURS.containsKey(block.getRegistryName());
+	}
+
+	static void register () {
+		addInteractionBehaviour(Blocks.LEVER.getRegistryName(), new LeverMovingInteraction());
+	}
+}

--- a/src/main/java/com/simibubi/create/AllInteractionBehaviours.java
+++ b/src/main/java/com/simibubi/create/AllInteractionBehaviours.java
@@ -1,6 +1,7 @@
 package com.simibubi.create;
 
-import com.simibubi.create.content.contraptions.components.structureMovement.LeverMovingInteraction;
+import com.simibubi.create.content.contraptions.components.deployer.DeployerMovingInteraction;
+import com.simibubi.create.content.contraptions.components.structureMovement.interaction.LeverMovingInteraction;
 import com.simibubi.create.content.contraptions.components.structureMovement.MovingInteractionBehaviour;
 
 import net.minecraft.block.Block;
@@ -10,24 +11,25 @@ import net.minecraft.util.ResourceLocation;
 import javax.annotation.Nullable;
 
 import java.util.HashMap;
+import java.util.function.Supplier;
 
 public class AllInteractionBehaviours {
-	private static final HashMap<ResourceLocation, MovingInteractionBehaviour> INTERACT_BEHAVIOURS = new HashMap<>();
+	private static final HashMap<ResourceLocation, Supplier<MovingInteractionBehaviour>> INTERACT_BEHAVIOURS = new HashMap<>();
 
-	public static void addInteractionBehaviour (ResourceLocation loc, MovingInteractionBehaviour behaviour) {
+	public static void addInteractionBehaviour (ResourceLocation loc, Supplier<MovingInteractionBehaviour> behaviour) {
 		if (INTERACT_BEHAVIOURS.containsKey(loc)) {
 			Create.LOGGER.warn("Interaction behaviour for " + loc.toString() + " was overridden");
 		}
 		INTERACT_BEHAVIOURS.put(loc, behaviour);
 	}
 
-	public static void addInteractionBehavioiur (Block block, MovingInteractionBehaviour behaviour) {
+	public static void addInteractionBehavioiur (Block block, Supplier<MovingInteractionBehaviour> behaviour) {
 		addInteractionBehaviour(block.getRegistryName(), behaviour);
 	}
 
 	@Nullable
 	public static MovingInteractionBehaviour of (ResourceLocation loc) {
-		return INTERACT_BEHAVIOURS.getOrDefault(loc, null);
+		return (INTERACT_BEHAVIOURS.get(loc) == null) ? null : INTERACT_BEHAVIOURS.get(loc).get();
 	}
 
 	@Nullable
@@ -40,6 +42,7 @@ public class AllInteractionBehaviours {
 	}
 
 	static void register () {
-		addInteractionBehaviour(Blocks.LEVER.getRegistryName(), new LeverMovingInteraction());
+		addInteractionBehaviour(Blocks.LEVER.getRegistryName(), LeverMovingInteraction::new);
+		addInteractionBehaviour(AllBlocks.DEPLOYER.getId(), DeployerMovingInteraction::new);
 	}
 }

--- a/src/main/java/com/simibubi/create/Create.java
+++ b/src/main/java/com/simibubi/create/Create.java
@@ -89,6 +89,7 @@ public class Create {
 		AllEntityTypes.register();
 		AllTileEntities.register();
 		AllMovementBehaviours.register();
+		AllInteractionBehaviours.register();
 		AllWorldFeatures.register();
 		AllEnchantments.register();
 		AllConfigs.register(ModLoadingContext.get());

--- a/src/main/java/com/simibubi/create/content/contraptions/components/deployer/DeployerMovingInteraction.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/deployer/DeployerMovingInteraction.java
@@ -1,6 +1,7 @@
 package com.simibubi.create.content.contraptions.components.deployer;
 
 import com.simibubi.create.AllItems;
+import com.simibubi.create.Create;
 import com.simibubi.create.content.contraptions.components.structureMovement.AbstractContraptionEntity;
 import com.simibubi.create.content.contraptions.components.structureMovement.MovementContext;
 import com.simibubi.create.content.contraptions.components.structureMovement.MovingInteractionBehaviour;
@@ -9,6 +10,7 @@ import com.simibubi.create.foundation.utility.NBTHelper;
 
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.util.Hand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.gen.feature.template.Template.BlockInfo;
@@ -43,13 +45,10 @@ public class DeployerMovingInteraction extends MovingInteractionBehaviour {
 			);
 		//	Create.LOGGER.info("Changed mode");
 		} else {
-			// this part isn't quite working yet due to being unable to get the fake player from ctx.temporaryData
+			if (ctx.world.isClientSide) return true; // we'll try again on the server side
 			DeployerFakePlayer fake = null;
-			if ( !(ctx.temporaryData instanceof DeployerFakePlayer)) {
-				if (ctx.world instanceof ServerWorld) {
-					ctx.temporaryData = new DeployerFakePlayer((ServerWorld) ctx.world);
-				}
-				else return false;
+			if ( !(ctx.temporaryData instanceof DeployerFakePlayer) && ctx.world instanceof ServerWorld) {
+				ctx.temporaryData = new DeployerFakePlayer((ServerWorld) ctx.world);
 			} else {
 				fake = (DeployerFakePlayer)ctx.temporaryData;
 			}

--- a/src/main/java/com/simibubi/create/content/contraptions/components/deployer/DeployerMovingInteraction.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/deployer/DeployerMovingInteraction.java
@@ -57,6 +57,8 @@ public class DeployerMovingInteraction extends MovingInteractionBehaviour {
 			if (ctx.data.contains("HeldItem")) {
 				player.setItemInHand(activeHand, ItemStack.of(ctx.data.getCompound("HeldItem")));
 				fake.setItemInHand(Hand.MAIN_HAND, heldStack);
+				ctx.tileData.put("HeldItem", heldStack.serializeNBT());
+				ctx.data.put("HeldItem", heldStack.serializeNBT());
 			}
 			ctx.tileData.remove("Inventory");
 			ctx.temporaryData = fake;

--- a/src/main/java/com/simibubi/create/content/contraptions/components/deployer/DeployerMovingInteraction.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/deployer/DeployerMovingInteraction.java
@@ -1,0 +1,72 @@
+package com.simibubi.create.content.contraptions.components.deployer;
+
+import com.simibubi.create.AllItems;
+import com.simibubi.create.content.contraptions.components.structureMovement.AbstractContraptionEntity;
+import com.simibubi.create.content.contraptions.components.structureMovement.MovementContext;
+import com.simibubi.create.content.contraptions.components.structureMovement.MovingInteractionBehaviour;
+
+import com.simibubi.create.foundation.utility.NBTHelper;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Hand;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.gen.feature.template.Template.BlockInfo;
+
+import net.minecraft.world.server.ServerWorld;
+import net.minecraftforge.common.util.Constants;
+
+import org.apache.commons.lang3.tuple.MutablePair;
+
+public class DeployerMovingInteraction extends MovingInteractionBehaviour {
+	@Override
+	public boolean handlePlayerInteraction (PlayerEntity player, Hand activeHand, BlockPos localPos, AbstractContraptionEntity contraptionEntity) {
+		BlockInfo info = contraptionEntity.getContraption().getBlocks().get(localPos);
+		if (info == null) return false;
+		MovementContext ctx = null;
+		int index = -1;
+		for (MutablePair<BlockInfo, MovementContext> pair : contraptionEntity.getContraption().getActors()) {
+			if (info.equals(pair.left)) {
+				ctx = pair.right;
+				index = contraptionEntity.getContraption().getActors().indexOf(pair);
+				break;
+			}
+		}
+		if (ctx == null) return false;
+
+		ItemStack heldStack = player.getItemInHand(activeHand);
+	//	Create.LOGGER.info("<-CTX: " + ctx.data.toString());
+		if (heldStack.getItem().equals(AllItems.WRENCH.get())) {
+			DeployerTileEntity.Mode mode = NBTHelper.readEnum(ctx.tileData, "Mode", DeployerTileEntity.Mode.class);
+			NBTHelper.writeEnum(ctx.tileData, "Mode",
+				mode==DeployerTileEntity.Mode.PUNCH ? DeployerTileEntity.Mode.USE : DeployerTileEntity.Mode.PUNCH
+			);
+		//	Create.LOGGER.info("Changed mode");
+		} else {
+			// this part isn't quite working yet due to being unable to get the fake player from ctx.temporaryData
+			DeployerFakePlayer fake = null;
+			if ( !(ctx.temporaryData instanceof DeployerFakePlayer)) {
+				if (ctx.world instanceof ServerWorld) {
+					ctx.temporaryData = new DeployerFakePlayer((ServerWorld) ctx.world);
+				}
+				else return false;
+			} else {
+				fake = (DeployerFakePlayer)ctx.temporaryData;
+			}
+			if (fake == null) return false;
+			fake.inventory.load(ctx.tileData.getList("Inventory", Constants.NBT.TAG_COMPOUND));
+			if (ctx.data.contains("HeldItem")) {
+				player.setItemInHand(activeHand, ItemStack.of(ctx.data.getCompound("HeldItem")));
+				fake.setItemInHand(Hand.MAIN_HAND, heldStack);
+			}
+			ctx.tileData.remove("Inventory");
+			ctx.temporaryData = fake;
+			//	Create.LOGGER.info("Swapped items");
+		}
+		if (index >= 0) {
+		//	Create.LOGGER.info("->CTX: " + ctx.data.toString());
+			setContraptionActorData(contraptionEntity, index, info, ctx);
+		}
+		return true;
+	}
+}

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/AbstractContraptionEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/AbstractContraptionEntity.java
@@ -165,7 +165,8 @@ public abstract class AbstractContraptionEntity extends Entity implements IEntit
 		int indexOfSeat = contraption.getSeats()
 			.indexOf(localPos);
 		if (indexOfSeat == -1)
-			return false;
+			return contraption.interactors.containsKey(localPos)
+				&& contraption.interactors.get(localPos).handlePlayerInteraction(player, interactionHand, localPos, this);
 
 		// Eject potential existing passenger
 		Entity toDismount = null;

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/LeverMovingInteraction.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/LeverMovingInteraction.java
@@ -1,0 +1,27 @@
+package com.simibubi.create.content.contraptions.components.structureMovement;
+
+import com.simibubi.create.CreateClient;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.state.properties.BlockStateProperties;
+import net.minecraft.util.Hand;
+import net.minecraft.util.SoundCategory;
+import net.minecraft.util.SoundEvents;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.gen.feature.template.Template;
+
+public class LeverMovingInteraction extends MovingInteractionBehaviour {
+	@Override
+	public boolean handlePlayerInteraction(PlayerEntity player, Hand activeHand, BlockPos localPos, AbstractContraptionEntity contraptionEntity) {
+		Template.BlockInfo info = contraptionEntity.contraption.blocks.get(localPos);
+		BlockState newState = info.state.cycle(BlockStateProperties.POWERED);
+		contraptionEntity.contraption.blocks.put(localPos, new Template.BlockInfo(info.pos, newState, info.nbt));
+		player.getCommandSenderWorld().playSound(
+			null, player.blockPosition(), SoundEvents.LEVER_CLICK, SoundCategory.BLOCKS, 0.3f,
+			newState.getValue(BlockStateProperties.POWERED) ? 0.6f : 0.5f
+		);
+		CreateClient.invalidateRenderers();
+		return true;
+	}
+}

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/LeverMovingInteraction.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/LeverMovingInteraction.java
@@ -2,6 +2,8 @@ package com.simibubi.create.content.contraptions.components.structureMovement;
 
 import com.simibubi.create.CreateClient;
 
+import com.simibubi.create.content.contraptions.components.structureMovement.render.ContraptionRenderDispatcher;
+
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.state.properties.BlockStateProperties;
@@ -21,7 +23,8 @@ public class LeverMovingInteraction extends MovingInteractionBehaviour {
 			null, player.blockPosition(), SoundEvents.LEVER_CLICK, SoundCategory.BLOCKS, 0.3f,
 			newState.getValue(BlockStateProperties.POWERED) ? 0.6f : 0.5f
 		);
-		CreateClient.invalidateRenderers();
+		// mark contraption to re-render
+		ContraptionRenderDispatcher.invalidate(contraptionEntity.contraption);
 		return true;
 	}
 }

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/MovingInteractionBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/MovingInteractionBehaviour.java
@@ -1,0 +1,13 @@
+package com.simibubi.create.content.contraptions.components.structureMovement;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.Hand;
+import net.minecraft.util.math.BlockPos;
+
+public abstract class MovingInteractionBehaviour {
+	public MovingInteractionBehaviour () { }
+
+	public boolean handlePlayerInteraction (PlayerEntity player, Hand activeHand, BlockPos localPos, AbstractContraptionEntity contraptionEntity) {
+		return true;
+	}
+}

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/MovingInteractionBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/MovingInteractionBehaviour.java
@@ -1,11 +1,30 @@
 package com.simibubi.create.content.contraptions.components.structureMovement;
 
+import com.simibubi.create.content.contraptions.components.structureMovement.render.ContraptionRenderDispatcher;
+
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.Hand;
 import net.minecraft.util.math.BlockPos;
 
+import net.minecraft.world.gen.feature.template.Template.BlockInfo;
+
+import org.apache.commons.lang3.tuple.MutablePair;
+
 public abstract class MovingInteractionBehaviour {
 	public MovingInteractionBehaviour () { }
+
+	protected void setContraptionActorData (AbstractContraptionEntity contraptionEntity, int index, BlockInfo info, MovementContext ctx) {
+		contraptionEntity.contraption.actors.remove(index);
+		contraptionEntity.contraption.actors.add(index, MutablePair.of(info, ctx));
+		// mark contraption to re-render because we changed actor data
+		ContraptionRenderDispatcher.invalidate(contraptionEntity.contraption);
+	}
+
+	protected void setContraptionBlockData (AbstractContraptionEntity contraptionEntity, BlockPos pos, BlockInfo info) {
+		contraptionEntity.contraption.blocks.put(pos, info);
+		// mark contraption to re-render because we changed block data
+		ContraptionRenderDispatcher.invalidate(contraptionEntity.contraption);
+	}
 
 	public boolean handlePlayerInteraction (PlayerEntity player, Hand activeHand, BlockPos localPos, AbstractContraptionEntity contraptionEntity) {
 		return true;

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/interaction/LeverMovingInteraction.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/interaction/LeverMovingInteraction.java
@@ -1,8 +1,7 @@
-package com.simibubi.create.content.contraptions.components.structureMovement;
+package com.simibubi.create.content.contraptions.components.structureMovement.interaction;
 
-import com.simibubi.create.CreateClient;
-
-import com.simibubi.create.content.contraptions.components.structureMovement.render.ContraptionRenderDispatcher;
+import com.simibubi.create.content.contraptions.components.structureMovement.AbstractContraptionEntity;
+import com.simibubi.create.content.contraptions.components.structureMovement.MovingInteractionBehaviour;
 
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;
@@ -11,20 +10,18 @@ import net.minecraft.util.Hand;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.SoundEvents;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.gen.feature.template.Template;
+import net.minecraft.world.gen.feature.template.Template.BlockInfo;
 
 public class LeverMovingInteraction extends MovingInteractionBehaviour {
 	@Override
 	public boolean handlePlayerInteraction(PlayerEntity player, Hand activeHand, BlockPos localPos, AbstractContraptionEntity contraptionEntity) {
-		Template.BlockInfo info = contraptionEntity.contraption.blocks.get(localPos);
+		BlockInfo info = contraptionEntity.getContraption().getBlocks().get(localPos);
 		BlockState newState = info.state.cycle(BlockStateProperties.POWERED);
-		contraptionEntity.contraption.blocks.put(localPos, new Template.BlockInfo(info.pos, newState, info.nbt));
+		setContraptionBlockData(contraptionEntity, localPos, new BlockInfo(info.pos, newState, info.nbt));
 		player.getCommandSenderWorld().playSound(
 			null, player.blockPosition(), SoundEvents.LEVER_CLICK, SoundCategory.BLOCKS, 0.3f,
 			newState.getValue(BlockStateProperties.POWERED) ? 0.6f : 0.5f
 		);
-		// mark contraption to re-render
-		ContraptionRenderDispatcher.invalidate(contraptionEntity.contraption);
 		return true;
 	}
 }


### PR DESCRIPTION
Framework for giving blocks special functionality while assembled into a contraption
* attempted to emulate the "Actors" framework, with the major difference being these behaviours occur on player interaction rather than on per-block motion
* requires behaviour implementation / registration for vanilla blocks, as those generally try to interact directly with world state
* mod blocks can easily provide hooks for their interaction behaviour

Caveats:
* I haven't attempted a UI behaviour yet, but I believe it should be possible by creating a behaviour that keeps the UI open (vanilla closes them a frame after opening)
* Instead of dedicated Behaviours for specified blocks, I could have used a fake World to simulate the OnUse in general, but I was concerned about the potential complexity of trying to support more complicated things like Pistons or multi-blocks

PR comes with two test / sample Behaviours:
* vanilla's Lever, showcasing a simple block that changes its state ==> Lever flips state when interacted with on the move
* Create's Deployer, operating with tile entity / inventory data ==> Deployer changes state when Wrenched, and otherwise swaps held item

Demo video in Create#devchat: https://discord.com/channels/620934202875183104/706162751642533909/878765495598342175