### PR TITLE
Fix Output-Flag for Emptied Fluid in JEI

### DIFF
--- a/src/main/java/com/simibubi/create/compat/jei/category/ItemDrainCategory.java
+++ b/src/main/java/com/simibubi/create/compat/jei/category/ItemDrainCategory.java
@@ -116,7 +116,7 @@ public class ItemDrainCategory extends CreateRecipeCategory<EmptyingRecipe> {
 			.get(0)
 			.getItems());
 
-		fluidStacks.init(0, true, 132, 8);
+		fluidStacks.init(0, false, 132, 8);
 		fluidStacks.set(0, withImprovedVisibility(fluidOutput));
 		itemStacks.init(0, true, 26, 7);
 		itemStacks.set(0, matchingIngredients);


### PR DESCRIPTION
The category for EmptyingRecipe in JEI marks the fluid slot as an input slot, confusing JEI recipe transfer handlers (like AE2).