### PR TITLE
Fixed basin recipes that override Recipe#getRemainingItems

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/processing/BasinRecipe.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/processing/BasinRecipe.java
@@ -16,9 +16,11 @@ import com.simibubi.create.foundation.tileEntity.behaviour.filtering.FilteringBe
 import com.simibubi.create.foundation.tileEntity.behaviour.fluid.SmartFluidTankBehaviour;
 import com.simibubi.create.foundation.tileEntity.behaviour.fluid.SmartFluidTankBehaviour.TankSegment;
 import com.simibubi.create.foundation.utility.Iterate;
+import com.simibubi.create.foundation.utility.recipe.DummyCraftingContainer;
 import com.simibubi.create.foundation.utility.recipe.IRecipeTypeInfo;
 
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.CraftingRecipe;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.level.Level;
@@ -104,9 +106,8 @@ public class BasinRecipe extends ProcessingRecipe<SmartInventory> {
 						continue Ingredients;
 					if (!simulate)
 						availableItems.extractItem(slot, 1, false);
-					else if (extracted.hasContainerItem())
-						recipeOutputItems.add(extracted.getContainerItem()
-							.copy());
+//					else if (extracted.hasContainerItem())
+//						recipeOutputItems.add(extracted.getContainerItem().copy());
 					extractedItemsFromSlot[slot]++;
 					continue Ingredients;
 				}
@@ -150,11 +151,17 @@ public class BasinRecipe extends ProcessingRecipe<SmartInventory> {
 			}
 
 			if (simulate) {
-				if (recipe instanceof BasinRecipe) {
-					recipeOutputItems.addAll(((BasinRecipe) recipe).rollResults());
-					recipeOutputFluids.addAll(((BasinRecipe) recipe).getFluidResults());
-				} else
+				if (recipe instanceof BasinRecipe basinRecipe) {
+					recipeOutputItems.addAll(basinRecipe.rollResults());
+					recipeOutputFluids.addAll(basinRecipe.getFluidResults());
+					recipeOutputItems.addAll(basinRecipe.getRemainingItems(basin.getInputInventory()));
+				} else {
 					recipeOutputItems.add(recipe.getResultItem());
+
+					if (recipe instanceof CraftingRecipe craftingRecipe) {
+						recipeOutputItems.addAll(craftingRecipe.getRemainingItems(new DummyCraftingContainer(basin.getInputInventory(), extractedItemsFromSlot)));
+					}
+				}
 			}
 
 			if (!basin.acceptOutputs(recipeOutputItems, recipeOutputFluids, simulate))

--- a/src/main/java/com/simibubi/create/content/contraptions/processing/BasinRecipe.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/processing/BasinRecipe.java
@@ -106,8 +106,6 @@ public class BasinRecipe extends ProcessingRecipe<SmartInventory> {
 						continue Ingredients;
 					if (!simulate)
 						availableItems.extractItem(slot, 1, false);
-//					else if (extracted.hasContainerItem())
-//						recipeOutputItems.add(extracted.getContainerItem().copy());
 					extractedItemsFromSlot[slot]++;
 					continue Ingredients;
 				}
@@ -159,7 +157,7 @@ public class BasinRecipe extends ProcessingRecipe<SmartInventory> {
 					recipeOutputItems.add(recipe.getResultItem());
 
 					if (recipe instanceof CraftingRecipe craftingRecipe) {
-						recipeOutputItems.addAll(craftingRecipe.getRemainingItems(new DummyCraftingContainer(basin.getInputInventory(), extractedItemsFromSlot)));
+						recipeOutputItems.addAll(craftingRecipe.getRemainingItems(new DummyCraftingContainer(availableItems, extractedItemsFromSlot)));
 					}
 				}
 			}

--- a/src/main/java/com/simibubi/create/foundation/utility/recipe/DummyCraftingContainer.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/recipe/DummyCraftingContainer.java
@@ -1,0 +1,80 @@
+package com.simibubi.create.foundation.utility.recipe;
+
+import org.jetbrains.annotations.NotNull;
+
+import net.minecraft.core.NonNullList;
+import net.minecraft.world.entity.player.StackedContents;
+import net.minecraft.world.inventory.CraftingContainer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.items.IItemHandler;
+
+public class DummyCraftingContainer extends CraftingContainer {
+
+	private final NonNullList<ItemStack> inv;
+
+	public DummyCraftingContainer(IItemHandler itemHandler, int[] extractedItemsFromSlot) {
+		super(null, 0, 0);
+
+		this.inv = createInventory(itemHandler, extractedItemsFromSlot);
+	}
+
+	@Override
+	public int getContainerSize() {
+		return this.inv.size();
+	}
+
+	@Override
+	public boolean isEmpty() {
+		for (int slot = 0; slot < this.getContainerSize(); slot++) {
+			if (!this.getItem(slot).isEmpty())
+				return false;
+		}
+
+		return true;
+	}
+
+	@Override
+	public @NotNull ItemStack getItem(int slot) {
+		return slot >= this.getContainerSize() ? ItemStack.EMPTY : this.inv.get(slot);
+	}
+
+	@Override
+	public @NotNull ItemStack removeItemNoUpdate(int slot) {
+		return ItemStack.EMPTY;
+	}
+
+	@Override
+	public @NotNull ItemStack removeItem(int slot, int count) {
+		return ItemStack.EMPTY;
+	}
+
+	@Override
+	public void setItem(int slot, @NotNull ItemStack stack) {}
+
+	@Override
+	public void clearContent() {}
+
+	@Override
+	public void fillStackedContents(@NotNull StackedContents helper) {}
+
+	private static NonNullList<ItemStack> createInventory(IItemHandler itemHandler, int[] extractedItemsFromSlot) {
+		NonNullList<ItemStack> inv = NonNullList.create();
+
+		for (int slot = 0; slot < itemHandler.getSlots(); slot++) {
+			ItemStack stack = itemHandler.getStackInSlot(slot);
+
+			if (stack.isEmpty())
+				continue;
+
+			for (int i = 0; i < extractedItemsFromSlot[slot]; i++) {
+				ItemStack stackCopy = stack.copy();
+				stackCopy.setCount(1);
+
+				inv.add(stackCopy);
+			}
+		}
+
+		return inv;
+	}
+
+}


### PR DESCRIPTION
- The output of Recipe#getRemainingItems was being ignored by basin recipes. This could cause duplication of container items
- Created DummyCraftingContainer to allow us to call Recipe#getRemainingItems for CraftingRecipes