### PR TITLE
Fix accuracy over network

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/ContraptionStallPacket.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/ContraptionStallPacket.java
@@ -12,31 +12,32 @@ import net.minecraftforge.network.NetworkEvent.Context;
 public class ContraptionStallPacket extends SimplePacketBase {
 
 	int entityID;
-	float x;
-	float y;
-	float z;
+	double x;
+	double y;
+	double z;
 	float angle;
 
 	public ContraptionStallPacket(int entityID, double posX, double posY, double posZ, float angle) {
 		this.entityID = entityID;
-		this.x = (float) posX;
-		this.y = (float) posY;
-		this.z = (float) posZ;
+		this.x = posX;
+		this.y = posY;
+		this.z = posZ;
 		this.angle = angle;
 	}
 
 	public ContraptionStallPacket(FriendlyByteBuf buffer) {
 		entityID = buffer.readInt();
-		x = buffer.readFloat();
-		y = buffer.readFloat();
-		z = buffer.readFloat();
+		x = buffer.readDouble();
+		y = buffer.readDouble();
+		z = buffer.readDouble();
 		angle = buffer.readFloat();
 	}
 
 	@Override
 	public void write(FriendlyByteBuf buffer) {
 		buffer.writeInt(entityID);
-		writeAll(buffer, x, y, z, angle);
+		writeAll(buffer, x, y, z);
+		buffer.writeFloat(angle);
 	}
 
 	@Override
@@ -46,9 +47,9 @@ public class ContraptionStallPacket extends SimplePacketBase {
 		context.get().setPacketHandled(true);
 	}
 
-	private void writeAll(FriendlyByteBuf buffer, float... floats) {
-		for (float f : floats)
-			buffer.writeFloat(f);
+	private void writeAll(FriendlyByteBuf buffer, double... doubles) {
+		for (double d : doubles)
+			buffer.writeDouble(d);
 	}
 
 }

--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/sync/LimbSwingUpdatePacket.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/sync/LimbSwingUpdatePacket.java
@@ -26,16 +26,16 @@ public class LimbSwingUpdatePacket extends SimplePacketBase {
 
 	public LimbSwingUpdatePacket(FriendlyByteBuf buffer) {
 		entityId = buffer.readInt();
-		position = new Vec3(buffer.readFloat(), buffer.readFloat(), buffer.readFloat());
+		position = new Vec3(buffer.readDouble(), buffer.readDouble(), buffer.readDouble());
 		limbSwing = buffer.readFloat();
 	}
 
 	@Override
 	public void write(FriendlyByteBuf buffer) {
 		buffer.writeInt(entityId);
-		buffer.writeFloat((float) position.x);
-		buffer.writeFloat((float) position.y);
-		buffer.writeFloat((float) position.z);
+		buffer.writeDouble(position.x);
+		buffer.writeDouble(position.y);
+		buffer.writeDouble(position.z);
 		buffer.writeFloat(limbSwing);
 	}
 

--- a/src/main/java/com/simibubi/create/content/logistics/trains/TrackNodeLocation.java
+++ b/src/main/java/com/simibubi/create/content/logistics/trains/TrackNodeLocation.java
@@ -46,7 +46,7 @@ public class TrackNodeLocation extends Vec3i {
 	}
 
 	public Vec3 getLocation() {
-		return new Vec3(getX() / 2f, getY() / 2f, getZ() / 2f);
+		return new Vec3(getX() / 2.0, getY() / 2.0, getZ() / 2.0);
 	}
 
 	public ResourceKey<Level> getDimension() {
@@ -58,7 +58,7 @@ public class TrackNodeLocation extends Vec3i {
 		return equalsIgnoreDim(pOther) && pOther instanceof TrackNodeLocation tnl
 			&& Objects.equals(tnl.dimension, dimension);
 	}
-	
+
 	public boolean equalsIgnoreDim(Object pOther) {
 		return super.equals(pOther);
 	}
@@ -83,12 +83,18 @@ public class TrackNodeLocation extends Vec3i {
 	}
 
 	public void send(FriendlyByteBuf buffer, DimensionPalette dimensions) {
-		buffer.writeBlockPos(new BlockPos(this));
+		buffer.writeVarInt(this.getX());
+		buffer.writeShort(this.getY());
+		buffer.writeVarInt(this.getZ());
 		buffer.writeVarInt(dimensions.encode(dimension));
 	}
 
 	public static TrackNodeLocation receive(FriendlyByteBuf buffer, DimensionPalette dimensions) {
-		TrackNodeLocation location = fromPackedPos(buffer.readBlockPos());
+		TrackNodeLocation location = fromPackedPos(new BlockPos(
+				buffer.readVarInt(),
+				buffer.readShort(),
+				buffer.readVarInt()
+		));
 		location.dimension = dimensions.decode(buffer.readVarInt());
 		return location;
 	}


### PR DESCRIPTION
Small changes that makes create work all the way to world border (or at least the things we have found).

* TrackNodeLocation seems to double the BlockPos but this means that it doesn't fit anymore in a long, thus has been replaced by 2 ints and a short.
* ContraptionStallPacket used floats for a entity location wich should be doubles.
* LimbSwingUpdatePacket same case as ContraptionStallPacket.