### PR TITLE
[WIP] Potato Cannon Extra

### DIFF
--- a/src/generated/resources/assets/create/lang/en_us.json
+++ b/src/generated/resources/assets/create/lang/en_us.json
@@ -537,6 +537,7 @@
 
 	"enchantment.create.capacity": "Capacity",
 	"enchantment.create.potato_recovery": "Potato Recovery",
+  "enchantment.create.multiplitato": "Multiplitato",
 
 	"entity.create.contraption": "Contraption",
 	"entity.create.crafting_blueprint": "Crafting Blueprint",
@@ -777,6 +778,8 @@
 	"advancement.create.extendo_grip.desc": "Get hold of an Extendo Grip.",
 	"advancement.create.potato_cannon": "Fwoomp!",
 	"advancement.create.potato_cannon.desc": "Defeat an enemy with your Potato Cannon.",
+  "advancement.create.potato_cannon_piercing": "Pew!!",
+  "advancement.create.potato_cannon_piercing.desc": "Pierce 5 Enemy with a single shot from your Potato Cannon.",
 	"advancement.create.dual_extendo_grip": "Ultimate Boing-age",
 	"advancement.create.dual_extendo_grip.desc": "Dual wield Extendo Grips for super-human reach.",
 	"advancement.create.eob": "End of Beta",
@@ -1232,6 +1235,7 @@
 	"create.tooltip.speedRequirement.none": "None",
 	"create.tooltip.speedRequirement.medium": "Moderate",
 	"create.tooltip.speedRequirement.high": "Fast",
+  "create.tooltip.speedRequirement.overclocked": "Overclocked",
 	"create.tooltip.stressImpact": "Kinetic Stress Impact: %1$s",
 	"create.tooltip.stressImpact.low": "Low",
 	"create.tooltip.stressImpact.medium": "Moderate",
@@ -1299,6 +1303,12 @@
 	"create.potato_cannon.ammo.attack_damage": "%1$s Attack Damage",
 	"create.potato_cannon.ammo.reload_ticks": "%1$s Reload Ticks",
 	"create.potato_cannon.ammo.knockback": "%1$s Knockback",
+  "create.potato_cannon.ammo.piercing": "Pierce %1$s Mob",
+  "create.potato_cannon.ammo.min_ammo": "Min. Ammo Cost : %1$s",
+  "create.potato_cannon.ammo.max_ammo": "Max. Ammo Cost : %1$s",
+  "create.potato_cannon.ammo.recover": "%1$s Recover Chance",
+  "create.potato_cannon.ammo.extra_shot": "%1$s Bonus Shot Chance",
+  "create.potato_cannon.ammo.unlimited_ammo": "Unlimited Ammo",
 
 	"create.hint.hose_pulley.title": "Bottomless Supply",
 	"create.hint.hose_pulley": "The targeted body of fluid is considered infinite.",

--- a/src/main/java/com/simibubi/create/AllEnchantments.java
+++ b/src/main/java/com/simibubi/create/AllEnchantments.java
@@ -1,6 +1,7 @@
 package com.simibubi.create;
 
 import com.simibubi.create.content.curiosities.armor.CapacityEnchantment;
+import com.simibubi.create.content.curiosities.weapons.MultiplitatoEnchantment;
 import com.simibubi.create.content.curiosities.weapons.PotatoRecoveryEnchantment;
 import com.simibubi.create.foundation.data.CreateRegistrate;
 import com.tterrag.registrate.util.entry.RegistryEntry;
@@ -19,7 +20,14 @@ public class AllEnchantments {
 		.lang("Potato Recovery")
 		.rarity(Rarity.UNCOMMON)
 		.register();
-	
+
+	public static final RegistryEntry<MultiplitatoEnchantment> MULTIPLITATO = REGISTRATE.object("multiplitato")
+			.enchantment(EnchantmentCategory.BOW, MultiplitatoEnchantment::new)
+			.addSlots(EquipmentSlot.MAINHAND, EquipmentSlot.OFFHAND)
+			.lang("Multiplitato")
+			.rarity(Rarity.VERY_RARE)
+			.register();
+
 	public static final RegistryEntry<CapacityEnchantment> CAPACITY = REGISTRATE.object("capacity")
 		.enchantment(EnchantmentCategory.ARMOR_CHEST, CapacityEnchantment::new)
 		.addSlots(EquipmentSlot.CHEST)

--- a/src/main/java/com/simibubi/create/content/curiosities/weapons/BuiltinPotatoProjectileTypes.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/weapons/BuiltinPotatoProjectileTypes.java
@@ -47,113 +47,188 @@ import net.minecraftforge.registries.IRegistryDelegate;
 public class BuiltinPotatoProjectileTypes {
 
 	private static final GameProfile ZOMBIE_CONVERTER_NAME =
-		new GameProfile(UUID.fromString("be12d3dc-27d3-4992-8c97-66be53fd49c5"), "Converter");
+			new GameProfile(UUID.fromString("be12d3dc-27d3-4992-8c97-66be53fd49c5"), "Converter");
 	private static final WorldAttached<FakePlayer> ZOMBIE_CONVERTERS =
-		new WorldAttached<>(w -> new FakePlayer((ServerLevel) w, ZOMBIE_CONVERTER_NAME));
+			new WorldAttached<>(w -> new FakePlayer((ServerLevel) w, ZOMBIE_CONVERTER_NAME));
 
 	public static final PotatoCannonProjectileType
 
-	FALLBACK = create("fallback").damage(0)
-		.register(),
+			FALLBACK = create("fallback").damage(0)
+			.register(),
 
-		POTATO = create("potato").damage(5)
-			.reloadTicks(15)
+	WHEAT_SEED = create("wheat_seeds").damage(2)
+			.reloadTicks(20)
+			.numberOfShot(4)
+			.cost(1)
 			.velocity(1.25f)
+			.accuracy(50.0f)
+			.sprayAccuracy(30.0f)
+			.knockback(0.25f)
+			.sprayInto(3)
+			.onBlockHit(plantCrop(Blocks.WHEAT.delegate))
+			.registerAndAssign(Items.WHEAT_SEEDS),
+
+	BEETROOT_SEEDS = create("beetroot_seeds").damage(3)
+			.reloadTicks(15)
+			.numberOfShot(2)
+			.cost(1)
+			.velocity(1.0f)
+			.accuracy(100.0f)
+			.sprayAccuracy(20.0f)
+			.knockback(0.30f)
+			.sprayInto(2)
+			.onBlockHit(plantCrop(Blocks.BEETROOTS.delegate))
+			.registerAndAssign(Items.BEETROOT_SEEDS),
+
+	MELON_SEEDS = create("melon_seeds").damage(3)
+			.reloadTicks(5)
+			.numberOfShot(16)
+			.cost(1)
+			.velocity(1.75f)
+			.accuracy(0.0f)
+			.knockback(0.15f)
+			.onBlockHit(plantCrop(Blocks.MELON_STEM.delegate))
+			.registerAndAssign(Items.MELON_SEEDS),
+
+	PUMPKIN_SEEDS = create("pumpkin_seeds").damage(4)
+			.reloadTicks(10)
+			.numberOfShot(8)
+			.cost(1)
+			.velocity(1.25f)
+			.accuracy(0.0f)
+			.sprayAccuracy(0.0f)
+			.knockback(0.40f)
+			.sprayInto(3)
+			.onBlockHit(plantCrop(Blocks.PUMPKIN_STEM.delegate))
+			.registerAndAssign(Items.PUMPKIN_SEEDS),
+
+	POTATO = create("potato").damage(5)
+			.reloadTicks(15)
+			.cost(1)
+			.velocity(1.25f)
+			.accuracy(60.0f)
 			.knockback(1.5f)
 			.renderTumbling()
 			.onBlockHit(plantCrop(Blocks.POTATOES.delegate))
 			.registerAndAssign(Items.POTATO),
 
-		BAKED_POTATO = create("baked_potato").damage(5)
+	BAKED_POTATO = create("baked_potato").damage(5)
 			.reloadTicks(15)
+			.cost(1)
 			.velocity(1.25f)
+			.accuracy(65.0f)
 			.knockback(0.5f)
 			.renderTumbling()
 			.preEntityHit(setFire(3))
 			.registerAndAssign(Items.BAKED_POTATO),
 
-		CARROT = create("carrot").damage(4)
+	CARROT = create("carrot").damage(4)
 			.reloadTicks(12)
+			.cost(1)
+			.piercing(1)
 			.velocity(1.45f)
 			.knockback(0.3f)
+			.accuracy(90.0f)
 			.renderTowardMotion(140, 1)
 			.soundPitch(1.5f)
 			.onBlockHit(plantCrop(Blocks.CARROTS.delegate))
 			.registerAndAssign(Items.CARROT),
 
-		GOLDEN_CARROT = create("golden_carrot").damage(12)
+	GOLDEN_CARROT = create("golden_carrot").damage(12)
 			.reloadTicks(15)
+			.cost(1)
+			.piercing(2)
 			.velocity(1.45f)
 			.knockback(0.5f)
+			.accuracy(100.0f)
 			.renderTowardMotion(140, 2)
 			.soundPitch(1.5f)
 			.registerAndAssign(Items.GOLDEN_CARROT),
 
-		SWEET_BERRIES = create("sweet_berry").damage(3)
+	SWEET_BERRIES = create("sweet_berry").damage(3)
 			.reloadTicks(10)
+			.cost(1)
 			.knockback(0.1f)
+			.accuracy(70.0f)
+			.sprayAccuracy(50.0f)
 			.velocity(1.05f)
 			.renderTumbling()
-			.splitInto(3)
+			.sprayInto(3)
 			.soundPitch(1.25f)
 			.registerAndAssign(Items.SWEET_BERRIES),
 
-		GLOW_BERRIES = create("glow_berry").damage(2)
+	GLOW_BERRIES = create("glow_berry").damage(2)
 			.reloadTicks(10)
+			.cost(1)
 			.knockback(0.05f)
+			.accuracy(75.0f)
+			.sprayAccuracy(25.0f)
 			.velocity(1.05f)
 			.renderTumbling()
-			.splitInto(2)
+			.sprayInto(2)
 			.soundPitch(1.2f)
 			.onEntityHit(potion(MobEffects.GLOWING, 1, 200, false))
 			.registerAndAssign(Items.GLOW_BERRIES),
 
-		CHOCOLATE_BERRIES = create("chocolate_berry").damage(4)
+	CHOCOLATE_BERRIES = create("chocolate_berry").damage(4)
 			.reloadTicks(10)
+			.cost(1)
 			.knockback(0.2f)
+			.accuracy(80.0f)
+			.sprayAccuracy(60.0f)
 			.velocity(1.05f)
 			.renderTumbling()
-			.splitInto(3)
+			.sprayInto(3)
 			.soundPitch(1.25f)
 			.registerAndAssign(AllItems.CHOCOLATE_BERRIES.get()),
 
-		POISON_POTATO = create("poison_potato").damage(5)
+	POISON_POTATO = create("poison_potato").damage(5)
 			.reloadTicks(15)
+			.cost(1)
 			.knockback(0.05f)
+			.accuracy(75.0f)
 			.velocity(1.25f)
 			.renderTumbling()
 			.onEntityHit(potion(MobEffects.POISON, 1, 160, true))
 			.registerAndAssign(Items.POISONOUS_POTATO),
 
-		CHORUS_FRUIT = create("chorus_fruit").damage(3)
+	CHORUS_FRUIT = create("chorus_fruit").damage(3)
 			.reloadTicks(15)
+			.cost(1)
 			.velocity(1.20f)
+			.accuracy(100.0f)
 			.knockback(0.05f)
 			.renderTumbling()
 			.onEntityHit(chorusTeleport(20))
 			.registerAndAssign(Items.CHORUS_FRUIT),
 
-		APPLE = create("apple").damage(5)
+	APPLE = create("apple").damage(5)
 			.reloadTicks(10)
+			.cost(1)
 			.velocity(1.45f)
 			.knockback(0.5f)
+			.accuracy(80.0f)
 			.renderTumbling()
 			.soundPitch(1.1f)
 			.registerAndAssign(Items.APPLE),
 
-		HONEYED_APPLE = create("honeyed_apple").damage(6)
+	HONEYED_APPLE = create("honeyed_apple").damage(6)
 			.reloadTicks(15)
+			.cost(1)
 			.velocity(1.35f)
 			.knockback(0.1f)
+			.accuracy(75.0f)
 			.renderTumbling()
 			.soundPitch(1.1f)
-			.onEntityHit(potion(MobEffects.MOVEMENT_SLOWDOWN, 2,160, true))
+			.onEntityHit(potion(MobEffects.MOVEMENT_SLOWDOWN, 2, 160, true))
 			.registerAndAssign(AllItems.HONEYED_APPLE.get()),
 
-		GOLDEN_APPLE = create("golden_apple").damage(1)
+	GOLDEN_APPLE = create("golden_apple").damage(1)
 			.reloadTicks(100)
+			.cost(1)
 			.velocity(1.45f)
 			.knockback(0.05f)
+			.accuracy(100.0f)
 			.renderTumbling()
 			.soundPitch(1.1f)
 			.onEntityHit(ray -> {
@@ -161,7 +236,7 @@ public class BuiltinPotatoProjectileTypes {
 				Level world = entity.level;
 
 				if (!(entity instanceof ZombieVillager)
-					|| !((ZombieVillager) entity).hasEffect(MobEffects.WEAKNESS))
+						|| !((ZombieVillager) entity).hasEffect(MobEffects.WEAKNESS))
 					return foodEffects(Foods.GOLDEN_APPLE, false).test(ray);
 				if (world.isClientSide)
 					return false;
@@ -173,87 +248,129 @@ public class BuiltinPotatoProjectileTypes {
 			})
 			.registerAndAssign(Items.GOLDEN_APPLE),
 
-		ENCHANTED_GOLDEN_APPLE = create("enchanted_golden_apple").damage(1)
+	ENCHANTED_GOLDEN_APPLE = create("enchanted_golden_apple").damage(1)
 			.reloadTicks(100)
+			.cost(1)
 			.velocity(1.45f)
 			.knockback(0.05f)
+			.accuracy(100.0f)
 			.renderTumbling()
 			.soundPitch(1.1f)
 			.onEntityHit(foodEffects(Foods.ENCHANTED_GOLDEN_APPLE, false))
 			.registerAndAssign(Items.ENCHANTED_GOLDEN_APPLE),
 
-		BEETROOT = create("beetroot").damage(2)
+	BEETROOT = create("beetroot").damage(2)
 			.reloadTicks(5)
+			.cost(1)
 			.velocity(1.6f)
 			.knockback(0.1f)
+			.accuracy(50.0f)
 			.renderTowardMotion(140, 2)
 			.soundPitch(1.6f)
 			.registerAndAssign(Items.BEETROOT),
 
-		MELON_SLICE = create("melon_slice").damage(3)
+	MELON_SLICE = create("melon_slice").damage(3)
 			.reloadTicks(8)
+			.cost(1)
 			.knockback(0.1f)
 			.velocity(1.45f)
+			.accuracy(40.0f)
 			.renderTumbling()
 			.soundPitch(1.5f)
 			.registerAndAssign(Items.MELON_SLICE),
 
-		GLISTERING_MELON = create("glistering_melon").damage(5)
+	GLISTERING_MELON = create("glistering_melon").damage(5)
 			.reloadTicks(8)
+			.cost(1)
 			.knockback(0.1f)
 			.velocity(1.45f)
+			.accuracy(60.0f)
 			.renderTumbling()
 			.soundPitch(1.5f)
 			.onEntityHit(potion(MobEffects.GLOWING, 1, 100, true))
 			.registerAndAssign(Items.GLISTERING_MELON_SLICE),
 
-		MELON_BLOCK = create("melon_block").damage(8)
+	MELON_BLOCK = create("melon_block").damage(8)
 			.reloadTicks(20)
+			.cost(1)
 			.knockback(2.0f)
 			.velocity(0.95f)
+			.accuracy(90.0f)
 			.renderTumbling()
 			.soundPitch(0.9f)
 			.onBlockHit(placeBlockOnGround(Blocks.MELON.delegate))
 			.registerAndAssign(Blocks.MELON),
 
-		PUMPKIN_BLOCK = create("pumpkin_block").damage(6)
+	PUMPKIN_BLOCK = create("pumpkin_block").damage(6)
 			.reloadTicks(15)
+			.cost(1)
 			.knockback(2.0f)
 			.velocity(0.95f)
+			.accuracy(100.0f)
 			.renderTumbling()
 			.soundPitch(0.9f)
 			.onBlockHit(placeBlockOnGround(Blocks.PUMPKIN.delegate))
 			.registerAndAssign(Blocks.PUMPKIN),
 
-		PUMPKIN_PIE = create("pumpkin_pie").damage(7)
+	PUMPKIN_PIE = create("pumpkin_pie").damage(7)
 			.reloadTicks(15)
+			.cost(1)
 			.knockback(0.05f)
 			.velocity(1.1f)
+			.accuracy(80.0f)
 			.renderTumbling()
 			.sticky()
 			.soundPitch(1.1f)
 			.registerAndAssign(Items.PUMPKIN_PIE),
 
-		CAKE = create("cake").damage(8)
+	CAKE = create("cake").damage(8)
 			.reloadTicks(15)
+			.cost(1)
 			.knockback(0.1f)
+			.accuracy(95.0f)
 			.velocity(1.1f)
 			.renderTumbling()
 			.sticky()
 			.soundPitch(1.0f)
 			.registerAndAssign(Items.CAKE),
 
-		BLAZE_CAKE = create("blaze_cake").damage(15)
+	BLAZE_CAKE = create("blaze_cake").damage(15)
 			.reloadTicks(20)
+			.cost(1)
 			.knockback(0.3f)
 			.velocity(1.1f)
+			.accuracy(90.0f)
 			.renderTumbling()
 			.sticky()
 			.preEntityHit(setFire(12))
 			.soundPitch(1.0f)
-			.registerAndAssign(AllItems.BLAZE_CAKE.get())
+			.registerAndAssign(AllItems.BLAZE_CAKE.get()),
 
-	;
+	SNOWBALL = create("snowball").damage(0) // Unlimited Ammo Test
+			.reloadTicks(10)
+			.cost(0)
+			.knockback(0.1f)
+			.velocity(1.0f)
+			.accuracy(80.0f)
+			.soundPitch(1.0f)
+			.registerAndAssign(Items.SNOWBALL)
+			/*,
+
+	 Maybe add that when it's going to be possible to change the texture without changing the item!
+	HONEY_BOTTLE = create("honey_bottle").damage(1)
+			.reloadTicks(100)
+			.numberOfShot(1)
+			.cost(1)
+			.knockback(0.3f)
+			.velocity(1.5f)
+			.accuracy(10.0f)
+			.sprayAccuracy(10.0f)
+			.sprayInto(8)
+			.sticky()
+			//.onlyCostOnce() // If a refire system come out, this is going to be important!!
+			.soundPitch(1.0f)
+			.registerAndAssign(Items.HONEY_BOTTLE)*/;
+
 
 	private static PotatoCannonProjectileType.Builder create(String name) {
 		return new PotatoCannonProjectileType.Builder(Create.asResource(name));
@@ -311,8 +428,8 @@ public class BuiltinPotatoProjectileTypes {
 			Direction face = ray.getDirection();
 			BlockPos placePos = hitPos.relative(face);
 			if (!world.getBlockState(placePos)
-				.getMaterial()
-				.isReplaceable())
+					.getMaterial()
+					.isReplaceable())
 				return false;
 			if (!(cropBlock.get() instanceof IPlantable))
 				return false;
@@ -335,8 +452,8 @@ public class BuiltinPotatoProjectileTypes {
 			Direction face = ray.getDirection();
 			BlockPos placePos = hitPos.relative(face);
 			if (!world.getBlockState(placePos)
-				.getMaterial()
-				.isReplaceable())
+					.getMaterial()
+					.isReplaceable())
 				return false;
 
 			if (face == Direction.UP) {
@@ -349,7 +466,7 @@ public class BuiltinPotatoProjectileTypes {
 					y = Math.max(y, placePos.getY());
 
 				FallingBlockEntity falling = new FallingBlockEntity((Level) world, placePos.getX() + 0.5, y,
-					placePos.getZ() + 0.5, block.get().defaultBlockState());
+						placePos.getZ() + 0.5, block.get().defaultBlockState());
 				falling.time = 1;
 				world.addFreshEntity(falling);
 			}
@@ -396,6 +513,7 @@ public class BuiltinPotatoProjectileTypes {
 		};
 	}
 
-	public static void register() {}
+	public static void register() {
+	}
 
 }

--- a/src/main/java/com/simibubi/create/content/curiosities/weapons/MultiplitatoEnchantment.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/weapons/MultiplitatoEnchantment.java
@@ -1,0 +1,24 @@
+package com.simibubi.create.content.curiosities.weapons;
+
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraft.world.item.enchantment.EnchantmentCategory;
+
+public class MultiplitatoEnchantment extends Enchantment {
+
+	public MultiplitatoEnchantment(Rarity p_i46731_1_, EnchantmentCategory p_i46731_2_, EquipmentSlot[] p_i46731_3_) {
+		super(p_i46731_1_, p_i46731_2_, p_i46731_3_);
+	}
+
+	@Override
+	public int getMaxLevel() {
+		return 2;
+	}
+
+	@Override
+	public boolean canApplyAtEnchantingTable(ItemStack stack) {
+		return false;
+	}
+
+}

--- a/src/main/java/com/simibubi/create/content/curiosities/weapons/PotatoCannonItem.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/weapons/PotatoCannonItem.java
@@ -2,6 +2,7 @@ package com.simibubi.create.content.curiosities.weapons;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -71,7 +72,11 @@ public class PotatoCannonItem extends ProjectileWeaponItem {
 			return true;
 		if (enchantment == Enchantments.MOB_LOOTING)
 			return true;
+		if (enchantment == Enchantments.PIERCING)
+			return true;
 		if (enchantment == AllEnchantments.POTATO_RECOVERY.get())
+			return true;
+		if (enchantment == AllEnchantments.MULTIPLITATO.get())
 			return true;
 		return super.canApplyAtEnchantingTable(stack, enchantment);
 	}
@@ -107,7 +112,11 @@ public class PotatoCannonItem extends ProjectileWeaponItem {
 	@Override
 	public InteractionResultHolder<ItemStack> use(Level world, Player player, InteractionHand hand) {
 		ItemStack stack = player.getItemInHand(hand);
+		final float EXTRA_SHOT_BASE = 25;
 		return findAmmoInInventory(world, player, stack).map(itemStack -> {
+
+			PotatoCannonProjectileType projectileType = PotatoProjectileTypeManager.getTypeForStack(itemStack)
+					.orElse(BuiltinPotatoProjectileTypes.FALLBACK);
 
 			if (ShootableGadgetItemMethods.shouldSwap(player, stack, hand, this::isCannon))
 				return InteractionResultHolder.fail(stack);
@@ -117,6 +126,21 @@ public class PotatoCannonItem extends ProjectileWeaponItem {
 				return InteractionResultHolder.success(stack);
 			}
 
+			int extraShot = EnchantmentHelper.getItemEnchantmentLevel(AllEnchantments.MULTIPLITATO.get(), stack);
+
+			if (extraShot > 3) // If it's 100%
+				extraShot = -1;
+			if (extraShot > 0)
+				if (Create.RANDOM.nextInt(100)+1 < EXTRA_SHOT_BASE * extraShot)
+					extraShot = -1;
+				else
+					extraShot = 0;
+
+			for (int i = extraShot; i < projectileType.getMaxFire(); i++) {
+			if (!projectileType.onlyCostOnce() || projectileType.onlyCostOnce() && i == 0)
+				if (!player.isCreative() && itemStack.getCount() < projectileType.getCost())
+					return InteractionResultHolder.fail(stack);
+
 			Vec3 barrelPos = ShootableGadgetItemMethods.getGunBarrelVec(player, hand == InteractionHand.MAIN_HAND,
 				new Vec3(.75f, -0.15f, 1.5f));
 			Vec3 correction =
@@ -124,8 +148,6 @@ public class PotatoCannonItem extends ProjectileWeaponItem {
 					.subtract(player.position()
 						.add(0, player.getEyeHeight(), 0));
 
-			PotatoCannonProjectileType projectileType = PotatoProjectileTypeManager.getTypeForStack(itemStack)
-				.orElse(BuiltinPotatoProjectileTypes.FALLBACK);
 			Vec3 lookVec = player.getLookAngle();
 			Vec3 motion = lookVec.add(correction)
 				.normalize()
@@ -133,48 +155,60 @@ public class PotatoCannonItem extends ProjectileWeaponItem {
 
 			float soundPitch = projectileType.getSoundPitch() + (Create.RANDOM.nextFloat() - .5f) / 4f;
 
-			boolean spray = projectileType.getSplit() > 1;
-			Vec3 sprayBase = VecHelper.rotate(new Vec3(0, 0.1, 0), 360 * Create.RANDOM.nextFloat(), Axis.Z);
-			float sprayChange = 360f / projectileType.getSplit();
+			//boolean spray = projectileType.getSpray() > 1; No longer needed!
+			Vec3 sprayBase = VecHelper.rotate(new Vec3(0, 0.1, 0), 360, Axis.Z); // Base Velocity
+			float sprayChange = 360f / projectileType.getSpray();
 
-			for (int i = 0; i < projectileType.getSplit(); i++) {
+			for (int j = 0; j < projectileType.getSpray(); j++) {
 				PotatoProjectileEntity projectile = AllEntityTypes.POTATO_PROJECTILE.create(world);
 				projectile.setItem(itemStack);
 				projectile.setEnchantmentEffectsFromCannon(stack);
+				float accuracy;
+				Vec3 sprayMotion = motion;
 
-				Vec3 splitMotion = motion;
-				if (spray) {
-					float imperfection = 40 * (Create.RANDOM.nextFloat() - 0.5f);
-					Vec3 sprayOffset = VecHelper.rotate(sprayBase, i * sprayChange + imperfection, Axis.Z);
-					splitMotion = splitMotion.add(VecHelper.lookAt(sprayOffset, motion));
-				}
-
-				if (i != 0)
+				if (j != 0) { // The first shot takes the base accuracy, the other shots takes the spread accuracy
 					projectile.recoveryChance = 0;
+					accuracy = projectileType.getSprayAccuracy();
+				} else if (i < 0) { // If the shot is a bonus shot, give the base accuracy and make it un recoverable (avoid dupes)
+					projectile.recoveryChance = 0;
+					accuracy = projectileType.getAccuracy();
+				}
+				else
+					accuracy = projectileType.getAccuracy();
+
+				accuracy = Math.max(accuracy, 0f); // Don't allow value bellow 0
+				accuracy = Math.min(accuracy, 100f); // Don't allow value above 100
+				accuracy -= 100f;
+
+				float imperfection = (40 * accuracy) * (Create.RANDOM.nextFloat() - (0.5f * accuracy));
+				Vec3 offset = VecHelper.rotate(sprayBase, i * sprayChange + imperfection, Axis.Z);
+				sprayMotion = sprayMotion.add(VecHelper.lookAt(offset, motion));
 
 				projectile.setPos(barrelPos.x, barrelPos.y, barrelPos.z);
-				projectile.setDeltaMovement(splitMotion);
+				projectile.setDeltaMovement(sprayMotion);
 				projectile.setOwner(player);
 				world.addFreshEntity(projectile);
 			}
 
-			if (!player.isCreative()) {
-				itemStack.shrink(1);
-				if (itemStack.isEmpty())
-					player.getInventory().removeItem(itemStack);
+			if (!player.isCreative() && projectileType.getCost() > 0) { // If creative or unlimited ammo, don't remove items
+				if (!projectileType.onlyCostOnce() && i != -1 || projectileType.onlyCostOnce() && i == 0) // If it cost only once, calculate the ammo at the beginning, else calculate every shot
+					itemStack.shrink(projectileType.getCost()); // Remove the correct amount of ammo
+				if (itemStack.isEmpty()) // Is the stack empty?
+					player.getInventory().removeItem(itemStack); // Delete the item
 			}
 
 			if (!BackTankUtil.canAbsorbDamage(player, maxUses()))
 				stack.hurtAndBreak(1, player, p -> p.broadcastBreakEvent(hand));
 
-			Integer cooldown =
-				findAmmoInInventory(world, player, stack).flatMap(PotatoProjectileTypeManager::getTypeForStack)
+			Integer cooldown = findAmmoInInventory(world, player, stack).flatMap(PotatoProjectileTypeManager::getTypeForStack)
 					.map(PotatoCannonProjectileType::getReloadTicks)
 					.orElse(10);
 
 			ShootableGadgetItemMethods.applyCooldown(player, stack, hand, this::isCannon, cooldown);
 			ShootableGadgetItemMethods.sendPackets(player,
 				b -> new PotatoCannonPacket(barrelPos, lookVec.normalize(), itemStack, hand, soundPitch, b));
+
+			}
 			return InteractionResultHolder.success(stack);
 		})
 			.orElse(InteractionResultHolder.pass(stack));
@@ -213,6 +247,9 @@ public class PotatoCannonItem extends ProjectileWeaponItem {
 	public void appendHoverText(ItemStack stack, Level world, List<Component> tooltip, TooltipFlag flag) {
 		int power = EnchantmentHelper.getItemEnchantmentLevel(Enchantments.POWER_ARROWS, stack);
 		int punch = EnchantmentHelper.getItemEnchantmentLevel(Enchantments.PUNCH_ARROWS, stack);
+		int piercing = EnchantmentHelper.getItemEnchantmentLevel(Enchantments.PIERCING, stack);
+		int recover = EnchantmentHelper.getItemEnchantmentLevel(AllEnchantments.POTATO_RECOVERY.get(), stack);
+		int extraShot = EnchantmentHelper.getItemEnchantmentLevel(AllEnchantments.MULTIPLITATO.get(), stack);
 		final float additionalDamageMult = 1 + power * .2f;
 		final float additionalKnockback = punch * .5f;
 
@@ -220,6 +257,12 @@ public class PotatoCannonItem extends ProjectileWeaponItem {
 			String _attack = "potato_cannon.ammo.attack_damage";
 			String _reload = "potato_cannon.ammo.reload_ticks";
 			String _knockback = "potato_cannon.ammo.knockback";
+			String _piercing = "potato_cannon.ammo.piercing";
+			String _minAmmo = "potato_cannon.ammo.min_ammo";
+			String _maxAmmo = "potato_cannon.ammo.max_ammo";
+			String _recover = "potato_cannon.ammo.recover";
+			String _extraShot = "potato_cannon.ammo.extra_shot";
+			String _unlimitedAmmo = "potato_cannon.ammo.unlimited_ammo";
 
 			tooltip.add(new TextComponent(""));
 			tooltip.add(new TranslatableComponent(ammo.getDescriptionId()).append(new TextComponent(":"))
@@ -229,6 +272,7 @@ public class PotatoCannonItem extends ProjectileWeaponItem {
 			TextComponent spacing = new TextComponent(" ");
 			ChatFormatting green = ChatFormatting.GREEN;
 			ChatFormatting darkGreen = ChatFormatting.DARK_GREEN;
+			ChatFormatting aqua = ChatFormatting.AQUA;
 
 			float damageF = type.getDamage() * additionalDamageMult;
 			MutableComponent damage = new TextComponent(
@@ -236,9 +280,30 @@ public class PotatoCannonItem extends ProjectileWeaponItem {
 			MutableComponent reloadTicks = new TextComponent("" + type.getReloadTicks());
 			MutableComponent knockback =
 				new TextComponent("" + (type.getKnockback() + additionalKnockback));
+			MutableComponent pierce =
+					new TextComponent("" + (type.getPiercing() + piercing));
+			MutableComponent minAmmo =
+					new TextComponent("" + (type.getCost()));
+			MutableComponent maxAmmo =
+					new TextComponent("" + (type.getMaxFire()*type.getCost()));
+			MutableComponent extraChance;
+			if (extraShot > 3)
+				extraChance = new TextComponent("100%");
+			else
+				extraChance = new TextComponent("" + (extraShot*25f) + "%");
+			MutableComponent recoverChance;
+			if (recover > 6)
+				recoverChance = new TextComponent("100%");
+			else
+				recoverChance = new TextComponent("" + (12.5f + recover*12.5f) + "%");
 
 			damage = damage.withStyle(additionalDamageMult > 1 ? green : darkGreen);
 			knockback = knockback.withStyle(additionalKnockback > 0 ? green : darkGreen);
+			pierce = pierce.withStyle(piercing > 0 ? green : darkGreen);
+			minAmmo = minAmmo.withStyle(green);
+			maxAmmo = maxAmmo.withStyle(green);
+			extraChance = extraChance.withStyle(extraShot > 3 ? aqua : green);
+			recoverChance = recoverChance.withStyle(recover > 6 ? aqua : green);
 			reloadTicks = reloadTicks.withStyle(darkGreen);
 
 			tooltip.add(spacing.plainCopy()
@@ -250,6 +315,30 @@ public class PotatoCannonItem extends ProjectileWeaponItem {
 			tooltip.add(spacing.plainCopy()
 				.append(Lang.translate(_knockback, knockback)
 					.withStyle(darkGreen)));
+			if (type.getCost()*type.getMaxFire() > 1 || type.getCost() > 1) // If it shoots more than once or if it cost more than one
+				tooltip.add(spacing.plainCopy()
+					.append(Lang.translate(_minAmmo, minAmmo)
+						.withStyle(darkGreen)));
+			if (type.getCost() == 0) // If it costs nothing
+				tooltip.add(spacing.plainCopy()
+						.append(Lang.translate(_unlimitedAmmo)
+								.withStyle(darkGreen)));
+			else if (type.getCost()*type.getMaxFire() > 1) // If it shoots more than once
+				tooltip.add(spacing.plainCopy()
+					.append(Lang.translate(_maxAmmo, maxAmmo)
+						.withStyle(darkGreen)));
+			if (recover > 0) // If it has at least one level of Potato Recover
+				tooltip.add(spacing.plainCopy()
+						.append(Lang.translate(_recover, recoverChance)
+								.withStyle(darkGreen)));
+			if (extraShot > 0) // If it has at least one level of Multiplitato
+			tooltip.add(spacing.plainCopy()
+					.append(Lang.translate(_extraShot, extraChance)
+							.withStyle(darkGreen)));
+			if (piercing + type.getPiercing() > 0) // If it has at least one point of piercing (either the item or the enchant)
+				tooltip.add(spacing.plainCopy()
+					.append(Lang.translate(_piercing, pierce)
+						.withStyle(darkGreen)));
 		});
 		super.appendHoverText(stack, world, tooltip, flag);
 	}

--- a/src/main/java/com/simibubi/create/content/curiosities/weapons/PotatoCannonProjectileType.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/weapons/PotatoCannonProjectileType.java
@@ -26,14 +26,27 @@ public class PotatoCannonProjectileType {
 	private Set<IRegistryDelegate<Item>> items = new HashSet<>();
 
 	private int reloadTicks = 10;
+	private int maxFire = 1;
 	private int damage = 1;
-	private int split = 1;
+	private int cost = 1;
+	private int spray = 1;
+	private int piercing = 0;
+	private int split = 1; // Currently Unused, will be used for projectile that split when hitting an entity or after some time
+	private int splitDuration = 1; // Currently Unused, will be used to determine the time before the projectile split, ignored if "onlySplitOnHit" is true
+	private float accuracy = 100;
+	private float sprayAccuracy = 100;
 	private float knockback = 1;
 	private float drag = 0.99f;
 	private float velocityMultiplier = 1;
 	private float gravityMultiplier = 1;
 	private float soundPitch = 1;
 	private boolean sticky = false;
+	private boolean costOnce = false;
+	private boolean onlySplitOnHit = false; // Currently Unused, will be used to determined if it split ONLY when hit
+	private boolean onlySplitOnTime = false; // Currently Unused, will be used to determined if it split ONLY after the timer
+	private int renderType = 0;
+	private int spin_ = 0;
+	private int spriteAngle_ = 0;
 	private PotatoProjectileRenderMode renderMode = PotatoProjectileRenderMode.Billboard.INSTANCE;
 
 	private Predicate<EntityHitResult> preEntityHit = e -> false; // True if hit should be canceled
@@ -51,16 +64,44 @@ public class PotatoCannonProjectileType {
 		return reloadTicks;
 	}
 
+	public int getMaxFire() {
+		return maxFire;
+	}
+
 	public int getDamage() {
 		return damage;
+	}
+
+	public int getPiercing() {
+		return piercing;
+	}
+
+	public int getCost() {
+		return cost;
+	}
+
+	public int getSpray() {
+		return spray;
 	}
 
 	public int getSplit() {
 		return split;
 	}
 
+	public int getSplitDuration() {
+		return splitDuration;
+	}
+
 	public float getKnockback() {
 		return knockback;
+	}
+
+	public float getAccuracy() {
+		return accuracy;
+	}
+
+	public float getSprayAccuracy() {
+		return sprayAccuracy;
 	}
 
 	public float getDrag() {
@@ -83,6 +124,18 @@ public class PotatoCannonProjectileType {
 		return sticky;
 	}
 
+	public boolean onlyCostOnce() {
+		return costOnce;
+	}
+
+	public boolean onlySplitOnHit() {
+		return onlySplitOnHit;
+	}
+
+	public boolean onlySplitOnTime() {
+		return onlySplitOnTime;
+	}
+
 	public PotatoProjectileRenderMode getRenderMode() {
 		return renderMode;
 	}
@@ -90,7 +143,7 @@ public class PotatoCannonProjectileType {
 	public boolean preEntityHit(EntityHitResult ray) {
 		return preEntityHit.test(ray);
 	}
-	
+
 	public boolean onEntityHit(EntityHitResult ray) {
 		return onEntityHit.test(ray);
 	}
@@ -122,14 +175,38 @@ public class PotatoCannonProjectileType {
 			}
 
 			parseJsonPrimitive(object, "reload_ticks", JsonPrimitive::isNumber, primitive -> type.reloadTicks = primitive.getAsInt());
+			parseJsonPrimitive(object, "max_fire", JsonPrimitive::isNumber, primitive -> type.maxFire = primitive.getAsInt());
+			parseJsonPrimitive(object, "piercing", JsonPrimitive::isNumber, primitive -> type.piercing = primitive.getAsInt());
 			parseJsonPrimitive(object, "damage", JsonPrimitive::isNumber, primitive -> type.damage = primitive.getAsInt());
+			parseJsonPrimitive(object, "cost", JsonPrimitive::isNumber, primitive -> type.cost = primitive.getAsInt());
+			parseJsonPrimitive(object, "spray", JsonPrimitive::isNumber, primitive -> type.spray = primitive.getAsInt());
 			parseJsonPrimitive(object, "split", JsonPrimitive::isNumber, primitive -> type.split = primitive.getAsInt());
+			parseJsonPrimitive(object, "split_duration", JsonPrimitive::isNumber, primitive -> type.splitDuration = primitive.getAsInt());
+			parseJsonPrimitive(object, "accuracy", JsonPrimitive::isNumber, primitive -> type.accuracy = primitive.getAsFloat());
+			parseJsonPrimitive(object, "spray_accuracy", JsonPrimitive::isNumber, primitive -> type.sprayAccuracy = primitive.getAsFloat());
 			parseJsonPrimitive(object, "knockback", JsonPrimitive::isNumber, primitive -> type.knockback = primitive.getAsFloat());
 			parseJsonPrimitive(object, "drag", JsonPrimitive::isNumber, primitive -> type.drag = primitive.getAsFloat());
 			parseJsonPrimitive(object, "velocity_multiplier", JsonPrimitive::isNumber, primitive -> type.velocityMultiplier = primitive.getAsFloat());
 			parseJsonPrimitive(object, "gravity_multiplier", JsonPrimitive::isNumber, primitive -> type.gravityMultiplier = primitive.getAsFloat());
 			parseJsonPrimitive(object, "sound_pitch", JsonPrimitive::isNumber, primitive -> type.soundPitch = primitive.getAsFloat());
 			parseJsonPrimitive(object, "sticky", JsonPrimitive::isBoolean, primitive -> type.sticky = primitive.getAsBoolean());
+			parseJsonPrimitive(object, "cost_once", JsonPrimitive::isBoolean, primitive -> type.costOnce = primitive.getAsBoolean());
+			parseJsonPrimitive(object, "only_split_on_hit", JsonPrimitive::isBoolean, primitive -> type.onlySplitOnHit = primitive.getAsBoolean());
+			parseJsonPrimitive(object, "only_split_on_time", JsonPrimitive::isBoolean, primitive -> type.onlySplitOnTime = primitive.getAsBoolean());
+			parseJsonPrimitive(object, "render_type", JsonPrimitive::isNumber, primitive -> type.renderType = primitive.getAsInt());
+			parseJsonPrimitive(object, "spin", JsonPrimitive::isNumber, primitive -> type.spin_ = primitive.getAsInt());
+			parseJsonPrimitive(object, "spriteAngle", JsonPrimitive::isNumber, primitive -> type.spriteAngle_ = primitive.getAsInt());
+			switch (type.renderType) {
+				default:
+					type.renderMode = PotatoProjectileRenderMode.Billboard.INSTANCE;
+					break;
+				case 1:
+					type.renderMode = PotatoProjectileRenderMode.Tumble.INSTANCE;
+					break;
+				case 2:
+					type.renderMode = new PotatoProjectileRenderMode.TowardMotion(type.spriteAngle_, type.spin_);
+					break;
+			}
 		} catch (Exception e) {
 			//
 		}
@@ -152,14 +229,24 @@ public class PotatoCannonProjectileType {
 			buffer.writeResourceLocation(delegate.name());
 		}
 		buffer.writeInt(type.reloadTicks);
+		buffer.writeInt(type.maxFire);
+		buffer.writeInt(type.piercing);
 		buffer.writeInt(type.damage);
+		buffer.writeInt(type.cost);
+		buffer.writeInt(type.spray);
 		buffer.writeInt(type.split);
+		buffer.writeInt(type.splitDuration);
+		buffer.writeFloat(type.accuracy);
+		buffer.writeFloat(type.sprayAccuracy);
 		buffer.writeFloat(type.knockback);
 		buffer.writeFloat(type.drag);
 		buffer.writeFloat(type.velocityMultiplier);
 		buffer.writeFloat(type.gravityMultiplier);
 		buffer.writeFloat(type.soundPitch);
 		buffer.writeBoolean(type.sticky);
+		buffer.writeBoolean(type.costOnce);
+		buffer.writeBoolean(type.onlySplitOnHit);
+		buffer.writeBoolean(type.onlySplitOnTime);
 	}
 
 	public static PotatoCannonProjectileType fromBuffer(FriendlyByteBuf buffer) {
@@ -172,14 +259,24 @@ public class PotatoCannonProjectileType {
 			}
 		}
 		type.reloadTicks = buffer.readInt();
+		type.maxFire = buffer.readInt();
+		type.piercing = buffer.readInt();
 		type.damage = buffer.readInt();
+		type.cost = buffer.readInt();
+		type.spray = buffer.readInt();
 		type.split = buffer.readInt();
+		type.splitDuration = buffer.readInt();
+		type.accuracy = buffer.readFloat();
+		type.sprayAccuracy = buffer.readFloat();
 		type.knockback = buffer.readFloat();
 		type.drag = buffer.readFloat();
 		type.velocityMultiplier = buffer.readFloat();
 		type.gravityMultiplier = buffer.readFloat();
 		type.soundPitch = buffer.readFloat();
 		type.sticky = buffer.readBoolean();
+		type.costOnce = buffer.readBoolean();
+		type.onlySplitOnHit = buffer.readBoolean();
+		type.onlySplitOnTime = buffer.readBoolean();
 		return type;
 	}
 
@@ -198,13 +295,48 @@ public class PotatoCannonProjectileType {
 			return this;
 		}
 
+		public Builder numberOfShot(int maxFire) {
+			result.maxFire = maxFire;
+			return this;
+		}
+
 		public Builder damage(int damage) {
 			result.damage = damage;
 			return this;
 		}
 
+		public Builder piercing(int piercing) {
+			result.piercing = piercing;
+			return this;
+		}
+
+		public Builder cost(int cost) {
+			result.cost = cost;
+			return this;
+		}
+
+		public Builder sprayInto(int spray) {
+			result.spray = spray;
+			return this;
+		}
+
 		public Builder splitInto(int split) {
 			result.split = split;
+			return this;
+		}
+
+		public Builder splitTimer(int splitDuration) {
+			result.splitDuration = splitDuration;
+			return this;
+		}
+
+		public Builder accuracy(float accuracy) {
+			result.accuracy = accuracy;
+			return this;
+		}
+
+		public Builder sprayAccuracy(float sprayAccuracy) {
+			result.sprayAccuracy = sprayAccuracy;
 			return this;
 		}
 
@@ -235,6 +367,21 @@ public class PotatoCannonProjectileType {
 
 		public Builder sticky() {
 			result.sticky = true;
+			return this;
+		}
+
+		public Builder onlyCostOnce() {
+			result.costOnce = true;
+			return this;
+		}
+
+		public Builder onlySplitOnHit() {
+			result.onlySplitOnHit = true;
+			return this;
+		}
+
+		public Builder onlySplitOnTime() {
+			result.onlySplitOnTime = true;
 			return this;
 		}
 


### PR DESCRIPTION
# This pull request makes the potato launcher more configurable, adds a bunch of cool stuff AND MAYBE add multiple potato cannon upgrade/type (Brass, Shadow Steel and Creative variant? Who knows)

### Things that are finished

- **New Ammunition for the Cannon**
Wheat Seeds, Beetroot Seeds, Melon Seeds, Pumpkin Seeds and Snowballs

- **New Ammunition Attributes**
int - "cost" = How much it cost per shot
int - "max_fire" = How many times it shoots per click
int - "refire_tick" = (TODO : How much time it takes before it shoots again inside of the same click event)
int - "piercing" = How many times can it pierce trough enemies (TODO : Add negative value support)
boolean - "no_piercing" = (TODO : Makes the projectile impossible to pierce)
int - "split" = How many projectile will it split into? (Curently Unused)
**OLD SPLIT VALUE HAS BEEN TRANSFERED TO A "spray" VALUE!!!**
int - "split_duration" = How much time (in ticks) it takes for the thing to split
boolean - "onlySplitOnHit" = Only split when it hits an enemy
boolean - "onlySplitOnTimer" = Only split when the split duration hits 0
float - "accuracy" = How accurate is the initial projectile
float - "spray_accuracy" = How accurate are the extra spray projectile
float - "split_spread" = How much does the split spread? Simmilar to accuracy
int - "render_type" = What type of render it use? 1 = Face Player, 2 = Tumble, 3 = Spin
float - "spin" = How much it spins, only work if render_type = 3
int - "sprite_angle" = How much is the sprite angle turned, only work if render_type = 3
(TODO : Add values for potion effect and block place!!)

- **New Shooting Mechanic**
Each time the player click, the cannon will shoot the specified amount of time, it will calculate on each shot if the player has enough ammo to continue, if it can't it will stop there, extra shots from the new enchant presented bellow are calculated before the cost per shot

- **New Enchants, Multiplitato**
This enchant allow to shoot an extra projectile WITHOUT consuming extra ammo
Current calculation : level * 25%, if level 4 or more, 100% of an extra shot
Planned new calculation : level * 25%, every 100%, it will shoot an extra projectile
250% = 2 extra projectiles with 50% for 3 extra projectiles
125% = 1 extra projectile with 25% for 2 extra projectiles

- **New Tooltips**
Added multiple tooltips : 
"X% Recover Chance", if it's over 100% it will display 100%
"Min./Max. Ammo Cost : X", if the cost isn't 1, it will show how much it require for at least one shot to be done and what it require for max power, might change it to "Cost X per shot" and "X Shots per Press"
"Unlimited Ammo", if the cost is 0, it will simply show this message
"Pierces X Mob", number of time it can pierce, will not be shown if it's 0
"X% Bonus Shot Chance", chances for a bonus shot, will add "X Free Extra Shot" in the future thanks to the new calculation

- **Piercing Works with the Potato Cannon**
This one is a big one, the potato cannon is able to pierce trough enemies if the ammo allows it or the player has piercing on their cannon!

- **Unhardcodded Render Type, Entity Effect and Block Place**
Another big one, render type, entity effect and block place are all hardcodded to projectile, now they can be customized using JSON!!
(TODO : Only Render Type work as of right now)

- **Bug Fix : Projectile collide with other projectiles from the owner**
Straight to the point lmao, this was an annoying bug and could have potentially caused bugs with the new piercing effect, however, I will soon code back the old behavior with a simple boolean value
---
### Conclusion (I guess)

So yeah, BIG stuff added to a random item lmao, after that big project is finished, I might potentially also improve severly multiple random things so they get more customisation, extra feature and more importantly, extra content!

Here is a list of the planned/codded feature

---
# TODO LIST

ORIGINAL ISSUE I MADE MYSELF : #2545

- [X] New Ammunition
- [ ] Multi Shot
- - [X] Custom Ammo Cost
- - [X] Custom Shot per Press
- - [ ] Custom Refire Timer (Need help)
- - [X] Multiplitato Extra Shot
- - - [ ] New Enchant Calculation
- [X] Custom Piercing
- - [ ] Support Negative Piercing Value
- - [ ] No Piercing Boolean
- [ ] Ammo Split (Need Help)
#2813
- - [X] Change Old Split to Spray
- - [ ] Custom Split
- - [ ] Custom Split Timer
- - [ ] Only Split on Timer
- - [ ] Only Split on Hit
- - [ ] Custom Split Spread (Accuracy)
- [X] Custom Accuracy
- [X] Custom Spray Accuracy
- [X] Multiplitato Enchant
- [ ] New Tooltips
- - [ ] Refire in Ticks
- - [X] Recover Chance
- - [X] Min/Max Ammo
- - [X] Unlimited Ammo
- - [X] Piercing
- - [X] Bonus Shot Chance
- - - [ ] New Calculation
- - - [ ] New Tooltip Info
- [ ] Unhardcodding most hardcodded stuff (Need Help)
- - [X] Render Type
- - [ ] Entity Effect (Need Help)
- - - [ ] Modded Effects
- - [ ] Block Placement (Need Help)
- - - [ ] Modded Blocks
- - [ ] Cure Zombie Villager
- [ ] Bug Fixes / Other (More to be added)
- - [x] Fix Projectile Invisibility after Piercing an Entity (Need Help)
- - [X] Projectiles collide with each other when it's the same owner
- - [ ] Multiple Cannon Type (NOT SURE)
- - [x] #2746
- - [x] #2614
- - [x] #2507
- - [ ] #2009
- - [ ] #2567