### PR TITLE
Update bug_report.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -49,6 +49,7 @@ body:
             label: Mod Version
             description: The version of the mod you were using when the bug occured
             options:
+                - "0.4.0d"
                 - "0.4.0c"
                 - "0.4.0b"
                 - "0.4.0a"


### PR DESCRIPTION
Add "0.4.0d" to Mod Version options list.

It pains me that this can't be done automatically upon a version bump.