### PR TITLE
fix potential dupe glitch with stackable fluid containers

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/fluids/actors/ItemDrainTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/fluids/actors/ItemDrainTileEntity.java
@@ -76,6 +76,7 @@ public class ItemDrainTileEntity extends SmartTileEntity implements IHaveGoggleI
 			return returned;
 
 		transportedStack = transportedStack.copy();
+		transportedStack.stack = inserted.copy();
 		transportedStack.beltPosition = side.getAxis()
 			.isVertical() ? .5f : 0;
 		transportedStack.prevSideOffset = transportedStack.sideOffset;
@@ -277,7 +278,7 @@ public class ItemDrainTileEntity extends SmartTileEntity implements IHaveGoggleI
 			heldItem = TransportedItemStack.read(compound.getCompound("HeldItem"));
 		super.read(compound, clientPacket);
 	}
-	
+
 	@Override
 	public <T> LazyOptional<T> getCapability(Capability<T> cap, Direction side) {
 		if (side != null && side.getAxis()


### PR DESCRIPTION
Item drains correctly split stacked fluid handlers, but just ignore that new stack and use the original anyway.
happens on fabric in https://github.com/Fabricators-of-Create/Create/issues/296