### PR TITLE
Using DUMMY IChunkStatusListener to prevent NPE

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/utility/worldWrappers/WrappedServerWorld.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/worldWrappers/WrappedServerWorld.java
@@ -3,6 +3,7 @@ package com.simibubi.create.foundation.utility.worldWrappers;
 import java.util.Collections;
 import java.util.List;
 
+import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import mcp.MethodsReturnNonnullByDefault;
@@ -19,9 +20,12 @@ import net.minecraft.util.SoundCategory;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.Util;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.ITickList;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
+import net.minecraft.world.chunk.ChunkStatus;
+import net.minecraft.world.chunk.listener.IChunkStatusListener;
 import net.minecraft.world.server.ServerChunkProvider;
 import net.minecraft.world.server.ServerTickList;
 import net.minecraft.world.server.ServerWorld;
@@ -38,7 +42,19 @@ public class WrappedServerWorld extends ServerWorld {
 
 	public WrappedServerWorld(World world) {
 		// Replace null with world.getChunkProvider().chunkManager.progressListener ? We had null in 1.15
-		super(world.getServer(), Util.backgroundExecutor(), getLevelSaveFromWorld(world), (IServerWorldInfo) world.getLevelData(), world.dimension(), world.dimensionType(), null, ((ServerChunkProvider) world.getChunkSource()).getGenerator(), world.isDebug(), world.getBiomeManager().biomeZoomSeed, Collections.EMPTY_LIST, false); //, world.field_25143);
+		super(world.getServer(), Util.backgroundExecutor(), getLevelSaveFromWorld(world), (IServerWorldInfo) world.getLevelData(), world.dimension(), world.dimensionType(), new IChunkStatusListener() {
+			@Override
+			public void updateSpawnPos(ChunkPos p_219509_1_) {
+			}
+
+			@Override
+			public void onStatusChange(ChunkPos p_219508_1_, @Nullable ChunkStatus p_219508_2_) {
+			}
+
+			@Override
+			public void stop() {
+			}
+		}, ((ServerChunkProvider) world.getChunkSource()).getGenerator(), world.isDebug(), world.getBiomeManager().biomeZoomSeed, Collections.EMPTY_LIST, false); //, world.field_25143);
 		this.world = world;
 	}
 


### PR DESCRIPTION
Using tree fertilizer on saplings from blue_skies will causing NPE:
This patch have been tested and fixed this problem
```
java.lang.NullPointerException: Ticking block entity
	at net.minecraft.world.server.ChunkManager.func_223180_a(ChunkManager.java:490) ~[?:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:A,pl:runtimedistcleaner:A}
	at java.util.concurrent.CompletableFuture$UniCompose.tryFire(CompletableFuture.java:1072) ~[?:?] {}
	at java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:478) ~[?:?] {}
	at net.minecraft.util.concurrent.ThreadTaskExecutor.func_213166_h(ThreadTaskExecutor.java:136) ~[?:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:computing_frames,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at net.minecraft.world.server.ServerChunkProvider$ChunkExecutor.func_213166_h(ServerChunkProvider.java:577) ~[?:?] {re:classloading}
	at net.minecraft.util.concurrent.ThreadTaskExecutor.func_213168_p(ThreadTaskExecutor.java:109) ~[?:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:computing_frames,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at net.minecraft.world.server.ServerChunkProvider$ChunkExecutor.func_213168_p(ServerChunkProvider.java:587) ~[?:?] {re:classloading}
	at net.minecraft.util.concurrent.ThreadTaskExecutor.func_213161_c(ThreadTaskExecutor.java:119) ~[?:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:computing_frames,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at net.minecraft.world.server.ServerChunkProvider.func_212849_a_(ServerChunkProvider.java:154) ~[?:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:performant.mixins.json:world.chunk.ServerChunkProviderThreadsMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.world.World.func_217353_a(World.java:263) ~[?:?] {re:computing_frames,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at net.minecraft.world.IWorldReader.func_217348_a(IWorldReader.java:112) ~[?:?] {re:computing_frames,pl:runtimedistcleaner:A,re:classloading,pl:runtimedistcleaner:A,re:mixin,pl:runtimedistcleaner:A}
	at net.minecraft.world.gen.feature.structure.StructureManager.func_235011_a_(StructureManager.java:34) ~[?:?] {re:mixin,re:classloading}
	at net.minecraft.world.server.ServerWorld.func_241827_a(ServerWorld.java:1643) ~[?:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,xf:fml:forgeendertech:coremod,pl:mixin:APP:performant.mixins.json:world.ServerWorldBlockUpdateMixin,pl:mixin:APP:abnormals_core.mixins.json:ServerWorldMixin,pl:mixin:APP:endergetic.mixins.json:ServerWorldMixin,pl:mixin:APP:performant.mixins.json:world.ServerWorldMixin,pl:mixin:APP:performant.mixins.json:entity.MobServerWorldMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at com.legacy.blue_skies.world.general_features.IStructureRestricted.shouldGenerate(IStructureRestricted.java:20) ~[blue_skies:1.1.3] {re:classloading}
	at com.legacy.blue_skies.world.general_features.AbstractSkyTreeFeature.func_225557_a_(AbstractSkyTreeFeature.java:57) ~[blue_skies:1.1.3] {re:classloading}
	at net.minecraft.world.gen.feature.TreeFeature.func_241855_a(SourceFile:163) ~[?:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:repurposed_structures.mixins.json:LessjungleBushInStructuresMixin,pl:mixin:A}
	at net.minecraft.world.gen.feature.TreeFeature.func_241855_a(SourceFile:37) ~[?:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:repurposed_structures.mixins.json:LessjungleBushInStructuresMixin,pl:mixin:A}
	at net.minecraft.world.gen.feature.ConfiguredFeature.func_242765_a(SourceFile:55) ~[?:?] {re:mixin,re:classloading,pl:mixin:APP:blue_skies.mixins.json:ConfiguredFeatureMixin,pl:mixin:A}
	at net.minecraft.block.trees.Tree.func_230339_a_(Tree.java:30) ~[?:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.block.SaplingBlock.func_226942_a_(SaplingBlock.java:73) ~[?:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.block.SaplingBlock.func_225535_a_(SaplingBlock.java:87) ~[?:?] {re:classloading,pl:accesstransformer:B}
	at com.simibubi.create.content.curiosities.TreeFertilizerItem.func_195939_a(TreeFertilizerItem.java:44) ~[create:mc1.16.5_v0.3.2d] {re:classloading}
	at net.minecraftforge.common.ForgeHooks.onPlaceItemIntoWorld(ForgeHooks.java:652) ~[forge:?] {re:mixin,re:classloading,pl:mixin:APP:dungeons_plus.mixins.json:ForgeHooksMixin,pl:mixin:APP:assets/enigmaticlegacy/enigmaticlegacy.mixins.json:MixinForgeHooks,pl:mixin:A}
	at net.minecraft.item.ItemStack.func_196084_a(ItemStack.java:212) ~[?:?] {re:mixin,pl:runtimedistcleaner:A,re:classloading,xf:fml:placebo:placeboitemusehook,xf:fml:forge:filled_map.4,xf:fml:unionlib:item_stack_patch,xf:fml:forge:itemstack,pl:mixin:APP:performant.mixins.json:item.ItemStackMixin,pl:mixin:APP:itemfilters-common.mixins.json:ItemStackMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at com.simibubi.create.content.contraptions.components.deployer.DeployerHandler.activateInner(DeployerHandler.java:312) ~[create:mc1.16.5_v0.3.2d] {re:classloading}
	at com.simibubi.create.content.contraptions.components.deployer.DeployerHandler.activate(DeployerHandler.java:134) ~[create:mc1.16.5_v0.3.2d] {re:classloading}
	at com.simibubi.create.content.contraptions.components.deployer.DeployerTileEntity.activate(DeployerTileEntity.java:289) ~[create:mc1.16.5_v0.3.2d] {re:classloading}
	at com.simibubi.create.content.contraptions.components.deployer.DeployerTileEntity.func_73660_a(DeployerTileEntity.java:196) ~[create:mc1.16.5_v0.3.2d] {re:classloading}
	at net.minecraft.world.World.func_217391_K(World.java:670) ~[?:?] {re:computing_frames,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at net.minecraft.world.server.ServerWorld.func_72835_b(ServerWorld.java:460) ~[?:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,xf:fml:forgeendertech:coremod,pl:mixin:APP:performant.mixins.json:world.ServerWorldBlockUpdateMixin,pl:mixin:APP:abnormals_core.mixins.json:ServerWorldMixin,pl:mixin:APP:endergetic.mixins.json:ServerWorldMixin,pl:mixin:APP:performant.mixins.json:world.ServerWorldMixin,pl:mixin:APP:performant.mixins.json:entity.MobServerWorldMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:1017) ~[?:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:betterendforge.mixins.json:MinecraftServerMixin,pl:mixin:APP:structure_gel.mixins.json:MinecraftServerMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:333) ~[?:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:926) ~[?:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:betterendforge.mixins.json:MinecraftServerMixin,pl:mixin:APP:structure_gel.mixins.json:MinecraftServerMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.server.MinecraftServer.func_240802_v_(MinecraftServer.java:759) ~[?:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:betterendforge.mixins.json:MinecraftServerMixin,pl:mixin:APP:structure_gel.mixins.json:MinecraftServerMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at net.minecraft.server.MinecraftServer.func_240783_a_(MinecraftServer.java:271) ~[?:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:betterendforge.mixins.json:MinecraftServerMixin,pl:mixin:APP:structure_gel.mixins.json:MinecraftServerMixin,pl:mixin:A,pl:runtimedistcleaner:A}
	at java.lang.Thread.run(Thread.java:829) [?:?] {}
```