### PR TITLE
Fix the bug that Funnel cannot pickup stationary item from moving belt

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/relays/belt/transport/BeltInventory.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/relays/belt/transport/BeltInventory.java
@@ -58,10 +58,10 @@ public class BeltInventory {
 			belt.setChanged();
 			belt.sendData();
 		}
-		
+
 		if (belt.getSpeed() == 0)
 			return;
-		
+
 		// Reverse item collection if belt just reversed
 		if (beltMovementPositive != belt.getDirectionAwareBeltMovementSpeed() > 0) {
 			beltMovementPositive = !beltMovementPositive;
@@ -107,7 +107,7 @@ public class BeltInventory {
 			// Don't move if held by processing (client)
 			if (world.isClientSide && currentItem.locked)
 				continue;
-			
+
 			// Don't move if held by external components
 			if (currentItem.lockedExternally) {
 				currentItem.lockedExternally = false;
@@ -149,16 +149,17 @@ public class BeltInventory {
 				if (currentItem.locked)
 					continue;
 			}
-			
+
+
+			// Belt Funnels
+			if (BeltFunnelInteractionHandler.checkForFunnels(this, currentItem, nextOffset))
+				continue;
+
 			if (noMovement)
 				continue;
 
 			// Belt Tunnels
 			if (BeltTunnelInteractionHandler.flapTunnelsAndCheckIfStuck(this, currentItem, nextOffset))
-				continue;
-
-			// Belt Funnels
-			if (BeltFunnelInteractionHandler.checkForFunnels(this, currentItem, nextOffset))
 				continue;
 
 			// Horizontal Crushing Wheels
@@ -243,7 +244,7 @@ public class BeltInventory {
 			belt.sendData();
 			return false;
 		}
-		
+
 		if (noMovement)
 			return false;
 
@@ -449,5 +450,5 @@ public class BeltInventory {
 	public List<TransportedItemStack> getTransportedItems() {
 		return items;
 	}
-	
+
 }


### PR DESCRIPTION
# Bug Description

In `BeltInventory` class, the belt checks actions to perform in the following order:
1. held by processing
2. held by external components
3. if there are items waiting in front
4. move beyond edge
5. item processing
6. ***no movement*** (determined by step 3)
7. belt tunnel
8. ***belt funnel***
9. crushing wheels

The problem it caused is that when there are items waiting in front, it will skip checking the belt funnel. As the result, belt funnels cannot take the item from belt if the item is stuck, even when the belt is moving.

# Solution
I switched the order of 6-7-8 to 8-6-7 so that it checks if it can be picked up by funnel, and then it checks if it is stuck, and then it checks if it can be accepted by tunnels.

# Potential Issue
1. I'm not sure if there is a reason to check tunnel before funnel. If so, checking tunnel might also need to be moved before checking funnel. My fix would allow funnel to have higher priority than tunnel.

2. I'm not sure how much it would affect performance.