### PR TITLE
Added comparator output for FluidTank boiler state

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/fluids/tank/FluidTankBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/fluids/tank/FluidTankBlock.java
@@ -83,8 +83,8 @@ public class FluidTankBlock extends Block implements IWrenchable, ITE<FluidTankT
 		super(p_i48440_1_);
 		this.creative = creative;
 		registerDefaultState(defaultBlockState().setValue(TOP, true)
-			.setValue(BOTTOM, true)
-			.setValue(SHAPE, Shape.WINDOW));
+					.setValue(BOTTOM, true)
+					.setValue(SHAPE, Shape.WINDOW));
 	}
 
 	public static boolean isTank(BlockState state) {
@@ -126,7 +126,7 @@ public class FluidTankBlock extends Block implements IWrenchable, ITE<FluidTankT
 
 	@Override
 	public VoxelShape getCollisionShape(BlockState pState, BlockGetter pLevel, BlockPos pPos,
-		CollisionContext pContext) {
+						 CollisionContext pContext) {
 		if (pContext == CollisionContext.empty())
 			return CAMPFIRE_SMOKE_CLIP;
 		return pState.getShape(pLevel, pPos);
@@ -139,7 +139,7 @@ public class FluidTankBlock extends Block implements IWrenchable, ITE<FluidTankT
 
 	@Override
 	public BlockState updateShape(BlockState pState, Direction pDirection, BlockState pNeighborState,
-		LevelAccessor pLevel, BlockPos pCurrentPos, BlockPos pNeighborPos) {
+					  LevelAccessor pLevel, BlockPos pCurrentPos, BlockPos pNeighborPos) {
 		if (pDirection == Direction.DOWN && pNeighborState.getBlock() != this)
 			withTileEntityDo(pLevel, pCurrentPos, FluidTankTileEntity::updateBoilerTemperature);
 		return pState;
@@ -147,7 +147,7 @@ public class FluidTankBlock extends Block implements IWrenchable, ITE<FluidTankT
 
 	@Override
 	public InteractionResult use(BlockState state, Level world, BlockPos pos, Player player, InteractionHand hand,
-		BlockHitResult ray) {
+					 BlockHitResult ray) {
 		ItemStack heldItem = player.getItemInHand(hand);
 		boolean onClient = world.isClientSide;
 
@@ -175,7 +175,7 @@ public class FluidTankBlock extends Block implements IWrenchable, ITE<FluidTankT
 
 		if (exchange == null) {
 			if (EmptyingByBasin.canItemBeEmptied(world, heldItem)
-				|| GenericItemFilling.canItemBeFilled(world, heldItem))
+			    || GenericItemFilling.canItemBeFilled(world, heldItem))
 				return InteractionResult.SUCCESS;
 			return InteractionResult.PASS;
 		}
@@ -244,7 +244,7 @@ public class FluidTankBlock extends Block implements IWrenchable, ITE<FluidTankT
 
 						Vec3 vec = ray.getLocation();
 						vec = new Vec3(vec.x, controllerTE.getBlockPos()
-							.getY() + level * (controllerTE.height - .5f) + .25f, vec.z);
+								 .getY() + level * (controllerTE.height - .5f) + .25f, vec.z);
 						Vec3 motion = player.position()
 							.subtract(vec)
 							.scale(1 / 20f);
@@ -337,13 +337,13 @@ public class FluidTankBlock extends Block implements IWrenchable, ITE<FluidTankT
 	// Tanks are less noisy when placed in batch
 	public static final SoundType SILENCED_METAL =
 		new ForgeSoundType(0.1F, 1.5F, () -> SoundEvents.METAL_BREAK, () -> SoundEvents.METAL_STEP,
-			() -> SoundEvents.METAL_PLACE, () -> SoundEvents.METAL_HIT, () -> SoundEvents.METAL_FALL);
+				     () -> SoundEvents.METAL_PLACE, () -> SoundEvents.METAL_HIT, () -> SoundEvents.METAL_FALL);
 
 	@Override
 	public SoundType getSoundType(BlockState state, LevelReader world, BlockPos pos, Entity entity) {
 		SoundType soundType = super.getSoundType(state, world, pos, entity);
 		if (entity != null && entity.getPersistentData()
-			.contains("SilenceTankSound"))
+		    .contains("SilenceTankSound"))
 			return SILENCED_METAL;
 		return soundType;
 	}
@@ -356,7 +356,55 @@ public class FluidTankBlock extends Block implements IWrenchable, ITE<FluidTankT
 	@Override
 	public int getAnalogOutputSignal(BlockState blockState, Level worldIn, BlockPos pos) {
 		return getTileEntityOptional(worldIn, pos).map(FluidTankTileEntity::getControllerTE)
-			.map(te -> ComparatorUtil.fractionToRedstoneLevel(te.getFillState()))
+			.map(te -> {
+					int output = 0;
+					if (te.isBoiler()) {
+						BoilerData boiler = te.getBoilerData();
+
+						if (boiler.isPassive()) {
+							output = 1;
+						} else {
+							switch (boiler.getBoilerLevel()) {
+							case 0  : break; // boiler is idle
+							case 1  : output = 2;
+								break;
+							case 2  : output = 3;
+								break;
+							case 3  : output = 4;
+								break;
+							case 4  : output = 5;
+								break;
+							case 5  :
+							case 6  : output = 6;
+								break;
+							case 7  :
+							case 8  : output = 7;
+								break;
+							case 9  : output = 8;
+								break;
+							case 10 : output = 9;
+								break;
+							case 11 :
+							case 12 : output = 10;
+								break;
+							case 13 :
+							case 14 : output = 11;
+								break;
+							case 15 : output = 12;
+								break;
+							case 16 : output = 13;
+								break;
+							case 17 : output = 14;
+								break;
+							case 18 : output = 15;
+								break;
+							}
+						}
+					} else {
+						output = ComparatorUtil.fractionToRedstoneLevel(te.getFillState());
+					}
+					return output;
+				})
 			.orElse(0);
 	}
 

--- a/src/main/java/com/simibubi/create/content/contraptions/fluids/tank/FluidTankTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/fluids/tank/FluidTankTileEntity.java
@@ -157,7 +157,7 @@ public class FluidTankTileEntity extends SmartTileEntity implements IHaveGoggleI
 					if (tankAt == null)
 						continue;
 					level.updateNeighbourForOutputSignal(pos, tankAt.getBlockState()
-						.getBlock());
+														 .getBlock());
 					if (tankAt.luminosity == actualLuminosity)
 						continue;
 					tankAt.setLuminosity(actualLuminosity);
@@ -315,7 +315,7 @@ public class FluidTankTileEntity extends SmartTileEntity implements IHaveGoggleI
 				for (int xOffset = 0; xOffset < width; xOffset++)
 					for (int zOffset = 0; zOffset < width; zOffset++)
 						if (level.getBlockEntity(
-							worldPosition.offset(xOffset, yOffset, zOffset))instanceof FluidTankTileEntity fte)
+												 worldPosition.offset(xOffset, yOffset, zOffset))instanceof FluidTankTileEntity fte)
 							fte.refreshCapability();
 		}
 
@@ -323,6 +323,14 @@ public class FluidTankTileEntity extends SmartTileEntity implements IHaveGoggleI
 			notifyUpdate();
 			boiler.checkPipeOrganAdvancement(this);
 		}
+	}
+
+	public boolean isBoiler() {
+		return boiler.isActive();
+	}
+
+	public BoilerData getBoilerData() {
+		return boiler;
 	}
 
 	@Override
@@ -377,7 +385,7 @@ public class FluidTankTileEntity extends SmartTileEntity implements IHaveGoggleI
 		if (controllerTE.boiler.addToGoggleTooltip(tooltip, isPlayerSneaking, controllerTE.getTotalTankSize()))
 			return true;
 		return containedFluidTooltip(tooltip, isPlayerSneaking,
-			controllerTE.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY));
+									 controllerTE.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY));
 	}
 
 	@Override


### PR DESCRIPTION
### Let the analog output signal for a boiler reflect the state of the boiler. 

#### What is the rationale for adding this feature?: 
1. Add more dynamism and visual flair to power plants
2. Automatically activate or deactivate contraptions based on how much power is available

#### What are the gameplay changes?
A comparator reading from a FluidTank as a boiler will have the following output . These numbers were selected to represent idle to max boiler level with level 9 (half max boiler level) giving signal of 8 (half max redstone level).

| Boiler Level | Comparator Output |
|-----------------|---------------------------|
| Idle | 0 |
| Passive |  1 | 
| 1 | 2 |
| 2 | 3 |
| 3 | 4 |
| 4 | 5 |
| 5 | 6 |
| 6 | 6 |
| 7 | 7 |
| 8 | 7 | 
| 9 | 8 |
| 10 | 9 |
| 11 | 10 |
| 12 | 10 |
| 13 | 11 |
| 14 | 11 |
| 15 | 12 |
| 16 | 13 |
| 17 | 14 |
| 18 | 15 | 

PS: My editor introduced some whitespace changes, if there is a code formatter I should run please let me know.

Cheers,
Mitch