### PR TITLE
Fix Single Ingredient Shapeless Mixing

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/components/mixer/MechanicalMixerTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/mixer/MechanicalMixerTileEntity.java
@@ -255,7 +255,7 @@ public class MechanicalMixerTileEntity extends BasinOperatingTileEntity {
 	protected <C extends Container> boolean matchStaticFilters(Recipe<C> r) {
 		return ((r instanceof CraftingRecipe && !(r instanceof IShapedRecipe<?>)
 				 && AllConfigs.SERVER.recipes.allowShapelessInMixer.get() && r.getIngredients()
-				.size() > 1
+				.size() >= 1
 				 && !MechanicalPressTileEntity.canCompress(r)) && !AllRecipeTypes.shouldIgnoreInAutomation(r)
 			|| r.getType() == AllRecipeTypes.MIXING.getType());
 	}


### PR DESCRIPTION
Fix mixer single ingredient shapeless crafting by adding a single = character.
It was checking only recipes with more than one ingredient, rather than equal to or more, and this conflicts with the Mechanical Mixer ponder message of:
_Available recipes include any Shapeless Crafting Recipe, plus a couple extra ones_

Fixes Fabricators-of-Create/Create#687.