### PR TITLE
Fix: blaze burner overfill and automation issue

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/processing/burner/BlazeBurnerTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/processing/burner/BlazeBurnerTileEntity.java
@@ -192,7 +192,7 @@ public class BlazeBurnerTileEntity extends SmartTileEntity {
 			newBurnTime = 1000;
 			newFuel = FuelType.SPECIAL;
 		} else {
-			newBurnTime = ForgeHooks.getBurnTime(itemStack, null);
+			newBurnTime = (int)Math.min(ForgeHooks.getBurnTime(itemStack, null), (float)(MAX_HEAT_CAPACITY) * 0.98);
 			if (newBurnTime > 0)
 				newFuel = FuelType.NORMAL;
 			else if (AllItemTags.BLAZE_BURNER_FUEL_REGULAR.matches(itemStack)) {


### PR DESCRIPTION
Currently when inserting an item that smelts > 50 items (such as lava buckets) into an unfueled blaze burner, its burn time will go over maximum.
This fixes that by limiting added burn time from a single item to 98% of max burn time.
Also fixes #3518