### PR TITLE
Change the way CopperBlockSet generates block models + condition support for Mech. Crafting

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/block/CopperBlockSet.java
+++ b/src/main/java/com/simibubi/create/foundation/block/CopperBlockSet.java
@@ -4,6 +4,7 @@ import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Supplier;
 
 import org.apache.commons.lang3.ArrayUtils;
@@ -228,10 +229,18 @@ public class CopperBlockSet {
 			String path = block.getRegistryName()
 				.getPath();
 			String baseLoc = ModelProvider.BLOCK_FOLDER + "/" + blocks.generalDirectory + getWeatherStatePrefix(state);
+
 			ResourceLocation texture = prov.modLoc(baseLoc + blocks.getName());
-			ResourceLocation endTexture = prov.modLoc(baseLoc + blocks.getEndTextureName());
-			prov.simpleBlock(block, prov.models()
-				.cubeColumn(path, texture, endTexture));
+			if (Objects.equals(blocks.getName(), blocks.getEndTextureName())) {
+				// End texture and base texture are equal, so we should use cube_all.
+				prov.simpleBlock(block, prov.models().cubeAll(path, texture));
+			} else {
+				// End texture and base texture aren't equal, so we should use cube_column.
+				ResourceLocation endTexture = prov.modLoc(baseLoc + blocks.getEndTextureName());
+				prov.simpleBlock(block, prov.models()
+						.cubeColumn(path, texture, endTexture));
+			}
+
 		}
 
 		@Override

--- a/src/main/java/com/simibubi/create/foundation/data/recipe/MechanicalCraftingRecipeBuilder.java
+++ b/src/main/java/com/simibubi/create/foundation/data/recipe/MechanicalCraftingRecipeBuilder.java
@@ -1,5 +1,6 @@
 package com.simibubi.create.foundation.data.recipe;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -15,6 +16,8 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.simibubi.create.AllRecipeTypes;
 
+import com.simibubi.create.content.contraptions.processing.ProcessingRecipeBuilder;
+
 import net.minecraft.data.recipes.FinishedRecipe;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.SetTag;
@@ -22,6 +25,10 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.ItemLike;
+import net.minecraftforge.common.crafting.CraftingHelper;
+import net.minecraftforge.common.crafting.conditions.ICondition;
+import net.minecraftforge.common.crafting.conditions.ModLoadedCondition;
+import net.minecraftforge.common.crafting.conditions.NotCondition;
 import net.minecraftforge.registries.ForgeRegistries;
 
 public class MechanicalCraftingRecipeBuilder {
@@ -31,11 +38,13 @@ public class MechanicalCraftingRecipeBuilder {
 	private final List<String> pattern = Lists.newArrayList();
 	private final Map<Character, Ingredient> key = Maps.newLinkedHashMap();
 	private boolean acceptMirrored;
+	private List<ICondition> recipeConditions;
 
 	public MechanicalCraftingRecipeBuilder(ItemLike p_i48261_1_, int p_i48261_2_) {
 		result = p_i48261_1_.asItem();
 		count = p_i48261_2_;
 		acceptMirrored = true;
+		recipeConditions = new ArrayList<>();
 	}
 
 	/**
@@ -127,7 +136,7 @@ public class MechanicalCraftingRecipeBuilder {
 	public void build(Consumer<FinishedRecipe> p_200467_1_, ResourceLocation p_200467_2_) {
 		validate(p_200467_2_);
 		p_200467_1_
-			.accept(new MechanicalCraftingRecipeBuilder.Result(p_200467_2_, result, count, pattern, key, acceptMirrored));
+			.accept(new MechanicalCraftingRecipeBuilder.Result(p_200467_2_, result, count, pattern, key, acceptMirrored, recipeConditions));
 	}
 
 	/**
@@ -156,6 +165,19 @@ public class MechanicalCraftingRecipeBuilder {
 		}
 	}
 
+	public MechanicalCraftingRecipeBuilder whenModLoaded(String modid) {
+		return withCondition(new ModLoadedCondition(modid));
+	}
+
+	public MechanicalCraftingRecipeBuilder whenModMissing(String modid) {
+		return withCondition(new NotCondition(new ModLoadedCondition(modid)));
+	}
+
+	public MechanicalCraftingRecipeBuilder withCondition(ICondition condition) {
+		recipeConditions.add(condition);
+		return this;
+	}
+
 	public class Result implements FinishedRecipe {
 		private final ResourceLocation id;
 		private final Item result;
@@ -163,15 +185,17 @@ public class MechanicalCraftingRecipeBuilder {
 		private final List<String> pattern;
 		private final Map<Character, Ingredient> key;
 		private final boolean acceptMirrored;
+		private List<ICondition> recipeConditions;
 
 		public Result(ResourceLocation p_i48271_2_, Item p_i48271_3_, int p_i48271_4_, List<String> p_i48271_6_,
-			Map<Character, Ingredient> p_i48271_7_, boolean asymmetrical) {
+			Map<Character, Ingredient> p_i48271_7_, boolean asymmetrical, List<ICondition> recipeConditions) {
 			this.id = p_i48271_2_;
 			this.result = p_i48271_3_;
 			this.count = p_i48271_4_;
 			this.pattern = p_i48271_6_;
 			this.key = p_i48271_7_;
 			this.acceptMirrored = asymmetrical;
+			this.recipeConditions = recipeConditions;
 		}
 
 		public void serializeRecipeData(JsonObject p_218610_1_) {
@@ -194,6 +218,13 @@ public class MechanicalCraftingRecipeBuilder {
 
 			p_218610_1_.add("result", jsonobject1);
 			p_218610_1_.addProperty("acceptMirrored", acceptMirrored);
+
+			if (recipeConditions.isEmpty())
+				return;
+
+			JsonArray conds = new JsonArray();
+			recipeConditions.forEach(c -> conds.add(CraftingHelper.serialize(c)));
+			p_218610_1_.add("conditions", conds);
 		}
 
 		public RecipeSerializer<?> getType() {

--- a/src/main/java/com/simibubi/create/foundation/data/recipe/MechanicalCraftingRecipeBuilder.java
+++ b/src/main/java/com/simibubi/create/foundation/data/recipe/MechanicalCraftingRecipeBuilder.java
@@ -1,6 +1,5 @@
 package com.simibubi.create.foundation.data.recipe;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -16,8 +15,6 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.simibubi.create.AllRecipeTypes;
 
-import com.simibubi.create.content.contraptions.processing.ProcessingRecipeBuilder;
-
 import net.minecraft.data.recipes.FinishedRecipe;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.SetTag;
@@ -25,10 +22,6 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.ItemLike;
-import net.minecraftforge.common.crafting.CraftingHelper;
-import net.minecraftforge.common.crafting.conditions.ICondition;
-import net.minecraftforge.common.crafting.conditions.ModLoadedCondition;
-import net.minecraftforge.common.crafting.conditions.NotCondition;
 import net.minecraftforge.registries.ForgeRegistries;
 
 public class MechanicalCraftingRecipeBuilder {
@@ -38,13 +31,11 @@ public class MechanicalCraftingRecipeBuilder {
 	private final List<String> pattern = Lists.newArrayList();
 	private final Map<Character, Ingredient> key = Maps.newLinkedHashMap();
 	private boolean acceptMirrored;
-	private List<ICondition> recipeConditions;
 
 	public MechanicalCraftingRecipeBuilder(ItemLike p_i48261_1_, int p_i48261_2_) {
 		result = p_i48261_1_.asItem();
 		count = p_i48261_2_;
 		acceptMirrored = true;
-		recipeConditions = new ArrayList<>();
 	}
 
 	/**
@@ -136,7 +127,7 @@ public class MechanicalCraftingRecipeBuilder {
 	public void build(Consumer<FinishedRecipe> p_200467_1_, ResourceLocation p_200467_2_) {
 		validate(p_200467_2_);
 		p_200467_1_
-			.accept(new MechanicalCraftingRecipeBuilder.Result(p_200467_2_, result, count, pattern, key, acceptMirrored, recipeConditions));
+			.accept(new MechanicalCraftingRecipeBuilder.Result(p_200467_2_, result, count, pattern, key, acceptMirrored));
 	}
 
 	/**
@@ -165,19 +156,6 @@ public class MechanicalCraftingRecipeBuilder {
 		}
 	}
 
-	public MechanicalCraftingRecipeBuilder whenModLoaded(String modid) {
-		return withCondition(new ModLoadedCondition(modid));
-	}
-
-	public MechanicalCraftingRecipeBuilder whenModMissing(String modid) {
-		return withCondition(new NotCondition(new ModLoadedCondition(modid)));
-	}
-
-	public MechanicalCraftingRecipeBuilder withCondition(ICondition condition) {
-		recipeConditions.add(condition);
-		return this;
-	}
-
 	public class Result implements FinishedRecipe {
 		private final ResourceLocation id;
 		private final Item result;
@@ -185,17 +163,15 @@ public class MechanicalCraftingRecipeBuilder {
 		private final List<String> pattern;
 		private final Map<Character, Ingredient> key;
 		private final boolean acceptMirrored;
-		private List<ICondition> recipeConditions;
 
 		public Result(ResourceLocation p_i48271_2_, Item p_i48271_3_, int p_i48271_4_, List<String> p_i48271_6_,
-			Map<Character, Ingredient> p_i48271_7_, boolean asymmetrical, List<ICondition> recipeConditions) {
+			Map<Character, Ingredient> p_i48271_7_, boolean asymmetrical) {
 			this.id = p_i48271_2_;
 			this.result = p_i48271_3_;
 			this.count = p_i48271_4_;
 			this.pattern = p_i48271_6_;
 			this.key = p_i48271_7_;
 			this.acceptMirrored = asymmetrical;
-			this.recipeConditions = recipeConditions;
 		}
 
 		public void serializeRecipeData(JsonObject p_218610_1_) {
@@ -218,13 +194,6 @@ public class MechanicalCraftingRecipeBuilder {
 
 			p_218610_1_.add("result", jsonobject1);
 			p_218610_1_.addProperty("acceptMirrored", acceptMirrored);
-
-			if (recipeConditions.isEmpty())
-				return;
-
-			JsonArray conds = new JsonArray();
-			recipeConditions.forEach(c -> conds.add(CraftingHelper.serialize(c)));
-			p_218610_1_.add("conditions", conds);
 		}
 
 		public RecipeSerializer<?> getType() {


### PR DESCRIPTION
If the specified name and end texture name are equal, then generate a cube_all model instead. This is just to make the code more readable, since having a cube_column model file where the textures are the same would be confusing.