### PR TITLE
Improve the performance of MechanicalPressTileEntity#canCompress

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/components/press/MechanicalPressTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/press/MechanicalPressTileEntity.java
@@ -3,8 +3,9 @@ package com.simibubi.create.content.contraptions.components.press;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.simibubi.create.AllBlocks;
 import com.simibubi.create.AllRecipeTypes;
 import com.simibubi.create.AllSoundEvents;
@@ -344,22 +345,19 @@ public class MechanicalPressTileEntity extends BasinOperatingTileEntity {
 		return AllRecipeTypes.PRESSING.find(pressingInv, level);
 	}
 
-	private static final List<ResourceLocation> RECIPE_DENY_LIST =
-		ImmutableList.of(new ResourceLocation("occultism", "spirit_trade"), new ResourceLocation("occultism", "ritual"));
+	private static final Set<ResourceLocation> RECIPE_DENY_SET =
+		ImmutableSet.of(new ResourceLocation("occultism", "spirit_trade"), new ResourceLocation("occultism", "ritual"));
 
 	public static <C extends Container> boolean canCompress(Recipe<C> recipe) {
-		NonNullList<Ingredient> ingredients = recipe.getIngredients();
-		if (!(recipe instanceof CraftingRecipe))
+		if (!(recipe instanceof CraftingRecipe) || !AllConfigs.SERVER.recipes.allowShapedSquareInPress.get())
 			return false;
-		
+
 		RecipeSerializer<?> serializer = recipe.getSerializer();
-		for (ResourceLocation denied : RECIPE_DENY_LIST) 
-			if (serializer != null && denied.equals(serializer.getRegistryName()))
-				return false;
-		
-		return AllConfigs.SERVER.recipes.allowShapedSquareInPress.get()
-			&& (ingredients.size() == 4 || ingredients.size() == 9) && ItemHelper.condenseIngredients(ingredients)
-				.size() == 1;
+		if (serializer != null && RECIPE_DENY_SET.contains(serializer.getRegistryName()))
+			return false;
+
+		NonNullList<Ingredient> ingredients = recipe.getIngredients();
+		return (ingredients.size() == 4 || ingredients.size() == 9) && ItemHelper.matchAllIngredients(ingredients);
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/foundation/item/ItemHelper.java
+++ b/src/main/java/com/simibubi/create/foundation/item/ItemHelper.java
@@ -118,8 +118,12 @@ public class ItemHelper {
 	}
 
 	public static boolean matchIngredients(Ingredient i1, Ingredient i2) {
+		if (i1 == i2)
+			return true;
 		ItemStack[] stacks1 = i1.getItems();
 		ItemStack[] stacks2 = i2.getItems();
+		if (stacks1 == stacks2)
+			return true;
 		if (stacks1.length == stacks2.length) {
 			for (int i = 0; i < stacks1.length; i++)
 				if (!ItemStack.isSame(stacks1[i], stacks2[i]))
@@ -127,6 +131,16 @@ public class ItemHelper {
 			return true;
 		}
 		return false;
+	}
+
+	public static boolean matchAllIngredients(NonNullList<Ingredient> ingredients) {
+		if (ingredients.size() <= 1)
+			return true;
+		Ingredient firstIngredient = ingredients.get(0);
+		for (int i = 1; i < ingredients.size(); i++)
+			if (!matchIngredients(firstIngredient, ingredients.get(i)))
+				return false;
+		return true;
 	}
 
 	public static enum ExtractionCountMode {


### PR DESCRIPTION
Here are some minor optimizations to speed up `MechanicalPressTileEntity#canCompress`, which gets called a lot in big packs that have a lot of recipes.

This helps with the minor performance issue found here: https://github.com/Creators-of-Create/Create/issues/2664