### PR TITLE
Disconnecting the Furnace Engine from AbstractFurnaceBlock

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/components/flywheel/engine/FurnaceEngineBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/flywheel/engine/FurnaceEngineBlock.java
@@ -33,7 +33,7 @@ public class FurnaceEngineBlock extends EngineBlock implements ITE<FurnaceEngine
 
 	@Override
 	protected boolean isValidBaseBlock(BlockState baseBlock, BlockGetter world, BlockPos pos) {
-		return baseBlock.getBlock() instanceof AbstractFurnaceBlock;
+		return FurnaceEngineModifiers.INSTANCE.getEngineState(baseBlock).isEngine();
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/contraptions/components/flywheel/engine/FurnaceEngineBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/flywheel/engine/FurnaceEngineBlock.java
@@ -33,7 +33,7 @@ public class FurnaceEngineBlock extends EngineBlock implements ITE<FurnaceEngine
 
 	@Override
 	protected boolean isValidBaseBlock(BlockState baseBlock, BlockGetter world, BlockPos pos) {
-		return FurnaceEngineModifiers.INSTANCE.getEngineState(baseBlock).isEngine();
+		return FurnaceEngineModifiers.get().getEngineState(baseBlock).isEngine();
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/contraptions/components/flywheel/engine/FurnaceEngineModifiers.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/flywheel/engine/FurnaceEngineModifiers.java
@@ -54,7 +54,7 @@ public class FurnaceEngineModifiers {
 		
 		/*
 		Example:
-		INSTANCE.register(Blocks.REDSTONE_LAMP.delegate, 1f, 
+		get().register(Blocks.REDSTONE_LAMP.delegate, 1f, 
 			s -> s.getBlock() instanceof RedstoneLampBlock && s.hasProperty(RedstoneLampBlock.LIT) ? 
 				(s.getValue(RedstoneLampBlock.LIT) ? EngineState.ACTIVE : EngineState.VALID) : EngineState.EMPTY);
 		*/

--- a/src/main/java/com/simibubi/create/content/contraptions/components/flywheel/engine/FurnaceEngineModifiers.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/flywheel/engine/FurnaceEngineModifiers.java
@@ -2,9 +2,12 @@ package com.simibubi.create.content.contraptions.components.flywheel.engine;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 
+import net.minecraft.world.level.block.AbstractFurnaceBlock;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.RedstoneLampBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.registries.IRegistryDelegate;
 
@@ -13,20 +16,53 @@ public class FurnaceEngineModifiers {
 	public final static FurnaceEngineModifiers INSTANCE = new FurnaceEngineModifiers();
 
 	protected Map<IRegistryDelegate<Block>, Float> blockModifiers = new HashMap<>();
+	protected Map<IRegistryDelegate<Block>, Function<BlockState, EngineState>> blockActivators = new HashMap<>();
 
 	public void register(IRegistryDelegate<Block> block, float modifier) {
 		this.blockModifiers.put(block, modifier);
 	}
+	
+	public void register(IRegistryDelegate<Block> block, float modifier, Function<BlockState, EngineState> engineState) {
+		this.blockModifiers.put(block, modifier);
+		this.blockActivators.put(block, engineState);
+	}
 
-	public float getModifierOrDefault(BlockState state, float defaultValue) {
+	private float getModifierOrDefault(BlockState state, float defaultValue) {
 		return blockModifiers.getOrDefault(state.getBlock().delegate, defaultValue);
+	}
+	
+	private Function<BlockState, EngineState> getEngineStateOrDefault(BlockState state, Function<BlockState, EngineState> engineState) {
+		return blockActivators.getOrDefault(state.getBlock().delegate, engineState);
 	}
 
 	public float getModifier(BlockState state) {
 		return getModifierOrDefault(state, 1f);
 	}
+	
+	public EngineState getEngineState(BlockState state) {
+		return getEngineStateOrDefault(state, s -> s.getBlock() instanceof AbstractFurnaceBlock && s.hasProperty(AbstractFurnaceBlock.LIT) ? (s.getValue(AbstractFurnaceBlock.LIT) ? EngineState.ACTIVE : EngineState.VALID) : EngineState.EMPTY).apply(state);
+	}
 
 	public static void register() {
 		INSTANCE.register(Blocks.BLAST_FURNACE.delegate, 2f);
+		//INSTANCE.register(Blocks.REDSTONE_LAMP.delegate, 1f, s -> s.getBlock() instanceof RedstoneLampBlock && s.hasProperty(RedstoneLampBlock.LIT) ? (s.getValue(RedstoneLampBlock.LIT) ? EngineState.ACTIVE : EngineState.VALID) : EngineState.EMPTY);
+	}
+	
+	public enum EngineState {
+		EMPTY,
+		VALID,
+		ACTIVE;
+		
+		public boolean isEngine() {
+			return this != EMPTY;
+		}
+		
+		public boolean isActive() {
+			return this == ACTIVE;
+		}
+		
+		public boolean isEmpty() {
+			return this == EMPTY;
+		}
 	}
 }

--- a/src/main/java/com/simibubi/create/content/contraptions/components/flywheel/engine/FurnaceEngineModifiers.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/flywheel/engine/FurnaceEngineModifiers.java
@@ -50,12 +50,14 @@ public class FurnaceEngineModifiers {
 	}
 
 	public static void register() {
-		INSTANCE.register(Blocks.BLAST_FURNACE.delegate, 2f);
+		get().register(Blocks.BLAST_FURNACE.delegate, 2f);
 		
-		// 	Example:
-		//	INSTANCE.register(Blocks.REDSTONE_LAMP.delegate, 1f, 
-		//		s -> s.getBlock() instanceof RedstoneLampBlock && s.hasProperty(RedstoneLampBlock.LIT) ? 
-		//			(s.getValue(RedstoneLampBlock.LIT) ? EngineState.ACTIVE : EngineState.VALID) : EngineState.EMPTY);
+		/*
+		Example:
+		INSTANCE.register(Blocks.REDSTONE_LAMP.delegate, 1f, 
+			s -> s.getBlock() instanceof RedstoneLampBlock && s.hasProperty(RedstoneLampBlock.LIT) ? 
+				(s.getValue(RedstoneLampBlock.LIT) ? EngineState.ACTIVE : EngineState.VALID) : EngineState.EMPTY);
+		*/
 	}
 	
 	public static FurnaceEngineModifiers get() {

--- a/src/main/java/com/simibubi/create/content/contraptions/components/flywheel/engine/FurnaceEngineModifiers.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/flywheel/engine/FurnaceEngineModifiers.java
@@ -7,16 +7,20 @@ import java.util.function.Function;
 import net.minecraft.world.level.block.AbstractFurnaceBlock;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.RedstoneLampBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.registries.IRegistryDelegate;
 
 public class FurnaceEngineModifiers {
 
-	public final static FurnaceEngineModifiers INSTANCE = new FurnaceEngineModifiers();
+	private final static FurnaceEngineModifiers INSTANCE = new FurnaceEngineModifiers();
+	
+	protected FurnaceEngineModifiers() {
+		blockModifiers = new HashMap<>();
+		blockActivators = new HashMap<>();
+	}
 
-	protected Map<IRegistryDelegate<Block>, Float> blockModifiers = new HashMap<>();
-	protected Map<IRegistryDelegate<Block>, Function<BlockState, EngineState>> blockActivators = new HashMap<>();
+	private final Map<IRegistryDelegate<Block>, Float> blockModifiers;
+	private final Map<IRegistryDelegate<Block>, Function<BlockState, EngineState>> blockActivators;
 
 	public void register(IRegistryDelegate<Block> block, float modifier) {
 		this.blockModifiers.put(block, modifier);
@@ -40,12 +44,22 @@ public class FurnaceEngineModifiers {
 	}
 	
 	public EngineState getEngineState(BlockState state) {
-		return getEngineStateOrDefault(state, s -> s.getBlock() instanceof AbstractFurnaceBlock && s.hasProperty(AbstractFurnaceBlock.LIT) ? (s.getValue(AbstractFurnaceBlock.LIT) ? EngineState.ACTIVE : EngineState.VALID) : EngineState.EMPTY).apply(state);
+		return getEngineStateOrDefault(state, 
+				s -> s.getBlock() instanceof AbstractFurnaceBlock && s.hasProperty(AbstractFurnaceBlock.LIT) ? 
+						(s.getValue(AbstractFurnaceBlock.LIT) ? EngineState.ACTIVE : EngineState.VALID) : EngineState.EMPTY).apply(state);
 	}
 
 	public static void register() {
 		INSTANCE.register(Blocks.BLAST_FURNACE.delegate, 2f);
-		//INSTANCE.register(Blocks.REDSTONE_LAMP.delegate, 1f, s -> s.getBlock() instanceof RedstoneLampBlock && s.hasProperty(RedstoneLampBlock.LIT) ? (s.getValue(RedstoneLampBlock.LIT) ? EngineState.ACTIVE : EngineState.VALID) : EngineState.EMPTY);
+		
+		// 	Example:
+		//	INSTANCE.register(Blocks.REDSTONE_LAMP.delegate, 1f, 
+		//		s -> s.getBlock() instanceof RedstoneLampBlock && s.hasProperty(RedstoneLampBlock.LIT) ? 
+		//			(s.getValue(RedstoneLampBlock.LIT) ? EngineState.ACTIVE : EngineState.VALID) : EngineState.EMPTY);
+	}
+	
+	public static FurnaceEngineModifiers get() {
+		return INSTANCE;
 	}
 	
 	public enum EngineState {

--- a/src/main/java/com/simibubi/create/content/contraptions/components/flywheel/engine/FurnaceEngineTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/flywheel/engine/FurnaceEngineTileEntity.java
@@ -22,11 +22,11 @@ public class FurnaceEngineTileEntity extends EngineTileEntity {
 
 	public void updateFurnace() {
 		BlockState state = level.getBlockState(EngineBlock.getBaseBlockPos(getBlockState(), worldPosition));
-		EngineState engineState = FurnaceEngineModifiers.INSTANCE.getEngineState(state);
+		EngineState engineState = FurnaceEngineModifiers.get().getEngineState(state);
 		if (engineState.isEmpty())
 			return;
 
-		float modifier = FurnaceEngineModifiers.INSTANCE.getModifier(state);
+		float modifier = FurnaceEngineModifiers.get().getModifier(state);
 		boolean active = engineState.isActive();
 		float speed = active ? 16 * modifier : 0;
 		float capacity =

--- a/src/main/java/com/simibubi/create/content/contraptions/components/flywheel/engine/FurnaceEngineTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/flywheel/engine/FurnaceEngineTileEntity.java
@@ -1,10 +1,10 @@
 package com.simibubi.create.content.contraptions.components.flywheel.engine;
 
 import com.simibubi.create.AllBlocks;
+import com.simibubi.create.content.contraptions.components.flywheel.engine.FurnaceEngineModifiers.EngineState;
 import com.simibubi.create.foundation.block.BlockStressValues;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.block.AbstractFurnaceBlock;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 
@@ -22,11 +22,12 @@ public class FurnaceEngineTileEntity extends EngineTileEntity {
 
 	public void updateFurnace() {
 		BlockState state = level.getBlockState(EngineBlock.getBaseBlockPos(getBlockState(), worldPosition));
-		if (!(state.getBlock() instanceof AbstractFurnaceBlock))
+		EngineState engineState = FurnaceEngineModifiers.INSTANCE.getEngineState(state);
+		if (engineState.isEmpty())
 			return;
 
 		float modifier = FurnaceEngineModifiers.INSTANCE.getModifier(state);
-		boolean active = state.hasProperty(AbstractFurnaceBlock.LIT) && state.getValue(AbstractFurnaceBlock.LIT);
+		boolean active = engineState.isActive();
 		float speed = active ? 16 * modifier : 0;
 		float capacity =
 			(float) (active ? BlockStressValues.getCapacity(AllBlocks.FURNACE_ENGINE.get())


### PR DESCRIPTION
Adds the ability to register any block as a power source to the furnace engine. This will allow for more flexibility and remove the need to implement AbstractFurnaceBlock and AbstractFurnaceBlockEntity (while retaining compatibility with AbstractFurnaceBlock). This change (or something similar) is required for me to be able to update the Furnace Burner and Crude Burner from Create Crafts & Additions.

Example:
in FurnaceEngineModifiers#register:
`INSTANCE.register(Blocks.REDSTONE_LAMP.delegate, 1f, s -> s.getBlock() instanceof RedstoneLampBlock && s.hasProperty(RedstoneLampBlock.LIT) ? (s.getValue(RedstoneLampBlock.LIT) ? EngineState.ACTIVE : EngineState.VALID) : EngineState.EMPTY);`
would result in this:
https://i.gyazo.com/222cf5a279857d03b333b4463eaafc69.gif