### PR TITLE
Fix FluidTagIngredient testing null tag

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/fluid/FluidIngredient.java
+++ b/src/main/java/com/simibubi/create/foundation/fluid/FluidIngredient.java
@@ -204,11 +204,13 @@ public abstract class FluidIngredient implements Predicate<FluidStack> {
 		@SuppressWarnings("deprecation")
 		@Override
 		protected boolean testInternal(FluidStack t) {
-			if (tag == null)
+			if (tag == null) {
 				for (FluidStack accepted : getMatchingFluidStacks())
 					if (accepted.getFluid()
 						.isSame(t.getFluid()))
 						return true;
+				return false;
+			}
 			return t.getFluid().is(tag);
 		}
 


### PR DESCRIPTION
This issue was bugging me while I was making Create Big Cannons, so here is a fix. Null tags seem to lead to NPEs when `FluidTagIngredient#testInternal` tries to test them.