### PR TITLE
Allows generator blocks to output different speeds in different direc…

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/RotationPropagator.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/RotationPropagator.java
@@ -156,7 +156,7 @@ public class RotationPropagator {
 	}
 
 	private static float getAxisModifier(KineticTileEntity te, Direction direction) {
-		if (!te.hasSource() || !(te instanceof DirectionalShaftHalvesTileEntity))
+		if (!(te.hasSource()||te.isSource()) || !(te instanceof DirectionalShaftHalvesTileEntity))
 			return 1;
 		Direction source = ((DirectionalShaftHalvesTileEntity) te).getSourceFacing();
 


### PR DESCRIPTION
…tions

It is currently impossible to for example make a block that both generates stress and that behaves as a gearshift in that it rotates differently on either side. This simple check should allow that to be possible in a much easier and more intuitive manner.