### PR TITLE
Fixed using ShapedRecipe instead of IShapedRecipe and restrictive shapeless check.

### DIFF
--- a/src/main/java/com/simibubi/create/compat/jei/CreateJEI.java
+++ b/src/main/java/com/simibubi/create/compat/jei/CreateJEI.java
@@ -31,6 +31,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.*;
 import net.minecraft.world.level.ItemLike;
+import net.minecraftforge.common.crafting.IShapedRecipe;
 import net.minecraftforge.fml.ModList;
 
 import javax.annotation.Nonnull;
@@ -94,7 +95,7 @@ public class CreateJEI implements IModPlugin {
 			.build(),
 
 	autoShapeless = register("automatic_shapeless", MixingCategory::autoShapeless)
-			.recipes(r -> r.getSerializer() == RecipeSerializer.SHAPELESS_RECIPE && r.getIngredients()
+			.recipes(r -> r instanceof CraftingRecipe && !(r instanceof IShapedRecipe<?>) && r.getIngredients()
 							.size() > 1 && !MechanicalPressTileEntity.canCompress(r) && !AllRecipeTypes.isManualRecipe(r),
 					BasinRecipe::convertShapeless)
 			.catalyst(AllBlocks.MECHANICAL_MIXER::get)
@@ -173,11 +174,11 @@ public class CreateJEI implements IModPlugin {
 			.build(),
 
 	autoShaped = register("automatic_shaped", MechanicalCraftingCategory::new)
-			.recipes(r -> r.getSerializer() == RecipeSerializer.SHAPELESS_RECIPE && r.getIngredients()
+			.recipes(r -> r instanceof CraftingRecipe && !(r instanceof IShapedRecipe<?>) && r.getIngredients()
 					.size() == 1)
 			.recipes(r -> (r.getType() == RecipeType.CRAFTING
-					&& r.getType() != AllRecipeTypes.MECHANICAL_CRAFTING.getType()) && (r instanceof ShapedRecipe)
-					&& !AllRecipeTypes.isManualRecipe(r))
+					   && r.getType() != AllRecipeTypes.MECHANICAL_CRAFTING.getType()) && (r instanceof IShapedRecipe<?>)
+					  && !AllRecipeTypes.isManualRecipe(r))
 			.catalyst(AllBlocks.MECHANICAL_CRAFTER::get)
 			.enableWhen(c -> c.allowRegularCraftingInCrafter)
 			.build(),

--- a/src/main/java/com/simibubi/create/compat/jei/category/MechanicalCraftingCategory.java
+++ b/src/main/java/com/simibubi/create/compat/jei/category/MechanicalCraftingCategory.java
@@ -28,6 +28,7 @@ import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.crafting.CraftingRecipe;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.ShapedRecipe;
+import net.minecraftforge.common.crafting.IShapedRecipe;
 
 public class MechanicalCraftingCategory extends CreateRecipeCategory<CraftingRecipe> {
 
@@ -86,11 +87,11 @@ public class MechanicalCraftingCategory extends CreateRecipeCategory<CraftingRec
 	}
 
 	private static int getWidth(CraftingRecipe recipe) {
-		return recipe instanceof ShapedRecipe ? ((ShapedRecipe) recipe).getWidth() : 1;
+		return recipe instanceof IShapedRecipe<?> ? ((IShapedRecipe<?>) recipe).getRecipeWidth() : 1;
 	}
 
 	private static int getHeight(CraftingRecipe recipe) {
-		return recipe instanceof ShapedRecipe ? ((ShapedRecipe) recipe).getHeight() : 1;
+		return recipe instanceof IShapedRecipe<?> ? ((IShapedRecipe<?>) recipe).getRecipeHeight() : 1;
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/contraptions/components/mixer/MechanicalMixerTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/mixer/MechanicalMixerTileEntity.java
@@ -32,6 +32,7 @@ import net.minecraft.sounds.SoundSource;
 import net.minecraft.util.Mth;
 import net.minecraft.world.Container;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.CraftingRecipe;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.block.entity.BlockEntityType;
@@ -40,6 +41,7 @@ import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.common.crafting.IShapedRecipe;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 
@@ -237,10 +239,10 @@ public class MechanicalMixerTileEntity extends BasinOperatingTileEntity {
 
 	@Override
 	protected <C extends Container> boolean matchStaticFilters(Recipe<C> r) {
-		return ((r.getSerializer() == RecipeSerializer.SHAPELESS_RECIPE
-			&& AllConfigs.SERVER.recipes.allowShapelessInMixer.get() && r.getIngredients()
+		return ((r instanceof CraftingRecipe && !(r instanceof IShapedRecipe<?>)
+				 && AllConfigs.SERVER.recipes.allowShapelessInMixer.get() && r.getIngredients()
 				.size() > 1
-			&& !MechanicalPressTileEntity.canCompress(r)) && !AllRecipeTypes.isManualRecipe(r)
+				 && !MechanicalPressTileEntity.canCompress(r)) && !AllRecipeTypes.isManualRecipe(r)
 			|| r.getType() == AllRecipeTypes.MIXING.getType());
 	}
 
@@ -289,9 +291,9 @@ public class MechanicalMixerTileEntity extends BasinOperatingTileEntity {
 
 		// SoundEvents.BLOCK_STONE_BREAK
 		boolean slow = Math.abs(getSpeed()) < 65;
-		if (slow && AnimationTickHolder.getTicks() % 2 == 0) 
+		if (slow && AnimationTickHolder.getTicks() % 2 == 0)
 			return;
-		if (runningTicks == 20) 
+		if (runningTicks == 20)
 			AllSoundEvents.MIXING.playAt(level, worldPosition, .75f, 1, true);
 	}
 

--- a/src/main/java/com/simibubi/create/content/curiosities/tools/BlueprintItem.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/tools/BlueprintItem.java
@@ -28,6 +28,7 @@ import net.minecraft.world.item.crafting.Ingredient.Value;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.ShapedRecipe;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.crafting.IShapedRecipe;
 import net.minecraftforge.common.crafting.MultiItemValue;
 import net.minecraftforge.fml.util.ObfuscationReflectionHelper;
 import net.minecraftforge.items.ItemStackHandler;
@@ -79,12 +80,12 @@ public class BlueprintItem extends Item {
 			inv.setStackInSlot(i, ItemStack.EMPTY);
 		inv.setStackInSlot(9, recipe.getResultItem());
 
-		if (recipe instanceof ShapedRecipe) {
-			ShapedRecipe shapedRecipe = (ShapedRecipe) recipe;
-			for (int row = 0; row < shapedRecipe.getHeight(); row++)
-				for (int col = 0; col < shapedRecipe.getWidth(); col++)
+		if (recipe instanceof IShapedRecipe) {
+			IShapedRecipe<?> shapedRecipe = (IShapedRecipe<?>) recipe;
+			for (int row = 0; row < shapedRecipe.getRecipeHeight(); row++)
+				for (int col = 0; col < shapedRecipe.getRecipeWidth(); col++)
 					inv.setStackInSlot(row * 3 + col,
-							convertIngredientToFilter(ingredients.get(row * shapedRecipe.getWidth() + col)));
+							convertIngredientToFilter(ingredients.get(row * shapedRecipe.getRecipeWidth() + col)));
 		} else {
 			for (int i = 0; i < ingredients.size(); i++)
 				inv.setStackInSlot(i, convertIngredientToFilter(ingredients.get(i)));


### PR DESCRIPTION
`IShapedRecipe` is a Forge interface that is meant to allow mods to have non `ShapedRecipe` shaped recipes.

The vanilla `ShapedRecipe` class also implements the interface.

This PR does make a potentially controversial assumption though:
```java
r instanceof CraftingRecipe && !(r instanceof IShapedRecipe<?>)
```

This PR assumes that if a recipe is a CraftingRecipe, but is *not* an `IShapedRecipe`, that it is shapeless, on paper this makes sense, and I can't personally think of any use cases where this assumptions fails.


This should fix recipes from any mod that does not use the vanilla `ShapedRecipe` or Shapeless Serializer for their recipes, not only CraftTweaker.