### PR TITLE
Add create honey bucket to a forge tag

### DIFF
--- a/src/main/resources/data/forge/tags/items/buckets/honey.json
+++ b/src/main/resources/data/forge/tags/items/buckets/honey.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "create:honey_bucket"
+  ]
+}


### PR DESCRIPTION
Me and a few other bee mods are trying to standardize where honey buckets should go for better mod compat. Hence this pr to put create's honey bucket into forge:buckets/honey item tag. The Bumblezone and Productive Bee's are going to have their honey buckets in that same place too very soon