### PR TITLE
Fix StationUnloadedCondition not working in other dimensions

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/trains/management/schedule/condition/StationUnloadedCondition.java
+++ b/src/main/java/com/simibubi/create/content/logistics/trains/management/schedule/condition/StationUnloadedCondition.java
@@ -28,7 +28,6 @@ public class StationUnloadedCondition extends ScheduleWaitCondition {
 		GlobalStation currentStation = train.getCurrentStation();
 		if (currentStation == null)
 			return false;
-		BlockPos stationPos = currentStation.getTilePos();
 		ResourceKey<Level> stationDim = currentStation.getTileDimension();
 		MinecraftServer server = level.getServer();
 		if (server == null)

--- a/src/main/java/com/simibubi/create/content/logistics/trains/management/schedule/condition/StationUnloadedCondition.java
+++ b/src/main/java/com/simibubi/create/content/logistics/trains/management/schedule/condition/StationUnloadedCondition.java
@@ -13,6 +13,9 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.MinecraftServer;
 
 public class StationUnloadedCondition extends ScheduleWaitCondition {
 	@Override
@@ -25,9 +28,16 @@ public class StationUnloadedCondition extends ScheduleWaitCondition {
 		GlobalStation currentStation = train.getCurrentStation();
 		if (currentStation == null)
 			return false;
-		if (level instanceof ServerLevel serverLevel) 
-			return !serverLevel.isPositionEntityTicking(currentStation.getTilePos());
-		return false;
+		BlockPos stationPos = currentStation.getTilePos();
+		ResourceKey<Level> stationDim = currentStation.getTileDimension();
+		MinecraftServer server = level.getServer();
+		if (server == null)
+			return false;
+		ServerLevel stationLevel = server.getLevel(stationDim);
+		if (stationLevel == null) {
+			return false;
+		}
+		return !stationLevel.isPositionEntityTicking(currentStation.getTilePos());
 	}
 
 	@Override


### PR DESCRIPTION
Related to #3791. If this condition is used in the nether, trains will always skip the station it's set on.

I pulled code from the fix in https://github.com/Creators-of-Create/Create/commit/c571493ce44ee1bb823eeb247acd01a589e6e8c9 into StationUnloadedCondtion. This seems to work in my testing.