### PR TITLE
Fix glowing_shader.vsh compilation issue

### DIFF
--- a/src/main/resources/assets/create/shaders/core/glowing_shader.vsh
+++ b/src/main/resources/assets/create/shaders/core/glowing_shader.vsh
@@ -26,7 +26,7 @@ out vec4 normal;
 void main() {
     gl_Position = ProjMat * ModelViewMat * vec4(Position, 1.0);
 
-    vertexDistance = cylindrical_distance(ModelViewMat, IViewRotMat * Position);
+    vertexDistance = fog_distance(ModelViewMat, IViewRotMat * Position, 1);
     vertexColor = Color;
     lightMapColor = texelFetch(Sampler2, UV2 / 16, 0);
     texCoord0 = UV0;


### PR DESCRIPTION
Current 1.18.2 client  in mc1.18/dev doesn't launch
```
Caused by: java.io.IOException: Couldn't compile vertex program (Mod Resources, create:glowing_shader) : 0(29) : error C1503: undefined variable "cylindrical_distance"
```

1.18.2 changed the `cylindrical_distance` function

1.18.1 fog.glsl
```glsl
float cylindrical_distance(mat4 modelViewMat, vec3 pos) {
    float distXZ = length((modelViewMat * vec4(pos.x, 0.0, pos.z, 1.0)).xyz);
    float distY = length((modelViewMat * vec4(0.0, pos.y, 0.0, 1.0)).xyz);
    return max(distXZ, distY);
}
```

1.18.2 fog.glsl
```glsl
float fog_distance(mat4 modelViewMat, vec3 pos, int shape) {
    if (shape == 0) {
        return length((modelViewMat * vec4(pos, 1.0)).xyz);
    } else {
        float distXZ = length((modelViewMat * vec4(pos.x, 0.0, pos.z, 1.0)).xyz);
        float distY = length((modelViewMat * vec4(0.0, pos.y, 0.0, 1.0)).xyz);
        return max(distXZ, distY);
    }
}
```
