### PR TITLE
Add config options

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/MovementBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/MovementBehaviour.java
@@ -5,6 +5,7 @@ import javax.annotation.Nullable;
 import com.jozufozu.flywheel.backend.material.MaterialManager;
 import com.simibubi.create.content.contraptions.components.structureMovement.render.ActorInstance;
 import com.simibubi.create.content.contraptions.components.structureMovement.render.ContraptionMatrices;
+import com.simibubi.create.foundation.config.AllConfigs;
 import com.simibubi.create.foundation.utility.worldWrappers.PlacementSimulationWorld;
 
 import net.minecraft.client.renderer.IRenderTypeBuffer;
@@ -33,7 +34,11 @@ public abstract class MovementBehaviour {
 	}
 
 	public void dropItem(MovementContext context, ItemStack stack) {
-		ItemStack remainder = ItemHandlerHelper.insertItem(context.contraption.inventory, stack, false);
+		ItemStack remainder;
+		if (AllConfigs.SERVER.kinetics.moveItemsToStorage.get())
+			remainder = ItemHandlerHelper.insertItem(context.contraption.inventory, stack, false);
+		else
+			remainder = stack;
 		if (remainder.isEmpty())
 			return;
 

--- a/src/main/java/com/simibubi/create/content/contraptions/fluids/FluidTransportBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/fluids/FluidTransportBehaviour.java
@@ -29,14 +29,14 @@ public abstract class FluidTransportBehaviour extends TileEntityBehaviour {
 
 	public static BehaviourType<FluidTransportBehaviour> TYPE = new BehaviourType<>();
 
-	enum UpdatePhase {
+	public enum UpdatePhase {
 		WAIT_FOR_PUMPS, // Do not run Layer II logic while pumps could still be distributing pressure
 		FLIP_FLOWS, // Do not cut any flows until all pipes had a chance to reverse them
 		IDLE; // Operate normally
 	}
 
-	Map<Direction, PipeConnection> interfaces;
-	UpdatePhase phase;
+	public Map<Direction, PipeConnection> interfaces;
+	public UpdatePhase phase;
 
 	public FluidTransportBehaviour(SmartTileEntity te) {
 		super(te);

--- a/src/main/java/com/simibubi/create/content/contraptions/fluids/OpenEndedPipe.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/fluids/OpenEndedPipe.java
@@ -11,6 +11,7 @@ import javax.annotation.Nullable;
 import com.simibubi.create.AllFluids;
 import com.simibubi.create.content.contraptions.fluids.potion.PotionFluidHandler;
 import com.simibubi.create.foundation.advancement.AllTriggers;
+import com.simibubi.create.foundation.config.AllConfigs;
 import com.simibubi.create.foundation.fluid.FluidHelper;
 import com.simibubi.create.foundation.utility.BlockFace;
 
@@ -214,6 +215,10 @@ public class OpenEndedPipe extends FlowSource {
 				.scheduleTick(outputPos, Fluids.WATER, 1);
 			return true;
 		}
+
+		if (!AllConfigs.SERVER.fluids.placeFluidSourceBlocks.get())
+			return true;
+
 		world.setBlock(outputPos, fluid.getFluid()
 			.defaultFluidState()
 			.createLegacyBlock(), 3);

--- a/src/main/java/com/simibubi/create/content/contraptions/fluids/PipeConnection.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/fluids/PipeConnection.java
@@ -32,7 +32,7 @@ import net.minecraftforge.fml.DistExecutor;
 
 public class PipeConnection {
 
-	Direction side;
+	public Direction side;
 
 	// Layer I
 	Couple<Float> pressure; // [inbound, outward]

--- a/src/main/java/com/simibubi/create/content/contraptions/fluids/actors/FluidFillingBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/fluids/actors/FluidFillingBehaviour.java
@@ -137,7 +137,7 @@ public class FluidFillingBehaviour extends FluidManipulationBehaviour {
 				return false;
 			if (simulate)
 				return true;
-			playEffect(world, null, fluid, false);
+			playEffect(world, root, fluid, false);
 			if (evaporate) {
 				int i = root.getX();
 				int j = root.getY();

--- a/src/main/java/com/simibubi/create/content/contraptions/fluids/actors/FluidFillingBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/fluids/actors/FluidFillingBehaviour.java
@@ -7,6 +7,7 @@ import java.util.Objects;
 import java.util.Set;
 
 import com.simibubi.create.foundation.advancement.AllTriggers;
+import com.simibubi.create.foundation.config.AllConfigs;
 import com.simibubi.create.foundation.fluid.FluidHelper;
 import com.simibubi.create.foundation.tileEntity.SmartTileEntity;
 import com.simibubi.create.foundation.tileEntity.behaviour.BehaviourType;
@@ -126,12 +127,13 @@ public class FluidFillingBehaviour extends FluidManipulationBehaviour {
 		int maxBlocks = maxBlocks();
 		boolean evaporate = world.dimensionType()
 			.ultraWarm() && fluid.is(FluidTags.WATER);
+		boolean canPlaceSources = AllConfigs.SERVER.fluids.placeFluidSourceBlocks.get();
 
-		if ((!fillInfinite() && infinite) || evaporate) {
+		if ((!fillInfinite() && infinite) || evaporate || !canPlaceSources) {
 			FluidState fluidState = world.getFluidState(rootPos);
 			boolean equivalentTo = fluidState.getType()
 				.isSame(fluid);
-			if (!equivalentTo && !evaporate)
+			if (!equivalentTo && !evaporate && canPlaceSources)
 				return false;
 			if (simulate)
 				return true;
@@ -142,7 +144,8 @@ public class FluidFillingBehaviour extends FluidManipulationBehaviour {
 				int k = root.getZ();
 				world.playSound(null, i, j, k, SoundEvents.FIRE_EXTINGUISH, SoundCategory.BLOCKS, 0.5F,
 					2.6F + (world.random.nextFloat() - world.random.nextFloat()) * 0.8F);
-			}
+			} else if (!canPlaceSources)
+				AllTriggers.triggerForNearbyPlayers(AllTriggers.HOSE_PULLEY, world, tileEntity.getBlockPos(), 8);
 			return true;
 		}
 

--- a/src/main/java/com/simibubi/create/foundation/config/CFluids.java
+++ b/src/main/java/com/simibubi/create/foundation/config/CFluids.java
@@ -12,6 +12,8 @@ public class CFluids extends ConfigBase {
 	public ConfigBool fillInfinite = b(false, "fillInfinite",Comments.fillInfinite);
 	public ConfigInt hosePulleyRange = i(128, 1, "hosePulleyRange", Comments.blocks, Comments.hosePulleyRange);
 
+	public ConfigBool placeFluidSourceBlocks = b(true, "placeFluidSourceBlocks", Comments.placeFluidSourceBlocks);
+
 	@Override
 	public String getName() {
 		return "fluids";
@@ -29,7 +31,8 @@ public class CFluids extends ConfigBase {
 		static String toDisable = "[-1 to disable this behaviour]";
 		static String hosePulleyBlockThreshold =
 			"The minimum amount of fluid blocks the hose pulley needs to find before deeming it an infinite source.";
-		static String fillInfinite="Does hose pulley poor fluids to the world even if it is an infinite source?";
+		static String fillInfinite = "Does hose pulley pour fluids into infinite sources?";
+		static String placeFluidSourceBlocks = "Can open-ended pipes and hose pulleys place fluid source blocks?";
 	}
 
 }

--- a/src/main/java/com/simibubi/create/foundation/config/CKinetics.java
+++ b/src/main/java/com/simibubi/create/foundation/config/CKinetics.java
@@ -38,6 +38,8 @@ public class CKinetics extends ConfigBase {
 	public ConfigInt maxCartCouplingLength = i(32, 1, "maxCartCouplingLength", Comments.maxCartCouplingLength);
 	public ConfigEnum<SpawnerMovementSetting> spawnerMovement =
 			e(SpawnerMovementSetting.NO_PICKUP, "movableSpawners", Comments.spawnerMovement);
+	public ConfigBool harvestPartiallyGrown = b(false, "harvestPartiallyGrown", Comments.harvestPartiallyGrown);
+	public ConfigBool harvesterReplants = b(true, "harvesterReplants", Comments.harvesterReplants);
 
 	public CStress stressValues = nested(1, CStress::new, Comments.stress);
 
@@ -74,6 +76,8 @@ public class CKinetics extends ConfigBase {
 		static String maxPistonPoles = "Maximum amount of extension poles behind a Mechanical Piston.";
 		static String maxRopeLength = "Max length of rope available off a Rope Pulley.";
 		static String maxCartCouplingLength = "Maximum allowed distance of two coupled minecarts.";
+		static String harvestPartiallyGrown = "Whether harvesters should break crops that aren't fully grown.";
+		static String harvesterReplants = "Whether harvesters should replant crops after harvesting.";
 		static String stats = "Configure speed/capacity levels for requirements and indicators.";
 		static String rpm = "[in Revolutions per Minute]";
 		static String su = "[in Stress Units]";

--- a/src/main/java/com/simibubi/create/foundation/config/CKinetics.java
+++ b/src/main/java/com/simibubi/create/foundation/config/CKinetics.java
@@ -38,6 +38,7 @@ public class CKinetics extends ConfigBase {
 	public ConfigInt maxCartCouplingLength = i(32, 1, "maxCartCouplingLength", Comments.maxCartCouplingLength);
 	public ConfigEnum<SpawnerMovementSetting> spawnerMovement =
 			e(SpawnerMovementSetting.NO_PICKUP, "movableSpawners", Comments.spawnerMovement);
+	public ConfigBool moveItemsToStorage = b(true, "moveItemsToStorage", Comments.moveItemsToStorage);
 	public ConfigBool harvestPartiallyGrown = b(false, "harvestPartiallyGrown", Comments.harvestPartiallyGrown);
 	public ConfigBool harvesterReplants = b(true, "harvesterReplants", Comments.harvesterReplants);
 
@@ -76,6 +77,8 @@ public class CKinetics extends ConfigBase {
 		static String maxPistonPoles = "Maximum amount of extension poles behind a Mechanical Piston.";
 		static String maxRopeLength = "Max length of rope available off a Rope Pulley.";
 		static String maxCartCouplingLength = "Maximum allowed distance of two coupled minecarts.";
+		static String moveItemsToStorage =
+			"Whether items mined or harvested by contraptions should be placed in their mounted storage.";
 		static String harvestPartiallyGrown = "Whether harvesters should break crops that aren't fully grown.";
 		static String harvesterReplants = "Whether harvesters should replant crops after harvesting.";
 		static String stats = "Configure speed/capacity levels for requirements and indicators.";


### PR DESCRIPTION
Added some config options for a modpack I'm working on, defaults are the same as current behavior.

* Make harvesters break partially-grown crops
* Make harvesters not replant crops
* Make mounted storage output-only (contraption can still use stuff in storage, but won't place mined/harvested items in storage)
* Prevent open pipes and hoses from placing fluid source blocks