### PR TITLE
1.19 fix jei dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,6 +157,7 @@ dependencies {
     }
 
     compileOnly fg.deobf("mezz.jei:jei-${jei_minecraft_version}-forge-api:${jei_version}")
+	compileOnly fg.deobf("mezz.jei:jei-${jei_minecraft_version}-common-api:${jei_version}")
     runtimeOnly fg.deobf("mezz.jei:jei-${jei_minecraft_version}-forge:${jei_version}")
 
     compileOnly fg.deobf("top.theillusivec4.curios:curios-forge:${curios_minecraft_version}-${curios_version}:api")

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ registrate_version = MC1.19-1.1.5
 flywheel_minecraft_version = 1.19.2
 flywheel_version = 0.6.5-3
 jei_minecraft_version = 1.19.2
-jei_version = 11.2.0.246
+jei_version = 11.2.0.247
 curios_minecraft_version = 1.19.2
 curios_version = 5.1.1.0
 


### PR DESCRIPTION
Added JEI dependencies, due to the lack of which the mod for version 1.19.2 was not built.

- Added a line  _compileOnly fg.deobf("mezz.jei:jei-${jei_minecraft_version}-common-api:${jei_version}")_  to build.gradle

- Changed the value  jei_version to 11.2.0.247
