### PR TITLE
Add support for other mod ids in LangMerger

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/data/AllLangPartials.java
+++ b/src/main/java/com/simibubi/create/foundation/data/AllLangPartials.java
@@ -9,7 +9,9 @@ import com.simibubi.create.foundation.ponder.PonderLocalization;
 import com.simibubi.create.foundation.utility.FilesHelper;
 import com.simibubi.create.foundation.utility.Lang;
 
-public enum AllLangPartials {
+import java.util.List;
+
+public enum AllLangPartials implements ILangPartial {
 
 	ADVANCEMENTS("Advancements", AllAdvancements::provideLangEntries),
 	INTERFACE("UI & Messages"),
@@ -24,7 +26,7 @@ public enum AllLangPartials {
 
 	private AllLangPartials(String display) {
 		this.display = display;
-		this.provider = this::fromResource;
+		this.provider = getDefault();
 	}
 
 	private AllLangPartials(String display, Supplier<JsonElement> customProvider) {
@@ -32,21 +34,19 @@ public enum AllLangPartials {
 		this.provider = customProvider;
 	}
 
+	@Override
 	public String getDisplay() {
 		return display;
 	}
 
-	public JsonElement provide() {
-		return provider.get();
+	@Override
+	public String getFileName() {
+		return Lang.asId(name());
 	}
 
-	private JsonElement fromResource() {
-		String fileName = Lang.asId(name());
-		String filepath = "assets/" + Create.ID + "/lang/default/" + fileName + ".json";
-		JsonElement element = FilesHelper.loadJsonResource(filepath);
-		if (element == null)
-			throw new IllegalStateException(String.format("Could not find default lang file: %s", filepath));
-		return element;
+	@Override
+	public JsonElement provide() {
+		return provider.get();
 	}
 
 }

--- a/src/main/java/com/simibubi/create/foundation/data/ILangPartial.java
+++ b/src/main/java/com/simibubi/create/foundation/data/ILangPartial.java
@@ -1,0 +1,29 @@
+package com.simibubi.create.foundation.data;
+
+import com.google.common.base.Supplier;
+import com.google.gson.JsonElement;
+import com.simibubi.create.Create;
+import com.simibubi.create.foundation.utility.FilesHelper;
+
+import java.util.List;
+
+public interface ILangPartial {
+
+	String getDisplay();
+	String getFileName();
+
+	default String getModID() { return Create.ID; }
+
+	JsonElement provide();
+
+	private JsonElement fromResource() {
+		String fileName = getFileName();
+		String filepath = "assets/" + getModID() + "/lang/default/" + fileName + ".json";
+		JsonElement element = FilesHelper.loadJsonResource(filepath);
+		if (element == null)
+			throw new IllegalStateException(String.format("Could not find default lang file: %s", filepath));
+		return element;
+	}
+
+	default Supplier<JsonElement> getDefault() { return this::fromResource; }
+}

--- a/src/main/java/com/simibubi/create/foundation/data/LangMerger.java
+++ b/src/main/java/com/simibubi/create/foundation/data/LangMerger.java
@@ -39,6 +39,8 @@ public class LangMerger implements DataProvider {
 	static final String CATEGORY_HEADER = "\t\"_\": \"->------------------------]  %s  [------------------------<-\",";
 
 	private DataGenerator gen;
+	private final String modid;
+	private final String displayName;
 
 	private List<Object> mergedLangData;
 	private Map<String, List<Object>> populatedLangData;
@@ -47,8 +49,12 @@ public class LangMerger implements DataProvider {
 
 	private List<String> langIgnore;
 
-	public LangMerger(DataGenerator gen) {
+	public LangMerger(DataGenerator gen) { this(gen, Create.ID, "Create"); }
+
+	public LangMerger(DataGenerator gen, String modid, String displayName) {
 		this.gen = gen;
+		this.modid = modid;
+		this.displayName = displayName;
 		this.mergedLangData = new ArrayList<>();
 		this.langIgnore = new ArrayList<>();
 		this.allLocalizedEntries = new HashMap<>();
@@ -78,7 +84,7 @@ public class LangMerger implements DataProvider {
 	@Override
 	public void run(HashCache cache) throws IOException {
 		Path path = this.gen.getOutputFolder()
-			.resolve("assets/" + Create.ID + "/lang/" + "en_us.json");
+			.resolve("assets/" + modid + "/lang/" + "en_us.json");
 
 		for (Pair<String, JsonElement> pair : getAllLocalizationFiles()) {
 			if (!pair.getRight()
@@ -112,7 +118,7 @@ public class LangMerger implements DataProvider {
 		for (Entry<String, List<Object>> localization : populatedLangData.entrySet()) {
 			String key = localization.getKey();
 			Path populatedLangPath = this.gen.getOutputFolder()
-				.resolve("assets/" + Create.ID + "/lang/unfinished/" + key);
+				.resolve("assets/" + modid + "/lang/unfinished/" + key);
 			save(cache, localization.getValue(), missingTranslationTally.get(key)
 				.intValue(), populatedLangPath, "Populating " + key + " with missing entries...");
 		}
@@ -180,7 +186,7 @@ public class LangMerger implements DataProvider {
 		// Always put tooltips and ponder scenes in their own paragraphs
 		if (key.endsWith(".tooltip"))
 			return true;
-		if (key.startsWith("create.ponder") && key.endsWith(PonderScene.TITLE_KEY))
+		if (key.startsWith(modid + ".ponder") && key.endsWith(PonderScene.TITLE_KEY))
 			return true;
 
 		key = key.replaceFirst("\\.", "");
@@ -198,7 +204,7 @@ public class LangMerger implements DataProvider {
 	private List<Pair<String, JsonElement>> getAllLocalizationFiles() {
 		ArrayList<Pair<String, JsonElement>> list = new ArrayList<>();
 
-		String filepath = "assets/" + Create.ID + "/lang/";
+		String filepath = "assets/" + modid + "/lang/";
 		try (InputStream resourceStream = ClassLoader.getSystemResourceAsStream(filepath)) {
 			BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(resourceStream));
 			while (true) {
@@ -250,7 +256,7 @@ public class LangMerger implements DataProvider {
 		if (missingKeys != -1)
 			builder.append("\t\"_\": \"Missing Localizations: " + missingKeys + "\",\n");
 		data.forEach(builder::append);
-		builder.append("\t\"_\": \"Thank you for translating Create!\"\n\n");
+		builder.append("\t\"_\": \"Thank you for translating ").append(displayName).append("!\"\n\n");
 		builder.append("}");
 		return builder.toString();
 	}

--- a/src/main/java/com/simibubi/create/foundation/data/LangMerger.java
+++ b/src/main/java/com/simibubi/create/foundation/data/LangMerger.java
@@ -41,6 +41,7 @@ public class LangMerger implements DataProvider {
 	private DataGenerator gen;
 	private final String modid;
 	private final String displayName;
+	private final ILangPartial[] langPartials;
 
 	private List<Object> mergedLangData;
 	private Map<String, List<Object>> populatedLangData;
@@ -49,12 +50,15 @@ public class LangMerger implements DataProvider {
 
 	private List<String> langIgnore;
 
-	public LangMerger(DataGenerator gen) { this(gen, Create.ID, "Create"); }
+	public LangMerger(DataGenerator gen) {
+		this(gen, Create.ID, "Create", AllLangPartials.values());
+	}
 
-	public LangMerger(DataGenerator gen, String modid, String displayName) {
+	public <T extends ILangPartial> LangMerger(DataGenerator gen, String modid, String displayName, T[] langPartials) {
 		this.gen = gen;
 		this.modid = modid;
 		this.displayName = displayName;
+		this.langPartials = langPartials;
 		this.mergedLangData = new ArrayList<>();
 		this.langIgnore = new ArrayList<>();
 		this.allLocalizedEntries = new HashMap<>();
@@ -66,7 +70,7 @@ public class LangMerger implements DataProvider {
 	private void populateLangIgnore() {
 		// Key prefixes added here will NOT be transferred to lang templates
 		langIgnore.add("create.ponder.debug_"); // Ponder debug scene text
-		langIgnore.add("create.gui.chromatic_projector"); 
+		langIgnore.add("create.gui.chromatic_projector");
 	}
 
 	private boolean shouldIgnore(String key) {
@@ -225,7 +229,7 @@ public class LangMerger implements DataProvider {
 	}
 
 	private void collectEntries() {
-		for (AllLangPartials partial : AllLangPartials.values())
+		for (ILangPartial partial : langPartials)
 			addAll(partial.getDisplay(), partial.provide()
 				.getAsJsonObject());
 	}


### PR DESCRIPTION
Allows for addon mods to use `LangMerger` because it is _very_ useful.