### PR TITLE
Fixed THE bug

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/RotationPropagator.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/RotationPropagator.java
@@ -36,7 +36,7 @@ public class RotationPropagator {
 	 * Determines the change in rotation between two attached kinetic entities. For
 	 * instance, an axis connection returns 1 while a 1-to-1 gear connection
 	 * reverses the rotation and therefore returns -1.
-	 * 
+	 *
 	 * @param from
 	 * @param to
 	 * @return
@@ -201,7 +201,7 @@ public class RotationPropagator {
 
 	/**
 	 * Insert the added position to the kinetic network.
-	 * 
+	 *
 	 * @param worldIn
 	 * @param pos
 	 */
@@ -215,7 +215,7 @@ public class RotationPropagator {
 
 	/**
 	 * Search for sourceless networks attached to the given entity and update them.
-	 * 
+	 *
 	 * @param currentTE
 	 */
 	private static void propagateNewSource(KineticTileEntity currentTE) {
@@ -230,11 +230,14 @@ public class RotationPropagator {
 
 			if (newSpeed == 0 && oppositeSpeed == 0)
 				continue;
-			
+
 			boolean incompatible =
 				Math.signum(newSpeed) != Math.signum(speedOfNeighbour) && (newSpeed != 0 && speedOfNeighbour != 0);
 
-			boolean tooFast = Math.abs(newSpeed) > AllConfigs.SERVER.kinetics.maxRotationSpeed.get();
+			boolean tooFast = Math.abs(newSpeed) > AllConfigs.SERVER.kinetics.maxRotationSpeed.get()
+					|| Math.abs(oppositeSpeed) > AllConfigs.SERVER.kinetics.maxRotationSpeed.get();
+			// Check for both the new speed and the opposite speed, just in case
+
 			boolean speedChangedTooOften = currentTE.getFlickerScore() > MAX_FLICKER_SCORE;
 			if (tooFast || speedChangedTooOften) {
 				world.destroyBlock(pos, true);
@@ -300,7 +303,7 @@ public class RotationPropagator {
 
 	/**
 	 * Remove the given entity from the network.
-	 * 
+	 *
 	 * @param worldIn
 	 * @param pos
 	 * @param removedTE
@@ -333,7 +336,7 @@ public class RotationPropagator {
 	/**
 	 * Clear the entire subnetwork depending on the given entity and find a new
 	 * source
-	 * 
+	 *
 	 * @param updateTE
 	 */
 	private static void propagateMissingSource(KineticTileEntity updateTE) {


### PR DESCRIPTION
Fixed the bug that causes Large Cogwheel -> Small Cogwheel to be able to go overcharged (over the maximum speed)

After doing some test to see what was the problem, it seems like Create doesn't check for oppositeSpeed and see if it's over the maximum speed (which make sense, but I don't know why a this value someone is the newSpeed value, I guess it's some weird problem)

In any case, it makes sense to do that check anyway so yeah, problem solved!