### PR TITLE
Make BasinRecipe use IRecipeTypeInfo instead of AllRecipeTypes

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/processing/BasinRecipe.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/processing/BasinRecipe.java
@@ -8,6 +8,8 @@ import java.util.List;
 
 import javax.annotation.Nonnull;
 
+
+import com.simibubi.create.foundation.utility.recipe.IRecipeTypeInfo;
 import com.simibubi.create.AllRecipeTypes;
 import com.simibubi.create.content.contraptions.processing.ProcessingRecipeBuilder.ProcessingRecipeParams;
 import com.simibubi.create.content.contraptions.processing.burner.BlazeBurnerBlock.HeatLevel;
@@ -173,7 +175,7 @@ public class BasinRecipe extends ProcessingRecipe<SmartInventory> {
 		return basinRecipe;
 	}
 
-	protected BasinRecipe(AllRecipeTypes type, ProcessingRecipeParams params) {
+	protected BasinRecipe(IRecipeTypeInfo type, ProcessingRecipeParams params) {
 		super(type, params);
 	}
 


### PR DESCRIPTION
Right now, you can't create custom basin recipes since the constructor only allows `AllRecipeTypes`. Making it allow `IRecipeTypeInfo` instead allows for custom basin recipes.