### PR TITLE
Move from item-based air source detection to tag-based

### DIFF
--- a/src/generated/resources/.cache/cache
+++ b/src/generated/resources/.cache/cache
@@ -5649,6 +5649,7 @@ c98ffdc2780c2a7690c590f46f014aeee7b0b504 data/create/tags/items/create_ingots.js
 4480f211f4a37bfee193eba945bc9f5a8d2c6e34 data/create/tags/items/crushed_ores.json
 67385d5198d0796ec8f0d2c6ae144c672f4317a1 data/create/tags/items/modded_stripped_logs.json
 27a1074a88a7b939c811341086afece325ed724c data/create/tags/items/modded_stripped_wood.json
+7973972edb524683ef365bc103fcfcde0858a854 data/create/tags/items/pressurized_air_sources.json
 bce28787b0271382842823d04a977912a88b01c2 data/create/tags/items/sandpaper.json
 6cdeeac1689f7b5bfd9bc40b462143d8eaf3ad0b data/create/tags/items/seats.json
 0f4276a6b7da5f4dee8909802e6717a4c97f0555 data/create/tags/items/sleepers.json

--- a/src/generated/resources/data/create/tags/items/pressurized_air_sources.json
+++ b/src/generated/resources/data/create/tags/items/pressurized_air_sources.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "create:copper_backtank"
+  ]
+}

--- a/src/main/java/com/simibubi/create/AllItems.java
+++ b/src/main/java/com/simibubi/create/AllItems.java
@@ -248,6 +248,7 @@ public class AllItems {
 
 	COPPER_BACKTANK = REGISTRATE.item("copper_backtank", p -> new CopperBacktankItem(p, COPPER_BACKTANK_PLACEABLE))
 		.model(AssetLookup.customGenericItemModel("_", "item"))
+		.tag(AllItemTags.PRESSURIZED_AIR_SOURCES.tag)
 		.register(),
 
 		DIVING_HELMET = REGISTRATE.item("diving_helmet", DivingHelmetItem::new)

--- a/src/main/java/com/simibubi/create/AllTags.java
+++ b/src/main/java/com/simibubi/create/AllTags.java
@@ -221,6 +221,7 @@ public class AllTags {
 		MODDED_STRIPPED_WOOD,
 		CASING,
 		SLEEPERS,
+		PRESSURIZED_AIR_SOURCES,
 
 		STRIPPED_LOGS(FORGE),
 		STRIPPED_WOOD(FORGE),
@@ -445,7 +446,7 @@ public class AllTags {
 		strippedWoodCompat(Mods.BOP, "fir", "redwood", "cherry", "mahogany", "jacaranda", "palm", "willow", "dead",
 			"magic", "umbran", "hellbark");
 		strippedWoodCompat(Mods.BSK, "bluebright", "starlit", "frostbright", "lunar", "dusk", "maple", "cherry");
-		
+
 		AllItemTags.MODDED_STRIPPED_LOGS.addOptional(Mods.BYG, "stripped_bulbis_stem");
 		AllItemTags.MODDED_STRIPPED_WOOD.addOptional(Mods.BYG, "stripped_bulbis_wood");
 

--- a/src/main/java/com/simibubi/create/content/curiosities/armor/BackTankUtil.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/armor/BackTankUtil.java
@@ -3,6 +3,7 @@ package com.simibubi.create.content.curiosities.armor;
 import com.simibubi.create.AllEnchantments;
 import com.simibubi.create.AllItems;
 import com.simibubi.create.AllSoundEvents;
+import com.simibubi.create.AllTags;
 import com.simibubi.create.foundation.config.AllConfigs;
 import com.simibubi.create.foundation.utility.Lang;
 
@@ -28,7 +29,7 @@ public class BackTankUtil {
 
 	public static ItemStack get(LivingEntity entity) {
 		for (ItemStack itemStack : entity.getArmorSlots())
-			if (AllItems.COPPER_BACKTANK.isIn(itemStack))
+			if (AllTags.AllItemTags.PRESSURIZED_AIR_SOURCES.matches(itemStack))
 				return itemStack;
 		return ItemStack.EMPTY;
 	}


### PR DESCRIPTION
Replace the current logic to detect sources of pressurized air with an item tag.
This allows addon mods to add different items providing air without  having to solve it by using extreme methods such as mixins.