### PR TITLE
CameraMixin change for compatibility

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/mixin/CameraMixin.java
+++ b/src/main/java/com/simibubi/create/foundation/mixin/CameraMixin.java
@@ -4,6 +4,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import com.simibubi.create.content.logistics.trains.CameraDistanceModifier;
@@ -26,15 +27,13 @@ public abstract class CameraMixin {
 		throw new AssertionError();
 	}
 
-	@Inject(
+	@ModifyArg(
 			method = "Lnet/minecraft/client/Camera;setup(Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/world/entity/Entity;ZZF)V",
 			at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Camera;move(DDD)V", ordinal = 0),
-			cancellable = true
+			index = 0
 	)
-	public void modifySetup(BlockGetter pLevel, Entity pEntity, boolean pDetached, boolean pThirdPersonReverse, float pPartialTick, CallbackInfo ci) {
-		move(-this.getMaxZoom(4.0D * CameraDistanceModifier.getMultiplier(AnimationTickHolder.getPartialTicks())), 0, 0);
-		ci.cancel();
+	public double modifyCameraOffset(double originalValue) {
+		return -this.getMaxZoom(4.0D * CameraDistanceModifier.getMultiplier(AnimationTickHolder.getPartialTicks()));
 	}
-
 
 }


### PR DESCRIPTION
I am developer of another mod, and my mod is broken after latest changes in Create mod. I was injecting at the TAIL of Camera.setup method, but you are cancelling Camera.setup from your mixin. I think it is good idea to not cancel method if logically method is not cancelled and did its work.
I am proposing another way to inject into Camera.setup method. I think my way should have better compatibility with other mods, which may want to inject at the end of method and do some extra work.