### PR TITLE
Actual implementation for a /create glue command

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/command/GlueCommand.java
+++ b/src/main/java/com/simibubi/create/foundation/command/GlueCommand.java
@@ -1,5 +1,9 @@
 package com.simibubi.create.foundation.command;
 
+import java.util.List;
+
+import com.google.common.collect.Lists;
+import com.mojang.brigadier.Command;
 import com.mojang.brigadier.builder.ArgumentBuilder;
 import com.simibubi.create.content.contraptions.components.structureMovement.glue.SuperGlueEntity;
 
@@ -8,25 +12,54 @@ import net.minecraft.commands.Commands;
 import net.minecraft.commands.arguments.coordinates.BlockPosArgument;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.network.chat.TextComponent;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.levelgen.structure.BoundingBox;
 
 public class GlueCommand {
+
 	public static ArgumentBuilder<CommandSourceStack, ?> register() {
-		return Commands.literal("glue")
-				.requires(cs -> cs.hasPermission(2))
-				.then(Commands.argument("pos", BlockPosArgument.blockPos())
-						//.then(Commands.argument("direction", EnumArgument.enumArgument(Direction.class))
-								.executes(ctx -> {
-									BlockPos pos = BlockPosArgument.getLoadedBlockPos(ctx, "pos");
+		return Commands.literal("glue").requires(cs -> cs.hasPermission(2))
+				.then(Commands.argument("from", BlockPosArgument.blockPos()).then(Commands.argument("to", BlockPosArgument.blockPos()).executes(ctx -> {
+					BoundingBox area = BoundingBox.fromCorners(BlockPosArgument.getLoadedBlockPos(ctx, "from"), BlockPosArgument.getLoadedBlockPos(ctx, "to"));
 
-									ServerLevel world = ctx.getSource().getLevel();
-									SuperGlueEntity entity = new SuperGlueEntity(world, pos, Direction.UP);
+					List<SuperGlueEntity> newGlue = Lists.newArrayList();
+					Direction[] directions = { Direction.EAST, Direction.SOUTH, Direction.UP };
+					int[] areaMaxCoords = { area.maxX(), area.maxZ(), area.maxY() };
+					ServerLevel world = ctx.getSource().getLevel();
+					int gluePastes = 0;
 
-									entity.playPlaceSound();
-									world.addFreshEntity(entity);
+					for (BlockPos blockPos : BlockPos.betweenClosed(area.minX(), area.minY(), area.minZ(), area.maxX(), area.maxY(), area.maxZ())) {
 
-									return 1;
-								}));
+						int[] blockCoords = { blockPos.getX(), blockPos.getZ(), blockPos.getY() };
 
+						for (int j = 0; j < 3; j++) {
+							if (!isAirBlock(world, blockPos) && !isTargetAirBlock(world, blockPos, directions[j]) && blockCoords[j] != areaMaxCoords[j]) {
+								BlockPos blockPos1 = blockPos.relative(directions[j]);
+								newGlue.add(new SuperGlueEntity(world, blockPos1, directions[j]));
+							}
+						}
+					}
+
+					for (SuperGlueEntity glue : newGlue) {
+						if (glue.onValidSurface()) {
+							world.addFreshEntity(glue);
+							gluePastes++;
+						}
+					}
+
+					ctx.getSource().sendSuccess(new TextComponent("Successfully applied glue " + gluePastes + " times"), true);
+					return Command.SINGLE_SUCCESS;
+				})));
+
+	}
+
+	private static boolean isAirBlock(ServerLevel world, BlockPos pos) {
+		return world.getBlockState(pos).getBlock() == Blocks.AIR;
+	}
+
+	private static boolean isTargetAirBlock(ServerLevel world, BlockPos pos, Direction direction) {
+		return world.getBlockState(pos.relative(direction)).getBlock() == Blocks.AIR;
 	}
 }


### PR DESCRIPTION
Implementation for the command /create glue x y z -> /create glue x1 y1 z1 x2 y2 z2
This implementation creates a bounding boundingbox like the /fill command does, and for every 2 connected surfaces(blocks) spawns a SuperGlueEntity, that behaves as intended.
The logic behind this is to check every block in the BB and place a superglue entity pasted to it on the east,south,up sides of said block if theres an adyacent block and said block isnt outside the BB.
This implementation is very useful for large scale building or with tools such as worldedit or similar, as it lets connect all blocks between themselves in a single command.
Note : There is no size limit implemented. As this is enough to get the work done I need for my team I consider it good enough for a pull request, to then be added said limit by Create team in the way they consider appropiate.

Showcase of the implementation : https://www.youtube.com/watch?v=UW5nETN9PBg&feature=youtu.be
Personally, this is exactly what i'd expect from running this command.
Yes, I did bug-test it, and somehow fixed that annoying bug where all glue entities would be linked in nbt to the first block from the forEach loop, which made them all spawn in the right place, but interact as if they were connected to that single block.
Also, this code model is the only one I can think of that preventn having 3 if's(one per side) with each containing 3 lines of code each, in other words, least text