### PR TITLE
Change SailBlock.applyDye() access modifier to public 

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/bearing/SailBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/bearing/SailBlock.java
@@ -107,7 +107,7 @@ public class SailBlock extends WrenchableDirectionalBlock {
 		return InteractionResult.PASS;
 	}
 
-	protected void applyDye(BlockState state, Level world, BlockPos pos, @Nullable DyeColor color) {
+	public void applyDye(BlockState state, Level world, BlockPos pos, @Nullable DyeColor color) {
 		BlockState newState =
 			(color == null ? AllBlocks.SAIL_FRAME : AllBlocks.DYED_SAILS.get(color)).getDefaultState();
 		newState = BlockHelper.copyProperties(state, newState);


### PR DESCRIPTION
Modifying the SailBlock.applyDye() method from `protected` to `public` to allow being called by other mods (or KubeJS).

This makes the access similar to [Belts](https://github.com/Creators-of-Create/Create/blob/a2ade690353eaaac63304c55e6663988c3e6265c/src/main/java/com/simibubi/create/content/contraptions/relays/belt/BeltTileEntity.java#L271).

Practical example is a paint brush item that can dye sails similar to dyes: https://imgur.com/a/WdW1ibT