### PR TITLE
Fix the bug that overflown deployer with empty held could not be extracted by funnel or hopper

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/item/ItemHelper.java
+++ b/src/main/java/com/simibubi/create/foundation/item/ItemHelper.java
@@ -215,8 +215,6 @@ public class ItemHelper {
 		for (int slot = 0; slot < inv.getSlots(); slot++) {
 			if (extracting.isEmpty()) {
 				ItemStack stackInSlot = inv.getStackInSlot(slot);
-				if (stackInSlot.isEmpty())
-					continue;
 				int maxExtractionCountForItem = amountFunction.apply(stackInSlot);
 				if (maxExtractionCountForItem == 0)
 					continue;
@@ -224,7 +222,8 @@ public class ItemHelper {
 			}
 
 			ItemStack stack = inv.extractItem(slot, maxExtractionCount - extracting.getCount(), true);
-
+			if (stack.isEmpty())
+				continue;
 			if (!test.test(stack))
 				continue;
 			if (!extracting.isEmpty() && !canItemStackAmountsStack(stack, extracting))


### PR DESCRIPTION
***Please read the alternative solution section and evaluate if those solutions are better than this fix***

# Bug Description

When deployer has item overflow, funnel and hopper cannot extract overflown item. However, chute can extract them.

More accurately,
1. funnel cannot extract overflown item when deployer does not hold any item
2. funnel would normally extract overflown item first even when deployer has hand held item, but in some situations the handheld item might be extracted first

# Cause

Both Chute and Funnel use `ItemHelper.extract`, but they use different ones, Chute use the one with fixed amount to extract, while funnel use the one that has stack-to-amount function as parameter. The first one calls `IItemHandler.extractItem` directly, while the second calls `getStackInSlot` first.

Deployer has a slot count of 1 for its interface, however, it has hidden slots (overflow slots) that cannot be accessed externally. Its item handler will return the overflown items first when `extractItem` is called. ***This means that overflown items are always extracted first***

The above 2 mechanics cause that funnel cannot extract overflown items when the deployer does not have handheld item. However, during experiments, it is possible that the handheld item is extracted first. This is because the overflown item is set only when the deployer is fully retracted. Thus, ***if the funnel extracts items while the deployer is going to have overflown item and is in the retracting phase, it will extract the hand held item and make the overflown item unextractable***

# Solution

I move the `isEmpty()` check to call on the `ItemStack` from `extractItem` instead of `getItemInSlot`. By doing so, the behavior is consistent with chute.

# Performance Impact

This would have a negligible effect on performance. Even though more checks are executed this way, it's mostly extracting items on empty slots, which most inventories would return empty stacks directly.

# Potential Issues & Alternative Solutions

This is not the only way to fix it, and since it's misleading, this bug might happen to other logistic mods that check `getItemInSlot` first.

Other solutions include:
1. set the overflow item right after action instead of when it's fully retracted
2. set the overflow item to main slot when main slot is empty

I didn't use these 2 approaches as I'm not sure if changing them would cause other bugs.

# Motivation
Chisel has a block that gives one stack of items when right clicked, with bare hands or not. This bug happens very often with it, and this is the fastest methods to generate items for AE's matter condensor.