### PR TITLE
Sticky mess!

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/glue/SuperGlueEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/glue/SuperGlueEntity.java
@@ -69,6 +69,7 @@ import net.minecraftforge.network.PacketDistributor;
 public class SuperGlueEntity extends Entity
 	implements IEntityAdditionalSpawnData, ISpecialEntityItemRequirement {
 
+	public static final int PIXEL_SIZE = 12;
 	private int validationTimer;
 	protected BlockPos hangingPosition;
 	protected Direction facingDirection = Direction.SOUTH;
@@ -86,14 +87,6 @@ public class SuperGlueEntity extends Entity
 
 	@Override
 	protected void defineSynchedData() {}
-
-	public int getWidthPixels() {
-		return 12;
-	}
-
-	public int getHeightPixels() {
-		return 12;
-	}
 
 	public void onBroken(@Nullable Entity breaker) {
 		playSound(SoundEvents.SLIME_SQUISH_SMALL, 1.0F, 1.0F);
@@ -132,9 +125,9 @@ public class SuperGlueEntity extends Entity
 			double y = hangingPosition.getY() + 0.5 - facingDirection.getStepY() * offset;
 			double z = hangingPosition.getZ() + 0.5 - facingDirection.getStepZ() * offset;
 			this.setPosRaw(x, y, z);
-			double w = getWidthPixels();
-			double h = getHeightPixels();
-			double l = getWidthPixels();
+			double w = PIXEL_SIZE;
+			double h = PIXEL_SIZE;
+			double l = PIXEL_SIZE;
 			Axis axis = this.getFacingDirection()
 				.getAxis();
 			double depth = 2 - 1 / 128f;
@@ -177,17 +170,17 @@ public class SuperGlueEntity extends Entity
 	}
 
 	public boolean onValidSurface() {
-		BlockPos pos = hangingPosition;
-		BlockPos pos2 = hangingPosition.relative(getFacingDirection().getOpposite());
-		if (level.isOutsideBuildHeight(pos2))
+		BlockPos glueSource = hangingPosition;
+		BlockPos glueTarget = hangingPosition.relative(getFacingDirection().getOpposite());
+		if (level.isOutsideBuildHeight(glueTarget))
 			return false;
-		if (!level.isAreaLoaded(pos, 0) || !level.isAreaLoaded(pos2, 0))
+		if (!level.isAreaLoaded(glueSource, 0) || !level.isAreaLoaded(glueTarget, 0))
 			return true;
-		if (!isValidFace(level, pos2, getFacingDirection())
-			&& !isValidFace(level, pos, getFacingDirection().getOpposite()))
+		if (!isValidFace(level, glueTarget, getFacingDirection())
+			&& !isValidFace(level, glueSource, getFacingDirection().getOpposite()))
 			return false;
-		if (isSideSticky(level, pos2, getFacingDirection())
-			|| isSideSticky(level, pos, getFacingDirection().getOpposite()))
+		if (isSideSticky(level, glueTarget, getFacingDirection())
+			|| isSideSticky(level, glueSource, getFacingDirection().getOpposite()))
 			return false;
 		return level.getEntities(this, getBoundingBox(), e -> e instanceof SuperGlueEntity)
 			.isEmpty();

--- a/src/main/java/com/simibubi/create/foundation/command/GlueCommand.java
+++ b/src/main/java/com/simibubi/create/foundation/command/GlueCommand.java
@@ -27,7 +27,7 @@ import static net.minecraft.commands.arguments.coordinates.SwizzleArgument.swizz
 
 public class GlueCommand {
 
-    public static final int GLUE_LIMIT = 32768;
+    public static final int GLUE_LIMIT = 8192;
 
     public static ArgumentBuilder<CommandSourceStack, ?> register() {
         return literal("glue")
@@ -45,9 +45,10 @@ public class GlueCommand {
             .then(literal("floodfill")
                 .then(argument("source", blockPos())
                     .executes(ctx -> floodfillCommand(ctx, GLUE_LIMIT, null))
+                    .then(argument("mask", blockPredicate())
+                        .executes(ctx -> floodfillCommand(ctx, GLUE_LIMIT, getBlockPredicate(ctx, "mask"))))
                     .then(argument("limit", integer(1, GLUE_LIMIT))
                         .executes(ctx -> floodfillCommand(ctx, GLUE_LIMIT, null))
-                        .executes(ctx -> floodfillCommand(ctx, ctx.getArgument("limit", Integer.class), null))
                         .then(argument("mask", blockPredicate())
                             .executes(ctx -> floodfillCommand(ctx, ctx.getArgument("limit", Integer.class), getBlockPredicate(ctx, "mask")))))))
             ;
@@ -67,7 +68,7 @@ public class GlueCommand {
 
     private static int floodfillCommand(CommandContext<CommandSourceStack> ctx, int limit, @Nullable Predicate<BlockInWorld> mask) throws CommandSyntaxException {
         int propagated = GlueHelper.floodfill(ctx.getSource().getLevel(), getLoadedBlockPos(ctx, "source"), limit, mask);
-        ctx.getSource().sendSuccess(new TextComponent("Successfully propagated " + propagated + "/" + limit + " patches of glue."), true);
+        ctx.getSource().sendSuccess(new TextComponent("Successfully propagated " + propagated + "(limited to " + limit + ") patches of glue."), true);
         return Command.SINGLE_SUCCESS;
     }
 }

--- a/src/main/java/com/simibubi/create/foundation/command/GlueCommand.java
+++ b/src/main/java/com/simibubi/create/foundation/command/GlueCommand.java
@@ -48,7 +48,7 @@ public class GlueCommand {
                     .then(argument("mask", blockPredicate())
                         .executes(ctx -> floodfillCommand(ctx, GLUE_LIMIT, getBlockPredicate(ctx, "mask"))))
                     .then(argument("limit", integer(1, GLUE_LIMIT))
-                        .executes(ctx -> floodfillCommand(ctx, GLUE_LIMIT, null))
+                        .executes(ctx -> floodfillCommand(ctx, ctx.getArgument("limit", Integer.class), null))
                         .then(argument("mask", blockPredicate())
                             .executes(ctx -> floodfillCommand(ctx, ctx.getArgument("limit", Integer.class), getBlockPredicate(ctx, "mask")))))))
             ;

--- a/src/main/java/com/simibubi/create/foundation/command/GlueCommand.java
+++ b/src/main/java/com/simibubi/create/foundation/command/GlueCommand.java
@@ -1,32 +1,73 @@
 package com.simibubi.create.foundation.command;
 
+import com.mojang.brigadier.Command;
 import com.mojang.brigadier.builder.ArgumentBuilder;
-import com.simibubi.create.content.contraptions.components.structureMovement.glue.SuperGlueEntity;
-
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.simibubi.create.foundation.utility.GlueHelper;
 import net.minecraft.commands.CommandSourceStack;
-import net.minecraft.commands.Commands;
-import net.minecraft.commands.arguments.coordinates.BlockPosArgument;
-import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.server.level.ServerLevel;
+import net.minecraft.network.chat.TextComponent;
+import net.minecraft.world.level.block.state.pattern.BlockInWorld;
+import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nullable;
+import java.util.EnumSet;
+import java.util.function.Predicate;
+
+import static com.mojang.brigadier.arguments.IntegerArgumentType.integer;
+import static net.minecraft.commands.Commands.argument;
+import static net.minecraft.commands.Commands.literal;
+import static net.minecraft.commands.arguments.blocks.BlockPredicateArgument.blockPredicate;
+import static net.minecraft.commands.arguments.blocks.BlockPredicateArgument.getBlockPredicate;
+import static net.minecraft.commands.arguments.coordinates.BlockPosArgument.blockPos;
+import static net.minecraft.commands.arguments.coordinates.BlockPosArgument.getLoadedBlockPos;
+import static net.minecraft.commands.arguments.coordinates.SwizzleArgument.getSwizzle;
+import static net.minecraft.commands.arguments.coordinates.SwizzleArgument.swizzle;
 
 public class GlueCommand {
-	public static ArgumentBuilder<CommandSourceStack, ?> register() {
-		return Commands.literal("glue")
-				.requires(cs -> cs.hasPermission(2))
-				.then(Commands.argument("pos", BlockPosArgument.blockPos())
-						//.then(Commands.argument("direction", EnumArgument.enumArgument(Direction.class))
-								.executes(ctx -> {
-									BlockPos pos = BlockPosArgument.getLoadedBlockPos(ctx, "pos");
 
-									ServerLevel world = ctx.getSource().getLevel();
-									SuperGlueEntity entity = new SuperGlueEntity(world, pos, Direction.UP);
+    public static final int GLUE_LIMIT = 32768;
 
-									entity.playPlaceSound();
-									world.addFreshEntity(entity);
+    public static ArgumentBuilder<CommandSourceStack, ?> register() {
+        return literal("glue")
+            .requires(cs -> cs.hasPermission(2))
+            .then(literal("fill")
+                .then(argument("pos1", blockPos()).then(argument("pos2", blockPos())
+                    .executes(ctx -> fillCommand(ctx, EnumSet.allOf(Direction.Axis.class)))
+                    .then(argument("axes", swizzle())//enumArgument(Direction.Axis.class))
+                        .executes(ctx -> fillCommand(ctx, getSwizzle(ctx, "axes")))))))
+            .then(literal("clear")
+                .then(argument("pos1", blockPos()).then(argument("pos2", blockPos())
+                    .executes(ctx -> clearCommand(ctx, EnumSet.allOf(Direction.Axis.class)))
+                    .then(argument("axes", swizzle())
+                        .executes(ctx -> clearCommand(ctx, getSwizzle(ctx, "axes")))))))
+            .then(literal("floodfill")
+                .then(argument("source", blockPos())
+                    .executes(ctx -> floodfillCommand(ctx, GLUE_LIMIT, null))
+                    .then(argument("limit", integer(1, GLUE_LIMIT))
+                        .executes(ctx -> floodfillCommand(ctx, GLUE_LIMIT, null))
+                        .executes(ctx -> floodfillCommand(ctx, ctx.getArgument("limit", Integer.class), null))
+                        .then(argument("mask", blockPredicate())
+                            .executes(ctx -> floodfillCommand(ctx, ctx.getArgument("limit", Integer.class), getBlockPredicate(ctx, "mask")))))))
+            ;
+    }
 
-									return 1;
-								}));
+    private static int fillCommand(CommandContext<CommandSourceStack> ctx, @NotNull EnumSet<Direction.Axis> axes) throws CommandSyntaxException {
+        int cleared = GlueHelper.fill(ctx.getSource().getLevel(), getLoadedBlockPos(ctx, "pos1"), getLoadedBlockPos(ctx, "pos2"), axes);
+        ctx.getSource().sendSuccess(new TextComponent("Successfully applied " + cleared + " patches of glue."), true);
+        return Command.SINGLE_SUCCESS;
+    }
 
-	}
+    private static int clearCommand(CommandContext<CommandSourceStack> ctx, @NotNull EnumSet<Direction.Axis> axes) throws CommandSyntaxException {
+        int cleared = GlueHelper.clear(ctx.getSource().getLevel(), getLoadedBlockPos(ctx, "pos1"), getLoadedBlockPos(ctx, "pos2"), axes);
+        ctx.getSource().sendSuccess(new TextComponent("Successfully cleared " + cleared + " patches of glue."), true);
+        return Command.SINGLE_SUCCESS;
+    }
+
+    private static int floodfillCommand(CommandContext<CommandSourceStack> ctx, int limit, @Nullable Predicate<BlockInWorld> mask) throws CommandSyntaxException {
+        int propagated = GlueHelper.floodfill(ctx.getSource().getLevel(), getLoadedBlockPos(ctx, "source"), limit, mask);
+        ctx.getSource().sendSuccess(new TextComponent("Successfully propagated " + propagated + "/" + limit + " patches of glue."), true);
+        return Command.SINGLE_SUCCESS;
+    }
 }

--- a/src/main/java/com/simibubi/create/foundation/utility/GlueHelper.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/GlueHelper.java
@@ -37,7 +37,10 @@ public class GlueHelper {
 
             for (var pos : BlockPos.betweenClosed(pos1, pos2)) {
                 var targetPos = pos.relative(dir.getOpposite());
-                if (!area.isInside(targetPos)) continue; // neighboring block inside area
+                if (!area.isInside(targetPos)
+                    || level.getBlockState(targetPos).isAir()
+                    || level.getBlockState(pos).isAir())
+                    continue; // neighboring block inside area
 
                 SuperGlueEntity entity = new SuperGlueEntity(level, pos.immutable(), dir);
                 if (!entity.onValidSurface()) continue;
@@ -52,7 +55,7 @@ public class GlueHelper {
     /**
      * Removes glue in a cuboid.
      *
-     * @param axis optional, to clear only glue on in one axis;
+     * @param axes axes to apply the glue on.
      * @return number of removed glue patches
      */
     public static int clear(Level level, BlockPos pos1, BlockPos pos2, @NotNull EnumSet<Direction.Axis> axes) {
@@ -73,8 +76,8 @@ public class GlueHelper {
      *
      * @param source source block to start from
      * @param limit  max number of glue patches to apply
-     * @param mask mask predicate to glue only blocks that match it
-     * @return
+     * @param mask glue doesn't spread through masked blocks
+     * @return number of applied patches
      */
     public static int floodfill(Level level, BlockPos source, int limit, @Nullable Predicate<BlockInWorld> mask) {
         // FIXME: this code and sail code are both BFS-order traversals. Maybe they should be refactored to one algo?
@@ -89,7 +92,7 @@ public class GlueHelper {
 
                 final BlockPos neighbor = pos.relative(dir);
                 if (visited.contains(neighbor)) continue;
-                if (mask != null && !mask.test(new BlockInWorld(level, neighbor, true))) {
+                if (mask != null && mask.test(new BlockInWorld(level, neighbor, true))) {
                     visited.add(neighbor);
                     continue;
                 }

--- a/src/main/java/com/simibubi/create/foundation/utility/GlueHelper.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/GlueHelper.java
@@ -1,0 +1,114 @@
+package com.simibubi.create.foundation.utility;
+
+import com.simibubi.create.content.contraptions.components.structureMovement.glue.SuperGlueEntity;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.pattern.BlockInWorld;
+import net.minecraft.world.level.entity.EntityTypeTest;
+import net.minecraft.world.level.levelgen.structure.BoundingBox;
+import net.minecraft.world.phys.AABB;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayDeque;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.function.Predicate;
+
+
+public class GlueHelper {
+
+    /**
+     * Applies glue everywhere in a cuboid
+     *
+     * @param axes axes to apply the glue on.
+     * @return number of applied glue patches
+     * TODO: skip exposed faces - when in water, when gluing things that are not glueable etc.
+     */
+    public static int fill(Level level, BlockPos pos1, BlockPos pos2, @NotNull EnumSet<Direction.Axis> axes) {
+        var area = BoundingBox.fromCorners(pos1, pos2);
+        var glued = 0;
+
+        for (var glueAxis : new Direction.Axis[]{Direction.Axis.Y, Direction.Axis.Z, Direction.Axis.X}) {
+            if (!axes.contains(glueAxis)) continue; // if axis specified - apply only for this one
+            var dir = Direction.get(Direction.AxisDirection.POSITIVE, glueAxis);
+
+            for (var pos : BlockPos.betweenClosed(pos1, pos2)) {
+                var targetPos = pos.relative(dir.getOpposite());
+                if (!area.isInside(targetPos)) continue; // neighboring block inside area
+
+                SuperGlueEntity entity = new SuperGlueEntity(level, pos.immutable(), dir);
+                if (!entity.onValidSurface()) continue;
+
+                ++glued;
+                level.addFreshEntity(entity);
+            }
+        }
+        return glued;
+    }
+
+    /**
+     * Removes glue in a cuboid.
+     *
+     * @param axis optional, to clear only glue on in one axis;
+     * @return number of removed glue patches
+     */
+    public static int clear(Level level, BlockPos pos1, BlockPos pos2, @NotNull EnumSet<Direction.Axis> axes) {
+        int removed = 0;
+        for (var glueEntity : level.getEntities(
+            EntityTypeTest.forClass(SuperGlueEntity.class),
+            new AABB(pos1, pos2).inflate(0.5),
+            e -> axes.contains(e.getFacingDirection().getAxis()))
+        ) {
+            glueEntity.setRemoved(Entity.RemovalReason.KILLED);
+            ++removed;
+        }
+        return removed;
+    }
+
+    /**
+     * Floodifill the glue propagating it from source block. BlockPredicate
+     *
+     * @param source source block to start from
+     * @param limit  max number of glue patches to apply
+     * @param mask mask predicate to glue only blocks that match it
+     * @return
+     */
+    public static int floodfill(Level level, BlockPos source, int limit, @Nullable Predicate<BlockInWorld> mask) {
+        // FIXME: this code and sail code are both BFS-order traversals. Maybe they should be refactored to one algo?
+        var frontier = new ArrayDeque<>(List.of(source));
+        var visited = new ArrayDeque<>(List.of(source));
+        int glued = 0;
+
+        while (!frontier.isEmpty()) {
+            final var pos = frontier.pop();
+
+            for (var dir : Iterate.directions) {
+
+                final BlockPos neighbor = pos.relative(dir);
+                if (visited.contains(neighbor)) continue;
+                if (mask != null && !mask.test(new BlockInWorld(level, neighbor, true))) {
+                    visited.add(neighbor);
+                    continue;
+                }
+
+                if (level.getBlockState(neighbor).isAir()) {
+                    visited.add(neighbor);
+                    continue;
+                }
+                SuperGlueEntity entity = new SuperGlueEntity(level, pos.immutable(), dir.getOpposite());
+                if (!entity.onValidSurface()) continue;
+
+                if (++glued >= limit) return glued;
+                level.addFreshEntity(entity);
+
+                var nextPos = pos.relative(dir);
+                frontier.add(nextPos);
+                visited.add(nextPos);
+            }
+        }
+        return glued;
+    }
+}


### PR DESCRIPTION
- added `/create glue fill|clear <cuboid> [axes]` command to fill/clear cuboid with glue
- added `/create glue floodfill <source> [limit] [mask]` command to propagate glue to neighbors. 
   - limit - used when you want to safely limit the number of glue (default is 8k).
   - mask - block/tag used to stop glue from propagating
- added GlueHelper as an API

## Example usage:

- `/c glue fill 0 0 0  10 10 10` -> glue all in specified area
- `/c glue fill 0 0 0  10 10 10  xz` -> glue only in xz-planes, so each y-layer is still separate
- `/c glue clear 0 0 0  10 10 10  y` -> dissolve glue between y-layers (make easy crossection)
- `/c glue floodfill 0 0 0` -> propagate  glue from `0 0 0` over valid blocks (limit ~8k)
- `/c glue floodfill 0 0 0  minecraft:dirt` -> same as above, but stop on dirt

https://user-images.githubusercontent.com/5300963/168122862-63cebed3-8dca-4cc4-9120-c5e6e83f10b1.mp4

https://user-images.githubusercontent.com/5300963/168122871-9fca7f70-6378-402d-99ca-c76d0df76504.mp4

We'll see how the 0.5 glue mechanic will work and when it comes out I'll update the code accordingly. This PR was meant mostly to introduce API via `GlueHelper`.

Big thanks to @Bodiw for his hint on how to resolve the problem with "ghost glue". This PR came to existence concurrently with https://github.com/Creators-of-Create/Create/pull/3012, but I wanted to expand on the functionality (especially floodfill), thus it's a completely different implementation.