### PR TITLE
Fix StationPoweredCondition not working in other dimensions

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/trains/management/schedule/condition/StationPoweredCondition.java
+++ b/src/main/java/com/simibubi/create/content/logistics/trains/management/schedule/condition/StationPoweredCondition.java
@@ -2,6 +2,7 @@ package com.simibubi.create.content.logistics.trains.management.schedule.conditi
 
 import com.simibubi.create.Create;
 import com.simibubi.create.content.logistics.trains.entity.Train;
+import com.simibubi.create.content.logistics.trains.entity.TravellingPoint;
 import com.simibubi.create.content.logistics.trains.management.edgePoint.station.GlobalStation;
 import com.simibubi.create.foundation.utility.Lang;
 import com.simibubi.create.foundation.utility.Pair;
@@ -10,6 +11,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
@@ -19,16 +21,20 @@ public class StationPoweredCondition extends ScheduleWaitCondition {
 	public Pair<ItemStack, Component> getSummary() {
 		return Pair.of(ItemStack.EMPTY, Lang.translateDirect("schedule.condition.powered"));
 	}
-	
+
 	@Override
 	public boolean tickCompletion(Level level, Train train, CompoundTag context) {
 		GlobalStation currentStation = train.getCurrentStation();
 		if (currentStation == null)
 			return false;
-		BlockPos stationPos = currentStation.getTilePos();
-		if (!level.isLoaded(stationPos))
+		TravellingPoint leadingPoint = train.carriages.get(0).getLeadingPoint();
+		if (leadingPoint.node1 == null)
 			return false;
-		return level.hasNeighborSignal(stationPos);
+		Level dimensionLevel = level.getServer().getLevel(leadingPoint.node1.getLocation().dimension);
+		BlockPos stationPos = currentStation.getTilePos();
+		if (!dimensionLevel.isLoaded(stationPos))
+			return false;
+		return dimensionLevel.hasNeighborSignal(stationPos);
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/logistics/trains/management/schedule/condition/StationPoweredCondition.java
+++ b/src/main/java/com/simibubi/create/content/logistics/trains/management/schedule/condition/StationPoweredCondition.java
@@ -11,7 +11,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;


### PR DESCRIPTION
Apologies if this isn't the perfect solution as I'm new to Minecraft modding also I reported this and fixed this issue in the `#forge-bugs` Discord channel.

Trains in the Nether (and likely other dimensions that aren't the Overworld), cannot make use of the "Station Powered" condition. This is because ticking of all tracks is limited to the Overworld:

https://github.com/Creators-of-Create/Create/blob/774345192ba120b7da195859eed9d3b750dda72d/src/main/java/com/simibubi/create/content/logistics/trains/GlobalRailwayManager.java#L183-L184

Resulting in these commands to be run against the Overworld:

https://github.com/Creators-of-Create/Create/blob/774345192ba120b7da195859eed9d3b750dda72d/src/main/java/com/simibubi/create/content/logistics/trains/management/schedule/condition/StationPoweredCondition.java#L29-L31

The best solution I could come up with was based on:

https://github.com/Creators-of-Create/Create/blob/3e89d9a8788ff69d388b7deab2dac259829d3484/src/main/java/com/simibubi/create/content/logistics/trains/entity/Train.java#L290-L298