### PR TITLE
fix typo: wrong chance shown in jei when chance < 0.01

### DIFF
--- a/src/main/java/com/simibubi/create/compat/jei/category/SequencedAssemblyCategory.java
+++ b/src/main/java/com/simibubi/create/compat/jei/category/SequencedAssemblyCategory.java
@@ -157,7 +157,7 @@ public class SequencedAssemblyCategory extends CreateRecipeCategory<SequencedAss
 		if (!singleOutput && mouseX >= minX && mouseX < maxX && mouseY >= minY && mouseY < maxY) {
 			float chance = recipe.getOutputChance();
 			tooltip.add(junk);
-			tooltip.add(Lang.translateDirect("recipe.processing.chance", chance < 0.01 ? "<1" : 100 - (int) (chance * 100))
+			tooltip.add(Lang.translateDirect("recipe.processing.chance", chance < 0.01 ? ">99" : 100 - (int) (chance * 100))
 				.withStyle(ChatFormatting.GOLD));
 			return tooltip;
 		}


### PR DESCRIPTION
In sequenced assembly recipe, if the production chance is lower than 0.01, both production and junk will be shown as '<1% chance' in JEI. This should be a typo.

~~Yes, I'm making a crazy recipe :laughing:~~