### PR TITLE
Implemeneted mounted storage API

### DIFF
--- a/src/main/java/com/simibubi/create/AllContraptionStorages.java
+++ b/src/main/java/com/simibubi/create/AllContraptionStorages.java
@@ -1,0 +1,41 @@
+package com.simibubi.create;
+
+import javax.annotation.Nonnull;
+
+import com.simibubi.create.api.contraption.ContraptionStorageRegistry;
+import com.simibubi.create.content.contraptions.components.storage.CreativeCrateRegistry;
+import com.simibubi.create.content.contraptions.components.storage.FlexCrateRegistry;
+import com.simibubi.create.content.contraptions.components.storage.VanillaStorageRegistry;
+
+import net.minecraftforge.common.util.Lazy;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraftforge.registries.IForgeRegistry;
+
+@Mod.EventBusSubscriber(modid = Create.ID, bus = Mod.EventBusSubscriber.Bus.MOD)
+public class AllContraptionStorages {
+
+	public static Lazy<ContraptionStorageRegistry> ADJUSTABLE_CRATE = ContraptionStorageRegistry.getInstance("create:crate");
+	public static Lazy<ContraptionStorageRegistry> CREATIVE_CRATE = ContraptionStorageRegistry.getInstance("create:creative_crate");
+	public static Lazy<ContraptionStorageRegistry> VANILLA = ContraptionStorageRegistry.getInstance("create:vanilla_storage");
+
+	public static void register(IEventBus modEventBus) {
+		ContraptionStorageRegistry.STORAGES.register(modEventBus);
+	}
+
+	@SubscribeEvent
+	public static void registerModules(@Nonnull RegistryEvent.Register<ContraptionStorageRegistry> event) {
+		IForgeRegistry<ContraptionStorageRegistry> registry = event.getRegistry();
+		ContraptionStorageRegistry.register(registry, "create:crate", FlexCrateRegistry::new);
+		ContraptionStorageRegistry.register(registry, "create:creative_crate", CreativeCrateRegistry::new);
+		ContraptionStorageRegistry.register(registry, "create:vanilla_storage", VanillaStorageRegistry::new);
+	}
+
+	@SubscribeEvent
+	public static void init(final FMLCommonSetupEvent event) {
+		ContraptionStorageRegistry.initCache();
+	}
+}

--- a/src/main/java/com/simibubi/create/Create.java
+++ b/src/main/java/com/simibubi/create/Create.java
@@ -2,6 +2,8 @@ package com.simibubi.create;
 
 import java.util.Random;
 
+import com.simibubi.create.api.contraption.ContraptionStorageRegistry;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -110,6 +112,8 @@ public class Create {
 			.getModEventBus();
 		IEventBus forgeEventBus = MinecraftForge.EVENT_BUS;
 
+		AllContraptionStorages.register(modEventBus);
+
 		modEventBus.addListener(Create::init);
 		modEventBus.addGenericListener(Feature.class, AllWorldFeatures::registerOreFeatures);
 		modEventBus.addGenericListener(Placement.class, AllWorldFeatures::registerDecoratorFeatures);
@@ -132,7 +136,6 @@ public class Create {
 		AllPackets.registerPackets();
 		SchematicInstances.register();
 		BuiltinPotatoProjectileTypes.register();
-
 		CHUNK_UTIL.init();
 
 		event.enqueueWork(() -> {

--- a/src/main/java/com/simibubi/create/api/contraption/ContraptionItemStackHandler.java
+++ b/src/main/java/com/simibubi/create/api/contraption/ContraptionItemStackHandler.java
@@ -1,0 +1,87 @@
+package com.simibubi.create.api.contraption;
+
+import com.simibubi.create.api.contraption.ContraptionStorageRegistry;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.NonNullList;
+import net.minecraft.world.World;
+import net.minecraftforge.items.ItemStackHandler;
+
+public abstract class ContraptionItemStackHandler extends ItemStackHandler {
+
+	/**
+	 * Priority of trash bins that void items
+	 */
+	public static int PRIORITY_TRASH = -10;
+
+	/**
+	 * Priority of item bins that store large quantities of one item type
+	 */
+	public static int PRIORITY_ITEM_BIN = 10;
+
+	/**
+	 * Priority of whitelist trash bins that void only specific set of items
+	 */
+	public static int PRIORITY_WHITELIST_TRASH = 20;
+
+
+	public ContraptionItemStackHandler() {
+	}
+
+	public ContraptionItemStackHandler(int size) {
+		super(size);
+	}
+
+	public ContraptionItemStackHandler(NonNullList<ItemStack> stacks) {
+		super(stacks);
+	}
+
+	/**
+	 * Performs manipulations on Tile Entity when it's being added to the world after contraption disassembly and returns false if default logic of copying items from handler to inventory should be skipped;
+	 *
+	 * @param te Tile Entity being added to the world
+	 * @return false if default create logic should be skipped
+	 */
+	public boolean addStorageToWorld(TileEntity te) {
+		return true;
+	}
+
+	/**
+	 * Returns handler priority - items are inserted first into storages with higher priority
+	 * <br>
+	 * Suggested values:
+	 * <ul>
+	 *     <li>-10 - trash bins</li>
+	 *     <li>0 - default priority</li>
+	 *     <li>1 - enderchest-like storages</li>
+	 *     <li>10 - bin-like storages (high amount of one item type)</li>
+	 *     <li>20 - trash bins with whitelist</li>
+	 * </ul>
+	 *
+	 * @return Handler priority
+	 */
+	public abstract int getPriority();
+
+	/**
+	 * Returns associated {@link ContraptionStorageRegistry}
+	 *
+	 * @return associated registry
+	 */
+	protected abstract ContraptionStorageRegistry registry();
+
+	@Override
+	public CompoundNBT serializeNBT() {
+		CompoundNBT nbt = super.serializeNBT();
+		nbt.putString(ContraptionStorageRegistry.REGISTRY_NAME, registry().getRegistryName().toString());
+		return nbt;
+	}
+
+	/**
+	 * This method is called right after contraption deserialization, and can be used to do word-dependant manipulations upon deserialization
+	 *
+	 * @param world contraption world
+	 */
+	public void applyWorld(World world) {
+	}
+}

--- a/src/main/java/com/simibubi/create/api/contraption/ContraptionStorageRegistry.java
+++ b/src/main/java/com/simibubi/create/api/contraption/ContraptionStorageRegistry.java
@@ -1,0 +1,235 @@
+package com.simibubi.create.api.contraption;
+
+import com.simibubi.create.Create;
+
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.TileEntityType;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.util.Lazy;
+import net.minecraftforge.fml.ModList;
+import net.minecraftforge.items.CapabilityItemHandler;
+import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.ItemStackHandler;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistryEntry;
+import net.minecraftforge.registries.IForgeRegistry;
+import net.minecraftforge.registries.RegistryBuilder;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+import javax.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public abstract class ContraptionStorageRegistry extends ForgeRegistryEntry<ContraptionStorageRegistry> {
+	public static final ItemStackHandler dummyHandler = new ItemStackHandler();
+	public static final DeferredRegister<ContraptionStorageRegistry> STORAGES = DeferredRegister.create(ContraptionStorageRegistry.class, Create.ID);
+	public static final Supplier<IForgeRegistry<ContraptionStorageRegistry>> REGISTRY = STORAGES.makeRegistry("mountable_storage", RegistryBuilder::new);
+	public static final String REGISTRY_NAME = "StorageRegistryId";
+	private static Map<TileEntityType<?>, ContraptionStorageRegistry> tileEntityMappingsCache = null;
+
+	public static void initCache() {
+		if (tileEntityMappingsCache != null) return;
+		tileEntityMappingsCache = new HashMap<>();
+		ContraptionStorageRegistry other;
+		for (ContraptionStorageRegistry registry : REGISTRY.get()) {
+			for (TileEntityType<?> tileEntityType : registry.affectedStorages()) {
+				if ((other = tileEntityMappingsCache.get(tileEntityType)) != null) {
+					if (other.getPriority() == registry.getPriority() && other.getPriority() != Priority.DUMMY) {
+						throw new RegistryConflictException(tileEntityType, other.getClass(), registry.getClass());
+					} else if (!registry.getPriority().isOverwrite(other.getPriority()))
+						continue;
+				}
+
+				tileEntityMappingsCache.put(tileEntityType, registry);
+			}
+		}
+	}
+
+	/**
+	 * Returns registry entry that handles provided entity type, or null if no matching entry found
+	 *
+	 * @param type Type of tile entity
+	 * @return matching registry entry, or null if nothing is found
+	 */
+	@Nullable
+	public static ContraptionStorageRegistry forTileEntity(TileEntityType<?> type) {
+		return tileEntityMappingsCache.get(type);
+	}
+
+	/**
+	 * Helper method to conditionally register handlers. Registers value from {@code supplier} parameter if {@code condition} returns true, otherwise generates new {@link DummyHandler} and registers it
+	 *
+	 * @param registry     registry for entry registering
+	 * @param condition    Loading condition supplier
+	 * @param registryName Name to register the entry under
+	 * @param supplier     Supplier to get the entry
+	 */
+	public static void registerConditionally(IForgeRegistry<ContraptionStorageRegistry> registry, Supplier<Boolean> condition, String registryName, Supplier<ContraptionStorageRegistry> supplier) {
+		ContraptionStorageRegistry entry;
+		if (condition.get()) {
+			entry = supplier.get().setRegistryName(registryName);
+		} else {
+			entry = new DummyHandler().setRegistryName(registryName);
+		}
+		registry.register(entry);
+	}
+
+	/**
+	 * Helper method to conditionally register handlers based on if specified mod is loaded. Registers value from {@code supplier} parameter if specified mod is loaded, otherwise generates new {@link DummyHandler} and registers it
+	 *
+	 * @param registry     registry for entry registering
+	 * @param modid        Required mod ID
+	 * @param registryName Name to register the entry under
+	 * @param supplier     Supplier to get the entry
+	 */
+	public static void registerIfModLoaded(IForgeRegistry<ContraptionStorageRegistry> registry, String modid, String registryName, Supplier<ContraptionStorageRegistry> supplier) {
+		registerConditionally(registry, () -> ModList.get().isLoaded(modid), registryName, supplier);
+	}
+
+	/**
+	 * Helper method to unconditionally register handlers
+	 *
+	 * @param registry     registry for entry registering
+	 * @param registryName Name to register the entry under
+	 * @param supplier     Supplier to get the entry
+	 */
+	public static void register(IForgeRegistry<ContraptionStorageRegistry> registry, String registryName, Supplier<ContraptionStorageRegistry> supplier) {
+		registerConditionally(registry, () -> true, registryName, supplier);
+	}
+
+	/**
+	 * Helper method to get default item handler capability from tile entity
+	 *
+	 * @param te TileEntity to get handler from
+	 * @return IItemHandler from {@link CapabilityItemHandler#ITEM_HANDLER_CAPABILITY} capability
+	 */
+	protected static IItemHandler getHandlerFromDefaultCapability(TileEntity te) {
+		return te.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).orElse(dummyHandler);
+	}
+
+	/**
+	 * Helper method for getting registry instance
+	 *
+	 * @param id registry name
+	 * @return Lazy with given name
+	 */
+	public static Lazy<ContraptionStorageRegistry> getInstance(String id) {
+		return Lazy.of(() -> REGISTRY.get().getValue(new ResourceLocation(id)));
+	}
+
+	/**
+	 * Method for getting registry priority. For additional info see {@link Priority}
+	 *
+	 * @return registry priority
+	 */
+	public abstract Priority getPriority();
+
+	/**
+	 * @return array of Tile Entity types handled by this registry
+	 */
+	public abstract TileEntityType<?>[] affectedStorages();
+
+	/**
+	 * @param te Tile Entity
+	 * @return true if given tile entity can be used as mounted storage
+	 */
+	public boolean canUseAsStorage(TileEntity te) {
+		return true;
+	}
+
+	/**
+	 * @param te original Tile Entity
+	 * @return Item handler to be used in contraption or null if default logic should be used
+	 */
+	public ContraptionItemStackHandler createHandler(TileEntity te) {
+		return null;
+	}
+
+	/**
+	 * Returns {@link  ContraptionItemStackHandler} deserialized from NBT
+	 *
+	 * @param nbt serialized NBT
+	 * @return deserialized handler
+	 */
+	public ContraptionItemStackHandler deserializeHandler(CompoundNBT nbt) {
+		throw new NotImplementedException();
+	}
+
+	/**
+	 * Helper method for deserializing handler from NBT
+	 *
+	 * @param handler handler to deserialize
+	 * @param nbt     serialized NBT
+	 * @return Deserialized handler
+	 */
+	protected final <T extends ContraptionItemStackHandler> T deserializeHandler(T handler, CompoundNBT nbt) {
+		handler.deserializeNBT(nbt);
+		return handler;
+	}
+
+	/**
+	 * Provides world to the contraption upon deserialization
+	 * @param world contraption world
+	 */
+
+	/**
+	 * Registry priority enum
+	 */
+	public enum Priority {
+		/**
+		 * Dummy priority, use this in case if your registry is a dummy and should be overwritten by any better option
+		 */
+		DUMMY {
+			@Override
+			public boolean isOverwrite(Priority other) {
+				return false;
+			}
+		},
+		/**
+		 * Add-on priority, use this if your registry is coming from an add-on to the external mod and should be overwritten if official support is added
+		 */
+		ADDON {
+			@Override
+			public boolean isOverwrite(Priority other) {
+				return other == DUMMY;
+			}
+		},
+		/**
+		 * Native mod priority, use this if your registry is a part of the mod it's adding support to
+		 */
+		NATIVE {
+			@Override
+			public boolean isOverwrite(Priority other) {
+				return other != NATIVE;
+			}
+		};
+
+		public abstract boolean isOverwrite(Priority other);
+	}
+
+	public static class DummyHandler extends ContraptionStorageRegistry {
+		@Override
+		public boolean canUseAsStorage(TileEntity te) {
+			return false;
+		}
+
+		@Override
+		public Priority getPriority() {
+			return Priority.DUMMY;
+		}
+
+		@Override
+		public TileEntityType<?>[] affectedStorages() {
+			return new TileEntityType[0];
+		}
+	}
+
+	public static class RegistryConflictException extends RuntimeException {
+		public RegistryConflictException(TileEntityType<?> teType, Class<? extends ContraptionStorageRegistry> a, Class<? extends ContraptionStorageRegistry> b) {
+			super("Registry conflict: registries " + a.getName() + " and " + b.getName() + " tried to register the same tile entity " + teType.getRegistryName());
+		}
+	}
+}

--- a/src/main/java/com/simibubi/create/content/contraptions/components/storage/CreativeCrateRegistry.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/storage/CreativeCrateRegistry.java
@@ -1,0 +1,29 @@
+package com.simibubi.create.content.contraptions.components.storage;
+
+import com.simibubi.create.AllTileEntities;
+import com.simibubi.create.api.contraption.ContraptionItemStackHandler;
+import com.simibubi.create.api.contraption.ContraptionStorageRegistry;
+import com.simibubi.create.content.logistics.block.inventories.BottomlessItemHandler;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.tileentity.TileEntityType;
+
+public class CreativeCrateRegistry extends ContraptionStorageRegistry {
+	@Override
+	public Priority getPriority() {
+		return Priority.NATIVE;
+	}
+
+	@Override
+	public TileEntityType<?>[] affectedStorages() {
+		return new TileEntityType[]{
+				AllTileEntities.CREATIVE_CRATE.get()
+		};
+	}
+
+	@Override
+	public ContraptionItemStackHandler deserializeHandler(CompoundNBT nbt) {
+		return deserializeHandler(new BottomlessItemHandler(() -> ItemStack.EMPTY), nbt);
+	}
+}

--- a/src/main/java/com/simibubi/create/content/contraptions/components/storage/FlexCrateRegistry.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/storage/FlexCrateRegistry.java
@@ -1,0 +1,43 @@
+package com.simibubi.create.content.contraptions.components.storage;
+
+import com.simibubi.create.AllTileEntities;
+import com.simibubi.create.api.contraption.ContraptionItemStackHandler;
+import com.simibubi.create.api.contraption.ContraptionStorageRegistry;
+import com.simibubi.create.content.logistics.block.inventories.CrateItemHandler;
+import com.simibubi.create.content.logistics.block.inventories.AdjustableCrateBlock;
+
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.TileEntityType;
+
+public class FlexCrateRegistry extends ContraptionStorageRegistry {
+	@Override
+	public Priority getPriority() {
+		return Priority.NATIVE;
+	}
+
+	@Override
+	public TileEntityType<?>[] affectedStorages() {
+		return new TileEntityType[]{
+				AllTileEntities.ADJUSTABLE_CRATE.get()
+		};
+	}
+
+	@Override
+	public ContraptionItemStackHandler createHandler(TileEntity te) {
+		// Split double flexcrates
+		if (te.getBlockState()
+				.getValue(AdjustableCrateBlock.DOUBLE))
+			te.getLevel()
+					.setBlockAndUpdate(te.getBlockPos(), te.getBlockState()
+							.setValue(AdjustableCrateBlock.DOUBLE, false));
+		te.clearCache();
+
+		return super.createHandler(te);
+	}
+
+	@Override
+	public ContraptionItemStackHandler deserializeHandler(CompoundNBT nbt) {
+		return deserializeHandler(new CrateItemHandler(), nbt);
+	}
+}

--- a/src/main/java/com/simibubi/create/content/contraptions/components/storage/VanillaStorageRegistry.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/storage/VanillaStorageRegistry.java
@@ -1,0 +1,41 @@
+package com.simibubi.create.content.contraptions.components.storage;
+
+import com.simibubi.create.api.contraption.ContraptionItemStackHandler;
+import com.simibubi.create.api.contraption.ContraptionStorageRegistry;
+
+import net.minecraft.block.ChestBlock;
+import net.minecraft.state.properties.ChestType;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.TileEntityType;
+
+public class VanillaStorageRegistry extends ContraptionStorageRegistry {
+	@Override
+	public Priority getPriority() {
+		return Priority.NATIVE;
+	}
+
+	@Override
+	public TileEntityType<?>[] affectedStorages() {
+		return new TileEntityType[]{
+				TileEntityType.CHEST,
+				TileEntityType.TRAPPED_CHEST,
+				TileEntityType.BARREL,
+				TileEntityType.SHULKER_BOX,
+		};
+	}
+
+	@Override
+	public ContraptionItemStackHandler createHandler(TileEntity te) {
+		// Split double chests
+		if (te.getType() == TileEntityType.CHEST || te.getType() == TileEntityType.TRAPPED_CHEST) {
+			if (te.getBlockState()
+					.getValue(ChestBlock.TYPE) != ChestType.SINGLE)
+				te.getLevel()
+						.setBlockAndUpdate(te.getBlockPos(), te.getBlockState()
+								.setValue(ChestBlock.TYPE, ChestType.SINGLE));
+			te.clearCache();
+		}
+
+		return super.createHandler(te);
+	}
+}

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/Contraption.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/Contraption.java
@@ -22,15 +22,15 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
-import com.simibubi.create.AllInteractionBehaviours;
-
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 
 import com.jozufozu.flywheel.backend.IFlywheelWorld;
 import com.jozufozu.flywheel.light.GridAlignedBB;
 import com.simibubi.create.AllBlocks;
+import com.simibubi.create.AllInteractionBehaviours;
 import com.simibubi.create.AllMovementBehaviours;
+import com.simibubi.create.api.contraption.ContraptionItemStackHandler;
 import com.simibubi.create.content.contraptions.base.IRotate;
 import com.simibubi.create.content.contraptions.base.KineticTileEntity;
 import com.simibubi.create.content.contraptions.components.actors.SeatBlock;
@@ -256,6 +256,15 @@ public abstract class Contraption {
 		List<IItemHandlerModifiable> list = storage.values()
 			.stream()
 			.map(MountedStorage::getItemHandler)
+			.sorted((a, b) -> {
+				int priorityA = 0;
+				int priorityB = 0;
+				if (a instanceof ContraptionItemStackHandler)
+					priorityA = ((ContraptionItemStackHandler) a).getPriority();
+				if (b instanceof ContraptionItemStackHandler)
+					priorityB = ((ContraptionItemStackHandler) b).getPriority();
+				return -(priorityA - priorityB);
+			})
 			.collect(Collectors.toList());
 		inventory =
 			new ContraptionInvWrapper(Arrays.copyOf(list.toArray(), list.size(), IItemHandlerModifiable[].class));
@@ -719,7 +728,7 @@ public abstract class Contraption {
 
 		storage.clear();
 		NBTHelper.iterateCompoundList(nbt.getList("Storage", NBT.TAG_COMPOUND), c -> storage
-			.put(NBTUtil.readBlockPos(c.getCompound("Pos")), MountedStorage.deserialize(c.getCompound("Data"))));
+			.put(NBTUtil.readBlockPos(c.getCompound("Pos")), MountedStorage.deserialize(world, c.getCompound("Data"))));
 
 		fluidStorage.clear();
 		NBTHelper.iterateCompoundList(nbt.getList("FluidStorage", NBT.TAG_COMPOUND), c -> fluidStorage

--- a/src/main/java/com/simibubi/create/content/logistics/block/inventories/AdjustableCrateTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/inventories/AdjustableCrateTileEntity.java
@@ -19,29 +19,23 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
-import net.minecraftforge.items.ItemStackHandler;
+
+import javax.annotation.Nonnull;
 
 public class AdjustableCrateTileEntity extends CrateTileEntity implements INamedContainerProvider {
 
-	public class Inv extends ItemStackHandler {
-		public Inv() {
-			super(32);
-		}
+	public class Inv extends CrateItemHandler {
 
 		@Override
-		public int getSlotLimit(int slot) {
-			if (slot < allowedAmount / 64)
-				return super.getSlotLimit(slot);
-			else if (slot == allowedAmount / 64)
-				return allowedAmount % 64;
-			return 0;
+		public int getAllowedAmount() {
+			return AdjustableCrateTileEntity.this.allowedAmount;
 		}
 
+		@Nonnull
 		@Override
-		public boolean isItemValid(int slot, ItemStack stack) {
-			if (slot > allowedAmount / 64)
-				return false;
-			return super.isItemValid(slot, stack);
+		public CrateItemHandler setAllowedAmount(int allowedAmount) {
+			AdjustableCrateTileEntity.this.allowedAmount = allowedAmount;
+			return this;
 		}
 
 		@Override

--- a/src/main/java/com/simibubi/create/content/logistics/block/inventories/BottomlessItemHandler.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/inventories/BottomlessItemHandler.java
@@ -4,14 +4,19 @@ import java.util.function.Supplier;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import com.simibubi.create.AllContraptionStorages;
+import com.simibubi.create.api.contraption.ContraptionItemStackHandler;
+import com.simibubi.create.api.contraption.ContraptionStorageRegistry;
+
 import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.items.ItemHandlerHelper;
-import net.minecraftforge.items.ItemStackHandler;
 
 @MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
-public class BottomlessItemHandler extends ItemStackHandler {
+public class BottomlessItemHandler extends ContraptionItemStackHandler {
 
 	private Supplier<ItemStack> suppliedItemStack;
 
@@ -59,5 +64,34 @@ public class BottomlessItemHandler extends ItemStackHandler {
 	@Override
 	public boolean isItemValid(int slot, ItemStack stack) {
 		return true;
+	}
+
+	@Override
+	public CompoundNBT serializeNBT() {
+		CompoundNBT nbt = super.serializeNBT();
+		nbt.put("ProvidedStack", suppliedItemStack.get().serializeNBT());
+		return nbt;
+	}
+
+	@Override
+	public void deserializeNBT(CompoundNBT nbt) {
+		super.deserializeNBT(nbt);
+		ItemStack stack = ItemStack.of(nbt.getCompound("ProvidedStack"));
+		suppliedItemStack = () -> stack;
+	}
+
+	@Override
+	public boolean addStorageToWorld(TileEntity te) {
+		return false;
+	}
+
+	@Override
+	public int getPriority() {
+		return ContraptionItemStackHandler.PRIORITY_TRASH;
+	}
+
+	@Override
+	protected ContraptionStorageRegistry registry() {
+		return AllContraptionStorages.CREATIVE_CRATE.get();
 	}
 }

--- a/src/main/java/com/simibubi/create/content/logistics/block/inventories/CrateItemHandler.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/inventories/CrateItemHandler.java
@@ -1,0 +1,74 @@
+package com.simibubi.create.content.logistics.block.inventories;
+
+import com.simibubi.create.AllContraptionStorages;
+import com.simibubi.create.api.contraption.ContraptionStorageRegistry;
+import com.simibubi.create.api.contraption.ContraptionItemStackHandler;
+
+import mcp.MethodsReturnNonnullByDefault;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompoundNBT;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@MethodsReturnNonnullByDefault
+@ParametersAreNonnullByDefault
+public class CrateItemHandler extends ContraptionItemStackHandler {
+	private int allowedAmount = 0;
+
+	public CrateItemHandler() {
+		super(32);
+	}
+
+	public CrateItemHandler(int allowedAmount) {
+		this();
+		this.allowedAmount = allowedAmount;
+	}
+
+	public int getAllowedAmount() {
+		return allowedAmount;
+	}
+
+	public CrateItemHandler setAllowedAmount(int allowedAmount) {
+		this.allowedAmount = allowedAmount;
+		return this;
+	}
+
+	@Override
+	public int getPriority() {
+		return 0;
+	}
+
+	@Override
+	protected ContraptionStorageRegistry registry() {
+		return AllContraptionStorages.ADJUSTABLE_CRATE.get();
+	}
+
+	@Override
+	public int getSlotLimit(int slot) {
+		if (slot < getAllowedAmount() / 64)
+			return super.getSlotLimit(slot);
+		else if (slot == getAllowedAmount() / 64)
+			return getAllowedAmount() % 64;
+		return 0;
+	}
+
+	@Override
+	public boolean isItemValid(int slot, ItemStack stack) {
+		if (slot > allowedAmount / 64)
+			return false;
+		return super.isItemValid(slot, stack);
+	}
+
+	@Override
+	public CompoundNBT serializeNBT() {
+		CompoundNBT nbt = super.serializeNBT();
+		nbt.putInt("AllowedAmount", getAllowedAmount());
+		return nbt;
+	}
+
+	@Override
+	public void deserializeNBT(CompoundNBT nbt) {
+		super.deserializeNBT(nbt);
+		allowedAmount = nbt.getInt("AllowedAmount");
+	}
+}


### PR DESCRIPTION
Implemented an API to allow other mods to add support for modded storages to be used as a part of moving contraption.
This PR also reduces the amount of hardcoded stuff in MountedStorage.java, moving all storages support to separate classes.
Also introduces priority system for storages on moving contraptions
Example of addon using these API changes can be found in `create-api` branch here: https://github.com/juh9870/MoreMountedStorages/tree/create-api

This also fixes issue with Adjustable Crate losing all custom setting (and possibly leading to voiding of incoming items) after being serialized and deserialized