### PR TITLE
Fix: Exception during belt initialization.

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/relays/belt/BeltTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/relays/belt/BeltTileEntity.java
@@ -168,6 +168,8 @@ public class BeltTileEntity extends KineticTileEntity {
 	protected void initializeItemHandler() {
 		if (level.isClientSide || itemHandler.isPresent())
 			return;
+		if (controller == null)
+			return;
 		if (!level.isLoaded(controller))
 			return;
 		BlockEntity te = level.getBlockEntity(controller);


### PR DESCRIPTION
## Fixed
Fixed a problem that caused a NullPointerException when a belt was placed over a hopper or chute because initialization ran before the BlockPos object was prepared.

Added null check to controller variable.

※I am not a native English speaker, so I apologize if my writing is not correct.

## Issue
https://github.com/Creators-of-Create/Create/issues/4347