### PR TITLE
[Compatibility] Cooking from other mods

### DIFF
--- a/src/generated/resources/data/forge/tags/items/chocolatebar/chocolatebar.json
+++ b/src/generated/resources/data/forge/tags/items/chocolatebar/chocolatebar.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "create:bar_of_chocolate"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/chocolates.json
+++ b/src/generated/resources/data/forge/tags/items/chocolates.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "create:bar_of_chocolate"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/dough/dough.json
+++ b/src/generated/resources/data/forge/tags/items/dough/dough.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "create:dough"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/doughs.json
+++ b/src/generated/resources/data/forge/tags/items/doughs.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "create:dough"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/flour.json
+++ b/src/generated/resources/data/forge/tags/items/flour.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "create:wheat_flour"
+  ]
+}


### PR DESCRIPTION
# Description
What about forge/tags for food? Now they are! 
At least for chocolate, flour and dough

> ![2022-03-06_02 32 44](https://user-images.githubusercontent.com/65350193/156903457-2d1227be-fd26-4550-9fd9-b5396b2b0917.png)
> Croptopia mod as an example

# Contents
- Added compatibility with Croptopia crafting.
- Added compatibility with Pam's HarvestCraft 2 crafting. 