### PR TITLE
Allow CopperBlockSet to use different root directories

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/block/CopperBlockSet.java
+++ b/src/main/java/com/simibubi/create/foundation/block/CopperBlockSet.java
@@ -55,18 +55,28 @@ public class CopperBlockSet {
 		new Variant<?>[] { BlockVariant.INSTANCE, SlabVariant.INSTANCE, StairVariant.INSTANCE };
 
 	protected final String name;
+	protected final String generalDirectory; // Leave empty for root folder
 	protected final Variant<?>[] variants;
 	protected final Map<Variant<?>, BlockEntry<?>[]> entries = new HashMap<>();
 	protected final NonNullBiConsumer<DataGenContext<Block, ?>, RegistrateRecipeProvider> mainBlockRecipe;
 	protected final String endTextureName;
 
 	public CopperBlockSet(AbstractRegistrate<?> registrate, String name, String endTextureName, Variant<?>[] variants) {
-		this(registrate, name, endTextureName, variants, NonNullBiConsumer.noop());
+		this(registrate, name, endTextureName, variants, NonNullBiConsumer.noop(), "copper/");
+	}
+
+	public CopperBlockSet(AbstractRegistrate<?> registrate, String name, String endTextureName, Variant<?>[] variants, String generalDirectory) {
+		this(registrate, name, endTextureName, variants, NonNullBiConsumer.noop(), generalDirectory);
+	}
+
+	public CopperBlockSet(AbstractRegistrate<?> registrate, String name, String endTextureName, Variant<?>[] variants, NonNullBiConsumer<DataGenContext<Block, ?>, RegistrateRecipeProvider> mainBlockRecipe) {
+		this(registrate, name, endTextureName, variants, mainBlockRecipe, "copper/");
 	}
 
 	public CopperBlockSet(AbstractRegistrate<?> registrate, String name, String endTextureName, Variant<?>[] variants,
-		NonNullBiConsumer<DataGenContext<Block, ?>, RegistrateRecipeProvider> mainBlockRecipe) {
+		NonNullBiConsumer<DataGenContext<Block, ?>, RegistrateRecipeProvider> mainBlockRecipe, String generalDirectory) {
 		this.name = name;
+		this.generalDirectory = generalDirectory;
 		this.endTextureName = endTextureName;
 		this.variants = variants;
 		this.mainBlockRecipe = mainBlockRecipe;
@@ -129,7 +139,7 @@ public class CopperBlockSet {
 					.requires(Items.HONEYCOMB)
 					.unlockedBy("has_unwaxed", RegistrateRecipeProvider.has(unwaxed))
 					.save(prov, new ResourceLocation(ctx.getId()
-						.getNamespace(), "crafting/copper/" + ctx.getName() + "_from_honeycomb"));
+						.getNamespace(), "crafting/" + generalDirectory + ctx.getName() + "_from_honeycomb"));
 			});
 		}
 
@@ -217,7 +227,7 @@ public class CopperBlockSet {
 			Block block = ctx.get();
 			String path = block.getRegistryName()
 				.getPath();
-			String baseLoc = ModelProvider.BLOCK_FOLDER + "/copper/" + getWeatherStatePrefix(state);
+			String baseLoc = ModelProvider.BLOCK_FOLDER + "/" + blocks.generalDirectory + getWeatherStatePrefix(state);
 			ResourceLocation texture = prov.modLoc(baseLoc + blocks.getName());
 			ResourceLocation endTexture = prov.modLoc(baseLoc + blocks.getEndTextureName());
 			prov.simpleBlock(block, prov.models()
@@ -262,7 +272,7 @@ public class CopperBlockSet {
 			ResourceLocation fullModel =
 				prov.modLoc(ModelProvider.BLOCK_FOLDER + "/" + getWeatherStatePrefix(state) + blocks.getName());
 
-			String baseLoc = ModelProvider.BLOCK_FOLDER + "/copper/" + getWeatherStatePrefix(state);
+			String baseLoc = ModelProvider.BLOCK_FOLDER + "/" + blocks.generalDirectory + getWeatherStatePrefix(state);
 			ResourceLocation texture = prov.modLoc(baseLoc + blocks.getName());
 			ResourceLocation endTexture = prov.modLoc(baseLoc + blocks.getEndTextureName());
 
@@ -317,7 +327,7 @@ public class CopperBlockSet {
 		@Override
 		public void generateBlockState(DataGenContext<Block, StairBlock> ctx, RegistrateBlockstateProvider prov,
 			CopperBlockSet blocks, WeatherState state, boolean waxed) {
-			String baseLoc = ModelProvider.BLOCK_FOLDER + "/copper/" + getWeatherStatePrefix(state);
+			String baseLoc = ModelProvider.BLOCK_FOLDER + "/" + blocks.generalDirectory + getWeatherStatePrefix(state);
 			ResourceLocation texture = prov.modLoc(baseLoc + blocks.getName());
 			ResourceLocation endTexture = prov.modLoc(baseLoc + blocks.getEndTextureName());
 			prov.stairsBlock(ctx.get(), texture, endTexture, endTexture);


### PR DESCRIPTION
CopperBlockSet has many useful functionalities that addons could use for their own metals that also oxidize. (For example, our addon Create: Alloyed adds bronze stuff that oxidizes similarly to copper). 

The problem is that the class defaults to using the 'copper' directory. So I added a new variable 'generalDirectory' that specifies where anything related to the class goes. 

For instance if I created a new material (say, "oxidizium") that should oxidize, I'd be able to use the CopperBlockSet class to handle most of the heavy lifting, and also have the generated data end up in ".../oxidizium/...".