### PR TITLE
Add check to TorquePropagator, fixing #3103

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/TorquePropagator.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/TorquePropagator.java
@@ -26,6 +26,8 @@ public class TorquePropagator {
 	public KineticNetwork getOrCreateNetworkFor(KineticTileEntity te) {
 		Long id = te.network;
 		KineticNetwork network;
+		if (!networks.containsKey(te.getLevel()))
+			networks.put(te.getLevel(), new HashMap<>());
 		Map<Long, KineticNetwork> map = networks.get(te.getLevel());
 		if (id == null)
 			return null;


### PR DESCRIPTION
Adds a check to the TorquePropagator to make sure the `networks` map contains the level of the current tile entity. This fixes issue #3103