### PR TITLE
Break door blocks when rotating a contraption vertically

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/Contraption.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/Contraption.java
@@ -21,6 +21,8 @@ import java.util.function.BiConsumer;
 
 import javax.annotation.Nullable;
 
+import net.minecraft.world.level.block.DoorBlock;
+
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -1045,7 +1047,7 @@ public abstract class Contraption {
 				boolean verticalRotation = transform.rotationAxis == null || transform.rotationAxis.isHorizontal();
 				verticalRotation = verticalRotation && transform.rotation != Rotation.NONE;
 				if (verticalRotation) {
-					if (state.getBlock() instanceof RopeBlock || state.getBlock() instanceof MagnetBlock)
+					if (state.getBlock() instanceof RopeBlock || state.getBlock() instanceof MagnetBlock || state.getBlock() instanceof DoorBlock)
 						world.destroyBlock(targetPos, true);
 				}
 


### PR DESCRIPTION
When creating a contraption that rotates blocks vertically as so,

![image](https://user-images.githubusercontent.com/25208576/184012634-05eaf054-7c30-4ada-8fed-ca21851b8878.png)

as the contraption disassembles the door will get stuck in an invalid position:
![image](https://user-images.githubusercontent.com/25208576/184012809-348afcda-b1d5-40f8-bcdb-85fb5b61d48f.png)

This PR makes doors follow the same logic as pulleys, and will get disassembled if moved about a vertical axis. This likely fixes #3616 as it fixes the underlying issue causing the problem. I was not able to replicate the crash reported in the issue when testing, however.