### PR TITLE
Add survivalContraptionPickup option to config

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/mounted/MinecartContraptionItem.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/mounted/MinecartContraptionItem.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
+import com.simibubi.create.foundation.config.AllConfigs;
+
 import org.apache.commons.lang3.tuple.MutablePair;
 
 import com.google.common.io.ByteArrayDataOutput;
@@ -203,6 +205,9 @@ public class MinecartContraptionItem extends Item {
 	public static void wrenchCanBeUsedToPickUpMinecartContraptions(PlayerInteractEvent.EntityInteract event) {
 		Entity entity = event.getTarget();
 		Player player = event.getPlayer();
+		if (!AllConfigs.SERVER.kinetics.survivalContraptionPickup.get() && !player.isCreative()) {
+			return;
+		}
 		if (player == null || entity == null)
 			return;
 

--- a/src/main/java/com/simibubi/create/foundation/config/CKinetics.java
+++ b/src/main/java/com/simibubi/create/foundation/config/CKinetics.java
@@ -34,6 +34,7 @@ public class CKinetics extends ConfigBase {
 	public final ConfigInt maxPistonPoles = i(64, 1, "maxPistonPoles", Comments.maxPistonPoles);
 	public final ConfigInt maxRopeLength = i(256, 1, "maxRopeLength", Comments.maxRopeLength);
 	public final ConfigInt maxCartCouplingLength = i(32, 1, "maxCartCouplingLength", Comments.maxCartCouplingLength);
+	public final ConfigBool survivalContraptionPickup = b(true, "survivalContraptionPickup", Comments.survivalContraptionPickup);
 	public final ConfigEnum<ContraptionMovementSetting> spawnerMovement =
 		e(ContraptionMovementSetting.NO_PICKUP, "movableSpawners", Comments.spawnerMovement);
 	public final ConfigEnum<ContraptionMovementSetting> amethystMovement =
@@ -105,6 +106,7 @@ public class CKinetics extends ConfigBase {
 		static String maxEjectorDistance = "Max Distance in blocks a Weighted Ejector can throw";
 		static String ejectorScanInterval =
 			"Time in ticks until the next item launched by an ejector scans blocks for potential collisions";
+		static String survivalContraptionPickup = "Allow for minecart contartaption pickup in survival mode.";
 		static String spawnerMovement = "Configure how Spawner blocks can be moved by contraptions.";
 		static String amethystMovement = "Configure how Budding Amethyst can be moved by contraptions.";
 		static String obsidianMovement = "Configure how Obsidian blocks can be moved by contraptions.";


### PR DESCRIPTION
Adds the ability to choose whether minecart contraptions should be able to be picked up. I believe picking minecarts up speeds up the game in an unfair way and feels like a creative mode level ability. 

The default will remain as is.