### PR TITLE
Added comparator output for FluidTank boiler state

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/fluids/tank/BoilerData.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/fluids/tank/BoilerData.java
@@ -38,423 +38,423 @@ import net.minecraftforge.fluids.capability.IFluidHandler;
 
 public class BoilerData {
 
-    static final int SAMPLE_RATE = 5;
-
-    private static final int waterSupplyPerLevel = 10;
-    private static final float passiveEngineEfficiency = 1 / 8f;
-
-    // pooled water supply
-    int gatheredSupply;
-    float[] supplyOverTime = new float[10];
-    int ticksUntilNextSample;
-    int currentIndex;
-
-    // heat score
-    public boolean needsHeatLevelUpdate;
-    public boolean passiveHeat;
-    public int activeHeat;
-
-    public float waterSupply;
-    public int attachedEngines;
-    public int attachedWhistles;
-
-    // display
-    private int maxHeatForSize = 0;
-    private int maxHeatForWater = 0;
-    private int minValue = 0;
-    private int maxValue = 0;
-
-    public LerpedFloat gauge = LerpedFloat.linear();
-
-    public void tick(FluidTankTileEntity controller) {
-        if (!isActive())
-            return;
-
-        Level level = controller.getLevel();
-        if (level.isClientSide) {
-            gauge.tickChaser();
-            float current = gauge.getValue(1);
-            if (current > 1 && Create.RANDOM.nextFloat() < 1 / 2f)
-                gauge.setValueNoUpdate(current + Math.min(-(current - 1) * Create.RANDOM.nextFloat(), 0));
-            return;
-        }
-
-        int capacity = controller.tankInventory.getCapacity();
-        boolean temperatureUpdated = needsHeatLevelUpdate && updateTemperature(controller);
-        if (!temperatureUpdated) {
-            ticksUntilNextSample--;
-            if (ticksUntilNextSample > 0)
-                return;
-            if (capacity == 0)
-                return;
-        }
-
-        ticksUntilNextSample = SAMPLE_RATE;
-        supplyOverTime[currentIndex] = gatheredSupply / (float) SAMPLE_RATE;
-        waterSupply = Math.max(waterSupply, supplyOverTime[currentIndex]);
-        currentIndex = (currentIndex + 1) % supplyOverTime.length;
-        gatheredSupply = 0;
-
-        if (capacity == 0) {
-            waterSupply = 0;
-        } else if (currentIndex == 0) {
-            waterSupply = 0;
-            for (float i : supplyOverTime)
-                waterSupply = Math.max(i, waterSupply);
-        }
-
-        if (controller instanceof CreativeFluidTankTileEntity)
-            waterSupply = waterSupplyPerLevel * 20;
-
-        if (getActualHeat(controller.getTotalTankSize()) == 18)
-            controller.award(AllAdvancements.STEAM_ENGINE_MAXED);
-
-        BlockPos controllerPos = controller.getBlockPos();
-        for (int yOffset = 0; yOffset < controller.height; yOffset++)
-            for (int xOffset = 0; xOffset < controller.width; xOffset++)
-                for (int zOffset = 0; zOffset < controller.width; zOffset++) {
-                    BlockPos pos = controllerPos.offset(xOffset, yOffset, zOffset);
-                    BlockState blockState = level.getBlockState(pos);
-                    if (!FluidTankBlock.isTank(blockState))
-                        continue;
-                    level.updateNeighbourForOutputSignal(pos, blockState.getBlock());
-                }
-
-        controller.notifyUpdate();
-    }
-
-    public int getTheoreticalHeatLevel() {
-        return activeHeat;
-    }
-
-    public int getMaxHeatLevelForBoilerSize(int boilerSize) {
-        return (int) Math.min(18, boilerSize / 4);
-    }
-
-    public int getMaxHeatLevelForWaterSupply() {
-        return (int) Math.min(18, Mth.ceil(waterSupply) / waterSupplyPerLevel);
-    }
-
-    public boolean isPassive() {
-        return passiveHeat && maxHeatForSize > 0 && maxHeatForWater > 0;
-    }
-
-    public boolean isPassive(int boilerSize) {
-        calcMinMaxForSize(boilerSize);
-        return isPassive();
-    }
-
-    public float getEngineEfficiency(int boilerSize) {
-        if (isPassive(boilerSize))
-            return passiveEngineEfficiency / attachedEngines;
-        if (activeHeat == 0)
-            return 0;
-        int actualHeat = getActualHeat(boilerSize);
-        return attachedEngines <= actualHeat ? 1 : (float) actualHeat / attachedEngines;
-    }
-
-    public int getBoilerLevel() {
-        return Math.min(activeHeat, Math.min(maxHeatForWater, maxHeatForSize));
-    }
-
-    private int getActualHeat(int boilerSize) {
-        int forBoilerSize = getMaxHeatLevelForBoilerSize(boilerSize);
-        int forWaterSupply = getMaxHeatLevelForWaterSupply();
-        int actualHeat = Math.min(activeHeat, Math.min(forWaterSupply, forBoilerSize));
-        return actualHeat;
-    }
-
-    public boolean addToGoggleTooltip(List<Component> tooltip, boolean isPlayerSneaking, int boilerSize) {
-        if (!isActive())
-            return false;
-
-        Component indent = Components.literal(IHaveGoggleInformation.spacing);
-        Component indent2 = Components.literal(IHaveGoggleInformation.spacing + " ");
-
-        calcMinMaxForSize(boilerSize);
-
-        tooltip.add(indent.plainCopy()
-                    .append(
-                            Lang.translateDirect("boiler.status", getHeatLevelTextComponent().withStyle(ChatFormatting.GREEN))));
-        tooltip.add(indent2.plainCopy()
-                    .append(getSizeComponent(true, false)));
-        tooltip.add(indent2.plainCopy()
-                    .append(getWaterComponent(true, false)));
-        tooltip.add(indent2.plainCopy()
-                    .append(getHeatComponent(true, false)));
-
-        if (attachedEngines == 0)
-            return true;
-
-        double totalSU = getEngineEfficiency(boilerSize) * 16 * Math.max(getBoilerLevel(), attachedEngines)
-            * BlockStressValues.getCapacity(AllBlocks.STEAM_ENGINE.get());
-
-        tooltip.add(Components.immutableEmpty());
-
-        Lang.translate("tooltip.capacityProvided")
-            .style(ChatFormatting.GRAY)
-            .forGoggles(tooltip);
-
-        Lang.number(totalSU)
-            .translate("generic.unit.stress")
-            .style(ChatFormatting.AQUA)
-            .space()
-            .add((attachedEngines == 1 ? Lang.translate("boiler.via_one_engine")
-                : Lang.translate("boiler.via_engines", attachedEngines)).style(ChatFormatting.DARK_GRAY))
-            .forGoggles(tooltip, 1);
-
-        return true;
-    }
-
-    public void calcMinMaxForSize(int boilerSize) {
-        maxHeatForSize = getMaxHeatLevelForBoilerSize(boilerSize);
-        maxHeatForWater = getMaxHeatLevelForWaterSupply();
-
-        minValue = Math.min(passiveHeat ? 1 : activeHeat, Math.min(maxHeatForWater, maxHeatForSize));
-        maxValue = Math.max(passiveHeat ? 1 : activeHeat, Math.max(maxHeatForWater, maxHeatForSize));
-    }
-
-    @NotNull
-    public MutableComponent getHeatLevelTextComponent() {
-        int boilerLevel = getBoilerLevel();
-
-        return isPassive() ? Lang.translateDirect("boiler.passive")
-            : (boilerLevel == 0) ? Lang.translateDirect("boiler.idle")
-            : (boilerLevel == 18) ? Lang.translateDirect("boiler.max_lvl")
-            : Lang.translateDirect("boiler.lvl", String.valueOf(boilerLevel));
-    }
-
-    public MutableComponent getSizeComponent(boolean forGoggles, boolean useBlocksAsBars, ChatFormatting... styles) {
-        return componentHelper("size", maxHeatForSize, forGoggles, useBlocksAsBars, styles);
-    }
-
-    public MutableComponent getWaterComponent(boolean forGoggles, boolean useBlocksAsBars, ChatFormatting... styles) {
-        return componentHelper("water", maxHeatForWater, forGoggles, useBlocksAsBars, styles);
-    }
-
-    public MutableComponent getHeatComponent(boolean forGoggles, boolean useBlocksAsBars, ChatFormatting... styles) {
-        return componentHelper("heat", passiveHeat ? 1 : activeHeat, forGoggles, useBlocksAsBars, styles);
-    }
-
-    private MutableComponent componentHelper(String label, int level, boolean forGoggles, boolean useBlocksAsBars,
-                                             ChatFormatting... styles) {
-        MutableComponent base = useBlocksAsBars ? blockComponent(level) : barComponent(level);
-
-        if (!forGoggles)
-            return base;
-
-        ChatFormatting style1 = styles.length >= 1 ? styles[0] : ChatFormatting.GRAY;
-        ChatFormatting style2 = styles.length >= 2 ? styles[1] : ChatFormatting.DARK_GRAY;
-
-        return Lang.translateDirect("boiler." + label)
-            .withStyle(style1)
-            .append(Lang.translateDirect("boiler." + label + "_dots")
-                    .withStyle(style2))
-            .append(base);
-    }
-
-    private MutableComponent blockComponent(int level) {
-        return Components.literal(
-            "" + "\u2588".repeat(minValue) + "\u2592".repeat(level - minValue) + "\u2591".repeat(maxValue - level));
-    }
-
-    private MutableComponent barComponent(int level) {
-        return Components.empty()
-            .append(bars(Math.max(0, minValue - 1), ChatFormatting.DARK_GREEN))
-            .append(bars(minValue > 0 ? 1 : 0, ChatFormatting.GREEN))
-            .append(bars(Math.max(0, level - minValue), ChatFormatting.DARK_GREEN))
-            .append(bars(Math.max(0, maxValue - level), ChatFormatting.DARK_RED))
-            .append(bars(Math.max(0, Math.min(18 - maxValue, ((maxValue / 5 + 1) * 5) - maxValue)),
-                         ChatFormatting.DARK_GRAY));
-
-    }
-
-    private MutableComponent bars(int level, ChatFormatting format) {
-        return Components.literal(Strings.repeat('|', level)).withStyle(format);
-    }
-
-    public boolean evaluate(FluidTankTileEntity controller) {
-        BlockPos controllerPos = controller.getBlockPos();
-        Level level = controller.getLevel();
-        int prevEngines = attachedEngines;
-        int prevWhistles = attachedWhistles;
-        attachedEngines = 0;
-        attachedWhistles = 0;
-
-        for (int yOffset = 0; yOffset < controller.height; yOffset++) {
-            for (int xOffset = 0; xOffset < controller.width; xOffset++) {
-                for (int zOffset = 0; zOffset < controller.width; zOffset++) {
-
-                    BlockPos pos = controllerPos.offset(xOffset, yOffset, zOffset);
-                    BlockState blockState = level.getBlockState(pos);
-                    if (!FluidTankBlock.isTank(blockState))
-                        continue;
-                    for (Direction d : Iterate.directions) {
-                        BlockPos attachedPos = pos.relative(d);
-                        BlockState attachedState = level.getBlockState(attachedPos);
-                        if (AllBlocks.STEAM_ENGINE.has(attachedState) && SteamEngineBlock.getFacing(attachedState) == d)
-                            attachedEngines++;
-                        if (AllBlocks.STEAM_WHISTLE.has(attachedState)
-                            && WhistleBlock.getAttachedDirection(attachedState)
-                            .getOpposite() == d)
-                            attachedWhistles++;
-                    }
-                }
-            }
-        }
-
-        needsHeatLevelUpdate = true;
-        return prevEngines != attachedEngines || prevWhistles != attachedWhistles;
-    }
-
-    public void checkPipeOrganAdvancement(FluidTankTileEntity controller) {
-        if (!controller.getBehaviour(AdvancementBehaviour.TYPE)
-            .isOwnerPresent())
-            return;
-
-        BlockPos controllerPos = controller.getBlockPos();
-        Level level = controller.getLevel();
-        Set<Integer> whistlePitches = new HashSet<>();
-
-        for (int yOffset = 0; yOffset < controller.height; yOffset++) {
-            for (int xOffset = 0; xOffset < controller.width; xOffset++) {
-                for (int zOffset = 0; zOffset < controller.width; zOffset++) {
-
-                    BlockPos pos = controllerPos.offset(xOffset, yOffset, zOffset);
-                    BlockState blockState = level.getBlockState(pos);
-                    if (!FluidTankBlock.isTank(blockState))
-                        continue;
-                    for (Direction d : Iterate.directions) {
-                        BlockPos attachedPos = pos.relative(d);
-                        BlockState attachedState = level.getBlockState(attachedPos);
-                        if (AllBlocks.STEAM_WHISTLE.has(attachedState)
-                            && WhistleBlock.getAttachedDirection(attachedState)
-                            .getOpposite() == d) {
-                            if (level.getBlockEntity(attachedPos)instanceof WhistleTileEntity wte)
-                                whistlePitches.add(wte.getPitchId());
-                        }
-                    }
-                }
-            }
-        }
-
-        if (whistlePitches.size() >= 12)
-            controller.award(AllAdvancements.PIPE_ORGAN);
-    }
-
-    public boolean updateTemperature(FluidTankTileEntity controller) {
-        BlockPos controllerPos = controller.getBlockPos();
-        Level level = controller.getLevel();
-        needsHeatLevelUpdate = false;
-
-        boolean prevPassive = passiveHeat;
-        int prevActive = activeHeat;
-        passiveHeat = false;
-        activeHeat = 0;
-
-        for (int xOffset = 0; xOffset < controller.width; xOffset++) {
-            for (int zOffset = 0; zOffset < controller.width; zOffset++) {
-                BlockPos pos = controllerPos.offset(xOffset, -1, zOffset);
-                BlockState blockState = level.getBlockState(pos);
-                float heat = BoilerHeaters.getActiveHeat(level, pos, blockState);
-                if (heat == 0) {
-                    passiveHeat = true;
-                } else if (heat > 0) {
-                    activeHeat += heat;
-                }
-            }
-        }
-
-        passiveHeat &= activeHeat == 0;
-
-        return prevActive != activeHeat || prevPassive != passiveHeat;
-    }
-
-    public boolean isActive() {
-        return attachedEngines > 0 || attachedWhistles > 0;
-    }
-
-    public void clear() {
-        waterSupply = 0;
-        activeHeat = 0;
-        passiveHeat = false;
-        attachedEngines = 0;
-        Arrays.fill(supplyOverTime, 0);
-    }
-
-    public CompoundTag write() {
-        CompoundTag nbt = new CompoundTag();
-        nbt.putFloat("Supply", waterSupply);
-        nbt.putInt("ActiveHeat", activeHeat);
-        nbt.putBoolean("PassiveHeat", passiveHeat);
-        nbt.putInt("Engines", attachedEngines);
-        nbt.putInt("Whistles", attachedWhistles);
-        nbt.putBoolean("Update", needsHeatLevelUpdate);
-        return nbt;
-    }
-
-    public void read(CompoundTag nbt, int boilerSize) {
-        waterSupply = nbt.getFloat("Supply");
-        activeHeat = nbt.getInt("ActiveHeat");
-        passiveHeat = nbt.getBoolean("PassiveHeat");
-        attachedEngines = nbt.getInt("Engines");
-        attachedWhistles = nbt.getInt("Whistles");
-        needsHeatLevelUpdate = nbt.getBoolean("Update");
-        Arrays.fill(supplyOverTime, (int) waterSupply);
-
-        int forBoilerSize = getMaxHeatLevelForBoilerSize(boilerSize);
-        int forWaterSupply = getMaxHeatLevelForWaterSupply();
-        int actualHeat = Math.min(activeHeat, Math.min(forWaterSupply, forBoilerSize));
-        float target = isPassive(boilerSize) ? 1 / 8f : forBoilerSize == 0 ? 0 : actualHeat / (forBoilerSize * 1f);
-        gauge.chase(target, 0.125f, Chaser.EXP);
-    }
-
-    public BoilerFluidHandler createHandler() {
-        return new BoilerFluidHandler();
-    }
-
-    public class BoilerFluidHandler implements IFluidHandler {
-
-        @Override
-        public int getTanks() {
-            return 1;
-        }
-
-        @Override
-        public FluidStack getFluidInTank(int tank) {
-            return FluidStack.EMPTY;
-        }
-
-        @Override
-        public int getTankCapacity(int tank) {
-            return 10000;
-        }
-
-        @Override
-        public boolean isFluidValid(int tank, FluidStack stack) {
-            return FluidHelper.isWater(stack.getFluid());
-        }
-
-        @Override
-        public int fill(FluidStack resource, FluidAction action) {
-            if (!isFluidValid(0, resource))
-                return 0;
-            int amount = resource.getAmount();
-            if (action.execute())
-                gatheredSupply += amount;
-            return amount;
-        }
-
-        @Override
-        public FluidStack drain(FluidStack resource, FluidAction action) {
-            return FluidStack.EMPTY;
-        }
-
-        @Override
-        public FluidStack drain(int maxDrain, FluidAction action) {
-            return FluidStack.EMPTY;
-        }
-
-    }
+	static final int SAMPLE_RATE = 5;
+
+	private static final int waterSupplyPerLevel = 10;
+	private static final float passiveEngineEfficiency = 1 / 8f;
+
+	// pooled water supply
+	int gatheredSupply;
+	float[] supplyOverTime = new float[10];
+	int ticksUntilNextSample;
+	int currentIndex;
+
+	// heat score
+	public boolean needsHeatLevelUpdate;
+	public boolean passiveHeat;
+	public int activeHeat;
+
+	public float waterSupply;
+	public int attachedEngines;
+	public int attachedWhistles;
+
+	// display
+	private int maxHeatForSize = 0;
+	private int maxHeatForWater = 0;
+	private int minValue = 0;
+	private int maxValue = 0;
+
+	public LerpedFloat gauge = LerpedFloat.linear();
+
+	public void tick(FluidTankTileEntity controller) {
+		if (!isActive())
+			return;
+
+		Level level = controller.getLevel();
+		if (level.isClientSide) {
+			gauge.tickChaser();
+			float current = gauge.getValue(1);
+			if (current > 1 && Create.RANDOM.nextFloat() < 1 / 2f)
+				gauge.setValueNoUpdate(current + Math.min(-(current - 1) * Create.RANDOM.nextFloat(), 0));
+			return;
+		}
+
+		int capacity = controller.tankInventory.getCapacity();
+		boolean temperatureUpdated = needsHeatLevelUpdate && updateTemperature(controller);
+		if (!temperatureUpdated) {
+			ticksUntilNextSample--;
+			if (ticksUntilNextSample > 0)
+				return;
+			if (capacity == 0)
+				return;
+		}
+
+		ticksUntilNextSample = SAMPLE_RATE;
+		supplyOverTime[currentIndex] = gatheredSupply / (float) SAMPLE_RATE;
+		waterSupply = Math.max(waterSupply, supplyOverTime[currentIndex]);
+		currentIndex = (currentIndex + 1) % supplyOverTime.length;
+		gatheredSupply = 0;
+
+		if (capacity == 0) {
+			waterSupply = 0;
+		} else if (currentIndex == 0) {
+			waterSupply = 0;
+			for (float i : supplyOverTime)
+				waterSupply = Math.max(i, waterSupply);
+		}
+
+		if (controller instanceof CreativeFluidTankTileEntity)
+			waterSupply = waterSupplyPerLevel * 20;
+
+		if (getActualHeat(controller.getTotalTankSize()) == 18)
+			controller.award(AllAdvancements.STEAM_ENGINE_MAXED);
+
+		BlockPos controllerPos = controller.getBlockPos();
+		for (int yOffset = 0; yOffset < controller.height; yOffset++)
+			for (int xOffset = 0; xOffset < controller.width; xOffset++)
+				for (int zOffset = 0; zOffset < controller.width; zOffset++) {
+					BlockPos pos = controllerPos.offset(xOffset, yOffset, zOffset);
+					BlockState blockState = level.getBlockState(pos);
+					if (!FluidTankBlock.isTank(blockState))
+						continue;
+					level.updateNeighbourForOutputSignal(pos, blockState.getBlock());
+				}
+
+		controller.notifyUpdate();
+	}
+
+	public int getTheoreticalHeatLevel() {
+		return activeHeat;
+	}
+
+	public int getMaxHeatLevelForBoilerSize(int boilerSize) {
+		return (int) Math.min(18, boilerSize / 4);
+	}
+
+	public int getMaxHeatLevelForWaterSupply() {
+		return (int) Math.min(18, Mth.ceil(waterSupply) / waterSupplyPerLevel);
+	}
+
+	public boolean isPassive() {
+		return passiveHeat && maxHeatForSize > 0 && maxHeatForWater > 0;
+	}
+
+	public boolean isPassive(int boilerSize) {
+		calcMinMaxForSize(boilerSize);
+		return isPassive();
+	}
+
+	public float getEngineEfficiency(int boilerSize) {
+		if (isPassive(boilerSize))
+			return passiveEngineEfficiency / attachedEngines;
+		if (activeHeat == 0)
+			return 0;
+		int actualHeat = getActualHeat(boilerSize);
+		return attachedEngines <= actualHeat ? 1 : (float) actualHeat / attachedEngines;
+	}
+
+	public int getBoilerLevel() {
+		return Math.min(activeHeat, Math.min(maxHeatForWater, maxHeatForSize));
+	}
+
+	private int getActualHeat(int boilerSize) {
+		int forBoilerSize = getMaxHeatLevelForBoilerSize(boilerSize);
+		int forWaterSupply = getMaxHeatLevelForWaterSupply();
+		int actualHeat = Math.min(activeHeat, Math.min(forWaterSupply, forBoilerSize));
+		return actualHeat;
+	}
+
+	public boolean addToGoggleTooltip(List<Component> tooltip, boolean isPlayerSneaking, int boilerSize) {
+		if (!isActive())
+			return false;
+
+		Component indent = Components.literal(IHaveGoggleInformation.spacing);
+		Component indent2 = Components.literal(IHaveGoggleInformation.spacing + " ");
+
+		calcMinMaxForSize(boilerSize);
+
+		tooltip.add(indent.plainCopy()
+					.append(
+							Lang.translateDirect("boiler.status", getHeatLevelTextComponent().withStyle(ChatFormatting.GREEN))));
+		tooltip.add(indent2.plainCopy()
+					.append(getSizeComponent(true, false)));
+		tooltip.add(indent2.plainCopy()
+					.append(getWaterComponent(true, false)));
+		tooltip.add(indent2.plainCopy()
+					.append(getHeatComponent(true, false)));
+
+		if (attachedEngines == 0)
+			return true;
+
+		double totalSU = getEngineEfficiency(boilerSize) * 16 * Math.max(getBoilerLevel(), attachedEngines)
+			* BlockStressValues.getCapacity(AllBlocks.STEAM_ENGINE.get());
+
+		tooltip.add(Components.immutableEmpty());
+
+		Lang.translate("tooltip.capacityProvided")
+			.style(ChatFormatting.GRAY)
+			.forGoggles(tooltip);
+
+		Lang.number(totalSU)
+			.translate("generic.unit.stress")
+			.style(ChatFormatting.AQUA)
+			.space()
+			.add((attachedEngines == 1 ? Lang.translate("boiler.via_one_engine")
+				: Lang.translate("boiler.via_engines", attachedEngines)).style(ChatFormatting.DARK_GRAY))
+			.forGoggles(tooltip, 1);
+
+		return true;
+	}
+
+	public void calcMinMaxForSize(int boilerSize) {
+		maxHeatForSize = getMaxHeatLevelForBoilerSize(boilerSize);
+		maxHeatForWater = getMaxHeatLevelForWaterSupply();
+
+		minValue = Math.min(passiveHeat ? 1 : activeHeat, Math.min(maxHeatForWater, maxHeatForSize));
+		maxValue = Math.max(passiveHeat ? 1 : activeHeat, Math.max(maxHeatForWater, maxHeatForSize));
+	}
+
+	@NotNull
+	public MutableComponent getHeatLevelTextComponent() {
+		int boilerLevel = getBoilerLevel();
+
+		return isPassive() ? Lang.translateDirect("boiler.passive")
+			: (boilerLevel == 0) ? Lang.translateDirect("boiler.idle")
+			: (boilerLevel == 18) ? Lang.translateDirect("boiler.max_lvl")
+			: Lang.translateDirect("boiler.lvl", String.valueOf(boilerLevel));
+	}
+
+	public MutableComponent getSizeComponent(boolean forGoggles, boolean useBlocksAsBars, ChatFormatting... styles) {
+		return componentHelper("size", maxHeatForSize, forGoggles, useBlocksAsBars, styles);
+	}
+
+	public MutableComponent getWaterComponent(boolean forGoggles, boolean useBlocksAsBars, ChatFormatting... styles) {
+		return componentHelper("water", maxHeatForWater, forGoggles, useBlocksAsBars, styles);
+	}
+
+	public MutableComponent getHeatComponent(boolean forGoggles, boolean useBlocksAsBars, ChatFormatting... styles) {
+		return componentHelper("heat", passiveHeat ? 1 : activeHeat, forGoggles, useBlocksAsBars, styles);
+	}
+
+	private MutableComponent componentHelper(String label, int level, boolean forGoggles, boolean useBlocksAsBars,
+											 ChatFormatting... styles) {
+		MutableComponent base = useBlocksAsBars ? blockComponent(level) : barComponent(level);
+
+		if (!forGoggles)
+			return base;
+
+		ChatFormatting style1 = styles.length >= 1 ? styles[0] : ChatFormatting.GRAY;
+		ChatFormatting style2 = styles.length >= 2 ? styles[1] : ChatFormatting.DARK_GRAY;
+
+		return Lang.translateDirect("boiler." + label)
+			.withStyle(style1)
+			.append(Lang.translateDirect("boiler." + label + "_dots")
+					.withStyle(style2))
+			.append(base);
+	}
+
+	private MutableComponent blockComponent(int level) {
+		return Components.literal(
+			"" + "\u2588".repeat(minValue) + "\u2592".repeat(level - minValue) + "\u2591".repeat(maxValue - level));
+	}
+
+	private MutableComponent barComponent(int level) {
+		return Components.empty()
+			.append(bars(Math.max(0, minValue - 1), ChatFormatting.DARK_GREEN))
+			.append(bars(minValue > 0 ? 1 : 0, ChatFormatting.GREEN))
+			.append(bars(Math.max(0, level - minValue), ChatFormatting.DARK_GREEN))
+			.append(bars(Math.max(0, maxValue - level), ChatFormatting.DARK_RED))
+			.append(bars(Math.max(0, Math.min(18 - maxValue, ((maxValue / 5 + 1) * 5) - maxValue)),
+						 ChatFormatting.DARK_GRAY));
+
+	}
+
+	private MutableComponent bars(int level, ChatFormatting format) {
+		return Components.literal(Strings.repeat('|', level)).withStyle(format);
+	}
+
+	public boolean evaluate(FluidTankTileEntity controller) {
+		BlockPos controllerPos = controller.getBlockPos();
+		Level level = controller.getLevel();
+		int prevEngines = attachedEngines;
+		int prevWhistles = attachedWhistles;
+		attachedEngines = 0;
+		attachedWhistles = 0;
+
+		for (int yOffset = 0; yOffset < controller.height; yOffset++) {
+			for (int xOffset = 0; xOffset < controller.width; xOffset++) {
+				for (int zOffset = 0; zOffset < controller.width; zOffset++) {
+
+					BlockPos pos = controllerPos.offset(xOffset, yOffset, zOffset);
+					BlockState blockState = level.getBlockState(pos);
+					if (!FluidTankBlock.isTank(blockState))
+						continue;
+					for (Direction d : Iterate.directions) {
+						BlockPos attachedPos = pos.relative(d);
+						BlockState attachedState = level.getBlockState(attachedPos);
+						if (AllBlocks.STEAM_ENGINE.has(attachedState) && SteamEngineBlock.getFacing(attachedState) == d)
+							attachedEngines++;
+						if (AllBlocks.STEAM_WHISTLE.has(attachedState)
+							&& WhistleBlock.getAttachedDirection(attachedState)
+							.getOpposite() == d)
+							attachedWhistles++;
+					}
+				}
+			}
+		}
+
+		needsHeatLevelUpdate = true;
+		return prevEngines != attachedEngines || prevWhistles != attachedWhistles;
+	}
+
+	public void checkPipeOrganAdvancement(FluidTankTileEntity controller) {
+		if (!controller.getBehaviour(AdvancementBehaviour.TYPE)
+			.isOwnerPresent())
+			return;
+
+		BlockPos controllerPos = controller.getBlockPos();
+		Level level = controller.getLevel();
+		Set<Integer> whistlePitches = new HashSet<>();
+
+		for (int yOffset = 0; yOffset < controller.height; yOffset++) {
+			for (int xOffset = 0; xOffset < controller.width; xOffset++) {
+				for (int zOffset = 0; zOffset < controller.width; zOffset++) {
+
+					BlockPos pos = controllerPos.offset(xOffset, yOffset, zOffset);
+					BlockState blockState = level.getBlockState(pos);
+					if (!FluidTankBlock.isTank(blockState))
+						continue;
+					for (Direction d : Iterate.directions) {
+						BlockPos attachedPos = pos.relative(d);
+						BlockState attachedState = level.getBlockState(attachedPos);
+						if (AllBlocks.STEAM_WHISTLE.has(attachedState)
+							&& WhistleBlock.getAttachedDirection(attachedState)
+							.getOpposite() == d) {
+							if (level.getBlockEntity(attachedPos)instanceof WhistleTileEntity wte)
+								whistlePitches.add(wte.getPitchId());
+						}
+					}
+				}
+			}
+		}
+
+		if (whistlePitches.size() >= 12)
+			controller.award(AllAdvancements.PIPE_ORGAN);
+	}
+
+	public boolean updateTemperature(FluidTankTileEntity controller) {
+		BlockPos controllerPos = controller.getBlockPos();
+		Level level = controller.getLevel();
+		needsHeatLevelUpdate = false;
+
+		boolean prevPassive = passiveHeat;
+		int prevActive = activeHeat;
+		passiveHeat = false;
+		activeHeat = 0;
+
+		for (int xOffset = 0; xOffset < controller.width; xOffset++) {
+			for (int zOffset = 0; zOffset < controller.width; zOffset++) {
+				BlockPos pos = controllerPos.offset(xOffset, -1, zOffset);
+				BlockState blockState = level.getBlockState(pos);
+				float heat = BoilerHeaters.getActiveHeat(level, pos, blockState);
+				if (heat == 0) {
+					passiveHeat = true;
+				} else if (heat > 0) {
+					activeHeat += heat;
+				}
+			}
+		}
+
+		passiveHeat &= activeHeat == 0;
+
+		return prevActive != activeHeat || prevPassive != passiveHeat;
+	}
+
+	public boolean isActive() {
+		return attachedEngines > 0 || attachedWhistles > 0;
+	}
+
+	public void clear() {
+		waterSupply = 0;
+		activeHeat = 0;
+		passiveHeat = false;
+		attachedEngines = 0;
+		Arrays.fill(supplyOverTime, 0);
+	}
+
+	public CompoundTag write() {
+		CompoundTag nbt = new CompoundTag();
+		nbt.putFloat("Supply", waterSupply);
+		nbt.putInt("ActiveHeat", activeHeat);
+		nbt.putBoolean("PassiveHeat", passiveHeat);
+		nbt.putInt("Engines", attachedEngines);
+		nbt.putInt("Whistles", attachedWhistles);
+		nbt.putBoolean("Update", needsHeatLevelUpdate);
+		return nbt;
+	}
+
+	public void read(CompoundTag nbt, int boilerSize) {
+		waterSupply = nbt.getFloat("Supply");
+		activeHeat = nbt.getInt("ActiveHeat");
+		passiveHeat = nbt.getBoolean("PassiveHeat");
+		attachedEngines = nbt.getInt("Engines");
+		attachedWhistles = nbt.getInt("Whistles");
+		needsHeatLevelUpdate = nbt.getBoolean("Update");
+		Arrays.fill(supplyOverTime, (int) waterSupply);
+
+		int forBoilerSize = getMaxHeatLevelForBoilerSize(boilerSize);
+		int forWaterSupply = getMaxHeatLevelForWaterSupply();
+		int actualHeat = Math.min(activeHeat, Math.min(forWaterSupply, forBoilerSize));
+		float target = isPassive(boilerSize) ? 1 / 8f : forBoilerSize == 0 ? 0 : actualHeat / (forBoilerSize * 1f);
+		gauge.chase(target, 0.125f, Chaser.EXP);
+	}
+
+	public BoilerFluidHandler createHandler() {
+		return new BoilerFluidHandler();
+	}
+
+	public class BoilerFluidHandler implements IFluidHandler {
+
+		@Override
+		public int getTanks() {
+			return 1;
+		}
+
+		@Override
+		public FluidStack getFluidInTank(int tank) {
+			return FluidStack.EMPTY;
+		}
+
+		@Override
+		public int getTankCapacity(int tank) {
+			return 10000;
+		}
+
+		@Override
+		public boolean isFluidValid(int tank, FluidStack stack) {
+			return FluidHelper.isWater(stack.getFluid());
+		}
+
+		@Override
+		public int fill(FluidStack resource, FluidAction action) {
+			if (!isFluidValid(0, resource))
+				return 0;
+			int amount = resource.getAmount();
+			if (action.execute())
+				gatheredSupply += amount;
+			return amount;
+		}
+
+		@Override
+		public FluidStack drain(FluidStack resource, FluidAction action) {
+			return FluidStack.EMPTY;
+		}
+
+		@Override
+		public FluidStack drain(int maxDrain, FluidAction action) {
+			return FluidStack.EMPTY;
+		}
+
+	}
 
 }

--- a/src/main/java/com/simibubi/create/content/contraptions/fluids/tank/BoilerData.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/fluids/tank/BoilerData.java
@@ -38,403 +38,423 @@ import net.minecraftforge.fluids.capability.IFluidHandler;
 
 public class BoilerData {
 
-	static final int SAMPLE_RATE = 5;
-
-	private static final int waterSupplyPerLevel = 10;
-	private static final float passiveEngineEfficiency = 1 / 8f;
-
-	// pooled water supply
-	int gatheredSupply;
-	float[] supplyOverTime = new float[10];
-	int ticksUntilNextSample;
-	int currentIndex;
-
-	// heat score
-	public boolean needsHeatLevelUpdate;
-	public boolean passiveHeat;
-	public int activeHeat;
-
-	public float waterSupply;
-	public int attachedEngines;
-	public int attachedWhistles;
-
-	// display
-	private int maxHeatForSize = 0;
-	private int maxHeatForWater = 0;
-	private int minValue = 0;
-	private int maxValue = 0;
-
-	public LerpedFloat gauge = LerpedFloat.linear();
-
-	public void tick(FluidTankTileEntity controller) {
-		if (!isActive())
-			return;
-		if (controller.getLevel().isClientSide) {
-			gauge.tickChaser();
-			float current = gauge.getValue(1);
-			if (current > 1 && Create.RANDOM.nextFloat() < 1 / 2f)
-				gauge.setValueNoUpdate(current + Math.min(-(current - 1) * Create.RANDOM.nextFloat(), 0));
-			return;
-		}
-		if (needsHeatLevelUpdate && updateTemperature(controller))
-			controller.notifyUpdate();
-		ticksUntilNextSample--;
-		if (ticksUntilNextSample > 0)
-			return;
-		int capacity = controller.tankInventory.getCapacity();
-		if (capacity == 0)
-			return;
-
-		ticksUntilNextSample = SAMPLE_RATE;
-		supplyOverTime[currentIndex] = gatheredSupply / (float) SAMPLE_RATE;
-		waterSupply = Math.max(waterSupply, supplyOverTime[currentIndex]);
-		currentIndex = (currentIndex + 1) % supplyOverTime.length;
-		gatheredSupply = 0;
-
-		if (currentIndex == 0) {
-			waterSupply = 0;
-			for (float i : supplyOverTime)
-				waterSupply = Math.max(i, waterSupply);
-		}
-		
-		if (controller instanceof CreativeFluidTankTileEntity)
-			waterSupply = waterSupplyPerLevel * 20;
-
-		if (getActualHeat(controller.getTotalTankSize()) == 18)
-			controller.award(AllAdvancements.STEAM_ENGINE_MAXED);
-
-		controller.notifyUpdate();
-	}
-
-	public int getTheoreticalHeatLevel() {
-		return activeHeat;
-	}
-
-	public int getMaxHeatLevelForBoilerSize(int boilerSize) {
-		return (int) Math.min(18, boilerSize / 4);
-	}
-
-	public int getMaxHeatLevelForWaterSupply() {
-		return (int) Math.min(18, Mth.ceil(waterSupply) / waterSupplyPerLevel);
-	}
-
-	public boolean isPassive() {
-		return passiveHeat && maxHeatForSize > 0 && maxHeatForWater > 0;
-	}
-
-	public boolean isPassive(int boilerSize) {
-		calcMinMaxForSize(boilerSize);
-		return isPassive();
-	}
-
-	public float getEngineEfficiency(int boilerSize) {
-		if (isPassive(boilerSize))
-			return passiveEngineEfficiency / attachedEngines;
-		if (activeHeat == 0)
-			return 0;
-		int actualHeat = getActualHeat(boilerSize);
-		return attachedEngines <= actualHeat ? 1 : (float) actualHeat / attachedEngines;
-	}
-
-	private int getActualHeat(int boilerSize) {
-		int forBoilerSize = getMaxHeatLevelForBoilerSize(boilerSize);
-		int forWaterSupply = getMaxHeatLevelForWaterSupply();
-		int actualHeat = Math.min(activeHeat, Math.min(forWaterSupply, forBoilerSize));
-		return actualHeat;
-	}
-
-	public boolean addToGoggleTooltip(List<Component> tooltip, boolean isPlayerSneaking, int boilerSize) {
-		if (!isActive())
-			return false;
-
-		Component indent = Components.literal(IHaveGoggleInformation.spacing);
-		Component indent2 = Components.literal(IHaveGoggleInformation.spacing + " ");
-
-		calcMinMaxForSize(boilerSize);
-
-		tooltip.add(indent.plainCopy()
-			.append(
-				Lang.translateDirect("boiler.status", getHeatLevelTextComponent().withStyle(ChatFormatting.GREEN))));
-		tooltip.add(indent2.plainCopy()
-			.append(getSizeComponent(true, false)));
-		tooltip.add(indent2.plainCopy()
-			.append(getWaterComponent(true, false)));
-		tooltip.add(indent2.plainCopy()
-			.append(getHeatComponent(true, false)));
-
-		if (attachedEngines == 0)
-			return true;
-
-		int boilerLevel = Math.min(activeHeat, Math.min(maxHeatForWater, maxHeatForSize));
-		double totalSU = getEngineEfficiency(boilerSize) * 16 * Math.max(boilerLevel, attachedEngines)
-			* BlockStressValues.getCapacity(AllBlocks.STEAM_ENGINE.get());
-
-		tooltip.add(Components.immutableEmpty());
-
-		Lang.translate("tooltip.capacityProvided")
-			.style(ChatFormatting.GRAY)
-			.forGoggles(tooltip);
-
-		Lang.number(totalSU)
-			.translate("generic.unit.stress")
-			.style(ChatFormatting.AQUA)
-			.space()
-			.add((attachedEngines == 1 ? Lang.translate("boiler.via_one_engine")
-				: Lang.translate("boiler.via_engines", attachedEngines)).style(ChatFormatting.DARK_GRAY))
-			.forGoggles(tooltip, 1);
-
-		return true;
-	}
-
-	public void calcMinMaxForSize(int boilerSize) {
-		maxHeatForSize = getMaxHeatLevelForBoilerSize(boilerSize);
-		maxHeatForWater = getMaxHeatLevelForWaterSupply();
-
-		minValue = Math.min(passiveHeat ? 1 : activeHeat, Math.min(maxHeatForWater, maxHeatForSize));
-		maxValue = Math.max(passiveHeat ? 1 : activeHeat, Math.max(maxHeatForWater, maxHeatForSize));
-	}
-
-	@NotNull
-	public MutableComponent getHeatLevelTextComponent() {
-		int boilerLevel = Math.min(activeHeat, Math.min(maxHeatForWater, maxHeatForSize));
-
-		return isPassive() ? Lang.translateDirect("boiler.passive")
-			: (boilerLevel == 0 ? Lang.translateDirect("boiler.idle")
-				: boilerLevel == 18 ? Lang.translateDirect("boiler.max_lvl")
-					: Lang.translateDirect("boiler.lvl", String.valueOf(boilerLevel)));
-	}
-
-	public MutableComponent getSizeComponent(boolean forGoggles, boolean useBlocksAsBars, ChatFormatting... styles) {
-		return componentHelper("size", maxHeatForSize, forGoggles, useBlocksAsBars, styles);
-	}
-
-	public MutableComponent getWaterComponent(boolean forGoggles, boolean useBlocksAsBars, ChatFormatting... styles) {
-		return componentHelper("water", maxHeatForWater, forGoggles, useBlocksAsBars, styles);
-	}
-
-	public MutableComponent getHeatComponent(boolean forGoggles, boolean useBlocksAsBars, ChatFormatting... styles) {
-		return componentHelper("heat", passiveHeat ? 1 : activeHeat, forGoggles, useBlocksAsBars, styles);
-	}
-
-	private MutableComponent componentHelper(String label, int level, boolean forGoggles, boolean useBlocksAsBars,
-		ChatFormatting... styles) {
-		MutableComponent base = useBlocksAsBars ? blockComponent(level) : barComponent(level);
-
-		if (!forGoggles)
-			return base;
-
-		ChatFormatting style1 = styles.length >= 1 ? styles[0] : ChatFormatting.GRAY;
-		ChatFormatting style2 = styles.length >= 2 ? styles[1] : ChatFormatting.DARK_GRAY;
-
-		return Lang.translateDirect("boiler." + label)
-			.withStyle(style1)
-			.append(Lang.translateDirect("boiler." + label + "_dots")
-				.withStyle(style2))
-			.append(base);
-	}
-
-	private MutableComponent blockComponent(int level) {
-		return Components.literal(
-			"" + "\u2588".repeat(minValue) + "\u2592".repeat(level - minValue) + "\u2591".repeat(maxValue - level));
-	}
-
-	private MutableComponent barComponent(int level) {
-		return Components.empty()
-			.append(bars(Math.max(0, minValue - 1), ChatFormatting.DARK_GREEN))
-			.append(bars(minValue > 0 ? 1 : 0, ChatFormatting.GREEN))
-			.append(bars(Math.max(0, level - minValue), ChatFormatting.DARK_GREEN))
-			.append(bars(Math.max(0, maxValue - level), ChatFormatting.DARK_RED))
-			.append(bars(Math.max(0, Math.min(18 - maxValue, ((maxValue / 5 + 1) * 5) - maxValue)),
-				ChatFormatting.DARK_GRAY));
-
-	}
-
-	private MutableComponent bars(int level, ChatFormatting format) {
-		return Components.literal(Strings.repeat('|', level)).withStyle(format);
-	}
-
-	public boolean evaluate(FluidTankTileEntity controller) {
-		BlockPos controllerPos = controller.getBlockPos();
-		Level level = controller.getLevel();
-		int prevEngines = attachedEngines;
-		int prevWhistles = attachedWhistles;
-		attachedEngines = 0;
-		attachedWhistles = 0;
-
-		for (int yOffset = 0; yOffset < controller.height; yOffset++) {
-			for (int xOffset = 0; xOffset < controller.width; xOffset++) {
-				for (int zOffset = 0; zOffset < controller.width; zOffset++) {
-
-					BlockPos pos = controllerPos.offset(xOffset, yOffset, zOffset);
-					BlockState blockState = level.getBlockState(pos);
-					if (!FluidTankBlock.isTank(blockState))
-						continue;
-					for (Direction d : Iterate.directions) {
-						BlockPos attachedPos = pos.relative(d);
-						BlockState attachedState = level.getBlockState(attachedPos);
-						if (AllBlocks.STEAM_ENGINE.has(attachedState) && SteamEngineBlock.getFacing(attachedState) == d)
-							attachedEngines++;
-						if (AllBlocks.STEAM_WHISTLE.has(attachedState)
-							&& WhistleBlock.getAttachedDirection(attachedState)
-								.getOpposite() == d)
-							attachedWhistles++;
-					}
-				}
-			}
-		}
-
-		needsHeatLevelUpdate = true;
-		return prevEngines != attachedEngines || prevWhistles != attachedWhistles;
-	}
-
-	public void checkPipeOrganAdvancement(FluidTankTileEntity controller) {
-		if (!controller.getBehaviour(AdvancementBehaviour.TYPE)
-			.isOwnerPresent())
-			return;
-
-		BlockPos controllerPos = controller.getBlockPos();
-		Level level = controller.getLevel();
-		Set<Integer> whistlePitches = new HashSet<>();
-
-		for (int yOffset = 0; yOffset < controller.height; yOffset++) {
-			for (int xOffset = 0; xOffset < controller.width; xOffset++) {
-				for (int zOffset = 0; zOffset < controller.width; zOffset++) {
-
-					BlockPos pos = controllerPos.offset(xOffset, yOffset, zOffset);
-					BlockState blockState = level.getBlockState(pos);
-					if (!FluidTankBlock.isTank(blockState))
-						continue;
-					for (Direction d : Iterate.directions) {
-						BlockPos attachedPos = pos.relative(d);
-						BlockState attachedState = level.getBlockState(attachedPos);
-						if (AllBlocks.STEAM_WHISTLE.has(attachedState)
-							&& WhistleBlock.getAttachedDirection(attachedState)
-								.getOpposite() == d) {
-							if (level.getBlockEntity(attachedPos)instanceof WhistleTileEntity wte)
-								whistlePitches.add(wte.getPitchId());
-						}
-					}
-				}
-			}
-		}
-
-		if (whistlePitches.size() >= 12)
-			controller.award(AllAdvancements.PIPE_ORGAN);
-	}
-
-	public boolean updateTemperature(FluidTankTileEntity controller) {
-		BlockPos controllerPos = controller.getBlockPos();
-		Level level = controller.getLevel();
-		needsHeatLevelUpdate = false;
-
-		boolean prevPassive = passiveHeat;
-		int prevActive = activeHeat;
-		passiveHeat = false;
-		activeHeat = 0;
-
-		for (int xOffset = 0; xOffset < controller.width; xOffset++) {
-			for (int zOffset = 0; zOffset < controller.width; zOffset++) {
-				BlockPos pos = controllerPos.offset(xOffset, -1, zOffset);
-				BlockState blockState = level.getBlockState(pos);
-				float heat = BoilerHeaters.getActiveHeat(level, pos, blockState);
-				if (heat == 0) {
-					passiveHeat = true;
-				} else if (heat > 0) {
-					activeHeat += heat;
-				}
-			}
-		}
-
-		passiveHeat &= activeHeat == 0;
-
-		return prevActive != activeHeat || prevPassive != passiveHeat;
-	}
-
-	public boolean isActive() {
-		return attachedEngines > 0 || attachedWhistles > 0;
-	}
-
-	public void clear() {
-		waterSupply = 0;
-		activeHeat = 0;
-		passiveHeat = false;
-		attachedEngines = 0;
-		Arrays.fill(supplyOverTime, 0);
-	}
-
-	public CompoundTag write() {
-		CompoundTag nbt = new CompoundTag();
-		nbt.putFloat("Supply", waterSupply);
-		nbt.putInt("ActiveHeat", activeHeat);
-		nbt.putBoolean("PassiveHeat", passiveHeat);
-		nbt.putInt("Engines", attachedEngines);
-		nbt.putInt("Whistles", attachedWhistles);
-		nbt.putBoolean("Update", needsHeatLevelUpdate);
-		return nbt;
-	}
-
-	public void read(CompoundTag nbt, int boilerSize) {
-		waterSupply = nbt.getFloat("Supply");
-		activeHeat = nbt.getInt("ActiveHeat");
-		passiveHeat = nbt.getBoolean("PassiveHeat");
-		attachedEngines = nbt.getInt("Engines");
-		attachedWhistles = nbt.getInt("Whistles");
-		needsHeatLevelUpdate = nbt.getBoolean("Update");
-		Arrays.fill(supplyOverTime, (int) waterSupply);
-
-		int forBoilerSize = getMaxHeatLevelForBoilerSize(boilerSize);
-		int forWaterSupply = getMaxHeatLevelForWaterSupply();
-		int actualHeat = Math.min(activeHeat, Math.min(forWaterSupply, forBoilerSize));
-		float target = isPassive(boilerSize) ? 1 / 8f : forBoilerSize == 0 ? 0 : actualHeat / (forBoilerSize * 1f);
-		gauge.chase(target, 0.125f, Chaser.EXP);
-	}
-
-	public BoilerFluidHandler createHandler() {
-		return new BoilerFluidHandler();
-	}
-
-	public class BoilerFluidHandler implements IFluidHandler {
-
-		@Override
-		public int getTanks() {
-			return 1;
-		}
-
-		@Override
-		public FluidStack getFluidInTank(int tank) {
-			return FluidStack.EMPTY;
-		}
-
-		@Override
-		public int getTankCapacity(int tank) {
-			return 10000;
-		}
-
-		@Override
-		public boolean isFluidValid(int tank, FluidStack stack) {
-			return FluidHelper.isWater(stack.getFluid());
-		}
-
-		@Override
-		public int fill(FluidStack resource, FluidAction action) {
-			if (!isFluidValid(0, resource))
-				return 0;
-			int amount = resource.getAmount();
-			if (action.execute())
-				gatheredSupply += amount;
-			return amount;
-		}
-
-		@Override
-		public FluidStack drain(FluidStack resource, FluidAction action) {
-			return FluidStack.EMPTY;
-		}
-
-		@Override
-		public FluidStack drain(int maxDrain, FluidAction action) {
-			return FluidStack.EMPTY;
-		}
-
-	}
+    static final int SAMPLE_RATE = 5;
+
+    private static final int waterSupplyPerLevel = 10;
+    private static final float passiveEngineEfficiency = 1 / 8f;
+
+    // pooled water supply
+    int gatheredSupply;
+    float[] supplyOverTime = new float[10];
+    int ticksUntilNextSample;
+    int currentIndex;
+
+    // heat score
+    public boolean needsHeatLevelUpdate;
+    public boolean passiveHeat;
+    public int activeHeat;
+
+    public float waterSupply;
+    public int attachedEngines;
+    public int attachedWhistles;
+
+    // display
+    private int maxHeatForSize = 0;
+    private int maxHeatForWater = 0;
+    private int minValue = 0;
+    private int maxValue = 0;
+
+    public LerpedFloat gauge = LerpedFloat.linear();
+
+    public void tick(FluidTankTileEntity controller) {
+        if (!isActive())
+            return;
+
+        Level level = controller.getLevel();
+        if (level.isClientSide) {
+            gauge.tickChaser();
+            float current = gauge.getValue(1);
+            if (current > 1 && Create.RANDOM.nextFloat() < 1 / 2f)
+                gauge.setValueNoUpdate(current + Math.min(-(current - 1) * Create.RANDOM.nextFloat(), 0));
+            return;
+        }
+
+        int capacity = controller.tankInventory.getCapacity();
+        boolean temperatureUpdated = needsHeatLevelUpdate && updateTemperature(controller);
+        if (!temperatureUpdated) {
+            ticksUntilNextSample--;
+            if (ticksUntilNextSample > 0)
+                return;
+            if (capacity == 0)
+                return;
+        }
+
+        ticksUntilNextSample = SAMPLE_RATE;
+        supplyOverTime[currentIndex] = gatheredSupply / (float) SAMPLE_RATE;
+        waterSupply = Math.max(waterSupply, supplyOverTime[currentIndex]);
+        currentIndex = (currentIndex + 1) % supplyOverTime.length;
+        gatheredSupply = 0;
+
+        if (capacity == 0) {
+            waterSupply = 0;
+        } else if (currentIndex == 0) {
+            waterSupply = 0;
+            for (float i : supplyOverTime)
+                waterSupply = Math.max(i, waterSupply);
+        }
+
+        if (controller instanceof CreativeFluidTankTileEntity)
+            waterSupply = waterSupplyPerLevel * 20;
+
+        if (getActualHeat(controller.getTotalTankSize()) == 18)
+            controller.award(AllAdvancements.STEAM_ENGINE_MAXED);
+
+        BlockPos controllerPos = controller.getBlockPos();
+        for (int yOffset = 0; yOffset < controller.height; yOffset++)
+            for (int xOffset = 0; xOffset < controller.width; xOffset++)
+                for (int zOffset = 0; zOffset < controller.width; zOffset++) {
+                    BlockPos pos = controllerPos.offset(xOffset, yOffset, zOffset);
+                    BlockState blockState = level.getBlockState(pos);
+                    if (!FluidTankBlock.isTank(blockState))
+                        continue;
+                    level.updateNeighbourForOutputSignal(pos, blockState.getBlock());
+                }
+
+        controller.notifyUpdate();
+    }
+
+    public int getTheoreticalHeatLevel() {
+        return activeHeat;
+    }
+
+    public int getMaxHeatLevelForBoilerSize(int boilerSize) {
+        return (int) Math.min(18, boilerSize / 4);
+    }
+
+    public int getMaxHeatLevelForWaterSupply() {
+        return (int) Math.min(18, Mth.ceil(waterSupply) / waterSupplyPerLevel);
+    }
+
+    public boolean isPassive() {
+        return passiveHeat && maxHeatForSize > 0 && maxHeatForWater > 0;
+    }
+
+    public boolean isPassive(int boilerSize) {
+        calcMinMaxForSize(boilerSize);
+        return isPassive();
+    }
+
+    public float getEngineEfficiency(int boilerSize) {
+        if (isPassive(boilerSize))
+            return passiveEngineEfficiency / attachedEngines;
+        if (activeHeat == 0)
+            return 0;
+        int actualHeat = getActualHeat(boilerSize);
+        return attachedEngines <= actualHeat ? 1 : (float) actualHeat / attachedEngines;
+    }
+
+    public int getBoilerLevel() {
+        return Math.min(activeHeat, Math.min(maxHeatForWater, maxHeatForSize));
+    }
+
+    private int getActualHeat(int boilerSize) {
+        int forBoilerSize = getMaxHeatLevelForBoilerSize(boilerSize);
+        int forWaterSupply = getMaxHeatLevelForWaterSupply();
+        int actualHeat = Math.min(activeHeat, Math.min(forWaterSupply, forBoilerSize));
+        return actualHeat;
+    }
+
+    public boolean addToGoggleTooltip(List<Component> tooltip, boolean isPlayerSneaking, int boilerSize) {
+        if (!isActive())
+            return false;
+
+        Component indent = Components.literal(IHaveGoggleInformation.spacing);
+        Component indent2 = Components.literal(IHaveGoggleInformation.spacing + " ");
+
+        calcMinMaxForSize(boilerSize);
+
+        tooltip.add(indent.plainCopy()
+                    .append(
+                            Lang.translateDirect("boiler.status", getHeatLevelTextComponent().withStyle(ChatFormatting.GREEN))));
+        tooltip.add(indent2.plainCopy()
+                    .append(getSizeComponent(true, false)));
+        tooltip.add(indent2.plainCopy()
+                    .append(getWaterComponent(true, false)));
+        tooltip.add(indent2.plainCopy()
+                    .append(getHeatComponent(true, false)));
+
+        if (attachedEngines == 0)
+            return true;
+
+        double totalSU = getEngineEfficiency(boilerSize) * 16 * Math.max(getBoilerLevel(), attachedEngines)
+            * BlockStressValues.getCapacity(AllBlocks.STEAM_ENGINE.get());
+
+        tooltip.add(Components.immutableEmpty());
+
+        Lang.translate("tooltip.capacityProvided")
+            .style(ChatFormatting.GRAY)
+            .forGoggles(tooltip);
+
+        Lang.number(totalSU)
+            .translate("generic.unit.stress")
+            .style(ChatFormatting.AQUA)
+            .space()
+            .add((attachedEngines == 1 ? Lang.translate("boiler.via_one_engine")
+                : Lang.translate("boiler.via_engines", attachedEngines)).style(ChatFormatting.DARK_GRAY))
+            .forGoggles(tooltip, 1);
+
+        return true;
+    }
+
+    public void calcMinMaxForSize(int boilerSize) {
+        maxHeatForSize = getMaxHeatLevelForBoilerSize(boilerSize);
+        maxHeatForWater = getMaxHeatLevelForWaterSupply();
+
+        minValue = Math.min(passiveHeat ? 1 : activeHeat, Math.min(maxHeatForWater, maxHeatForSize));
+        maxValue = Math.max(passiveHeat ? 1 : activeHeat, Math.max(maxHeatForWater, maxHeatForSize));
+    }
+
+    @NotNull
+    public MutableComponent getHeatLevelTextComponent() {
+        int boilerLevel = getBoilerLevel();
+
+        return isPassive() ? Lang.translateDirect("boiler.passive")
+            : (boilerLevel == 0) ? Lang.translateDirect("boiler.idle")
+            : (boilerLevel == 18) ? Lang.translateDirect("boiler.max_lvl")
+            : Lang.translateDirect("boiler.lvl", String.valueOf(boilerLevel));
+    }
+
+    public MutableComponent getSizeComponent(boolean forGoggles, boolean useBlocksAsBars, ChatFormatting... styles) {
+        return componentHelper("size", maxHeatForSize, forGoggles, useBlocksAsBars, styles);
+    }
+
+    public MutableComponent getWaterComponent(boolean forGoggles, boolean useBlocksAsBars, ChatFormatting... styles) {
+        return componentHelper("water", maxHeatForWater, forGoggles, useBlocksAsBars, styles);
+    }
+
+    public MutableComponent getHeatComponent(boolean forGoggles, boolean useBlocksAsBars, ChatFormatting... styles) {
+        return componentHelper("heat", passiveHeat ? 1 : activeHeat, forGoggles, useBlocksAsBars, styles);
+    }
+
+    private MutableComponent componentHelper(String label, int level, boolean forGoggles, boolean useBlocksAsBars,
+                                             ChatFormatting... styles) {
+        MutableComponent base = useBlocksAsBars ? blockComponent(level) : barComponent(level);
+
+        if (!forGoggles)
+            return base;
+
+        ChatFormatting style1 = styles.length >= 1 ? styles[0] : ChatFormatting.GRAY;
+        ChatFormatting style2 = styles.length >= 2 ? styles[1] : ChatFormatting.DARK_GRAY;
+
+        return Lang.translateDirect("boiler." + label)
+            .withStyle(style1)
+            .append(Lang.translateDirect("boiler." + label + "_dots")
+                    .withStyle(style2))
+            .append(base);
+    }
+
+    private MutableComponent blockComponent(int level) {
+        return Components.literal(
+            "" + "\u2588".repeat(minValue) + "\u2592".repeat(level - minValue) + "\u2591".repeat(maxValue - level));
+    }
+
+    private MutableComponent barComponent(int level) {
+        return Components.empty()
+            .append(bars(Math.max(0, minValue - 1), ChatFormatting.DARK_GREEN))
+            .append(bars(minValue > 0 ? 1 : 0, ChatFormatting.GREEN))
+            .append(bars(Math.max(0, level - minValue), ChatFormatting.DARK_GREEN))
+            .append(bars(Math.max(0, maxValue - level), ChatFormatting.DARK_RED))
+            .append(bars(Math.max(0, Math.min(18 - maxValue, ((maxValue / 5 + 1) * 5) - maxValue)),
+                         ChatFormatting.DARK_GRAY));
+
+    }
+
+    private MutableComponent bars(int level, ChatFormatting format) {
+        return Components.literal(Strings.repeat('|', level)).withStyle(format);
+    }
+
+    public boolean evaluate(FluidTankTileEntity controller) {
+        BlockPos controllerPos = controller.getBlockPos();
+        Level level = controller.getLevel();
+        int prevEngines = attachedEngines;
+        int prevWhistles = attachedWhistles;
+        attachedEngines = 0;
+        attachedWhistles = 0;
+
+        for (int yOffset = 0; yOffset < controller.height; yOffset++) {
+            for (int xOffset = 0; xOffset < controller.width; xOffset++) {
+                for (int zOffset = 0; zOffset < controller.width; zOffset++) {
+
+                    BlockPos pos = controllerPos.offset(xOffset, yOffset, zOffset);
+                    BlockState blockState = level.getBlockState(pos);
+                    if (!FluidTankBlock.isTank(blockState))
+                        continue;
+                    for (Direction d : Iterate.directions) {
+                        BlockPos attachedPos = pos.relative(d);
+                        BlockState attachedState = level.getBlockState(attachedPos);
+                        if (AllBlocks.STEAM_ENGINE.has(attachedState) && SteamEngineBlock.getFacing(attachedState) == d)
+                            attachedEngines++;
+                        if (AllBlocks.STEAM_WHISTLE.has(attachedState)
+                            && WhistleBlock.getAttachedDirection(attachedState)
+                            .getOpposite() == d)
+                            attachedWhistles++;
+                    }
+                }
+            }
+        }
+
+        needsHeatLevelUpdate = true;
+        return prevEngines != attachedEngines || prevWhistles != attachedWhistles;
+    }
+
+    public void checkPipeOrganAdvancement(FluidTankTileEntity controller) {
+        if (!controller.getBehaviour(AdvancementBehaviour.TYPE)
+            .isOwnerPresent())
+            return;
+
+        BlockPos controllerPos = controller.getBlockPos();
+        Level level = controller.getLevel();
+        Set<Integer> whistlePitches = new HashSet<>();
+
+        for (int yOffset = 0; yOffset < controller.height; yOffset++) {
+            for (int xOffset = 0; xOffset < controller.width; xOffset++) {
+                for (int zOffset = 0; zOffset < controller.width; zOffset++) {
+
+                    BlockPos pos = controllerPos.offset(xOffset, yOffset, zOffset);
+                    BlockState blockState = level.getBlockState(pos);
+                    if (!FluidTankBlock.isTank(blockState))
+                        continue;
+                    for (Direction d : Iterate.directions) {
+                        BlockPos attachedPos = pos.relative(d);
+                        BlockState attachedState = level.getBlockState(attachedPos);
+                        if (AllBlocks.STEAM_WHISTLE.has(attachedState)
+                            && WhistleBlock.getAttachedDirection(attachedState)
+                            .getOpposite() == d) {
+                            if (level.getBlockEntity(attachedPos)instanceof WhistleTileEntity wte)
+                                whistlePitches.add(wte.getPitchId());
+                        }
+                    }
+                }
+            }
+        }
+
+        if (whistlePitches.size() >= 12)
+            controller.award(AllAdvancements.PIPE_ORGAN);
+    }
+
+    public boolean updateTemperature(FluidTankTileEntity controller) {
+        BlockPos controllerPos = controller.getBlockPos();
+        Level level = controller.getLevel();
+        needsHeatLevelUpdate = false;
+
+        boolean prevPassive = passiveHeat;
+        int prevActive = activeHeat;
+        passiveHeat = false;
+        activeHeat = 0;
+
+        for (int xOffset = 0; xOffset < controller.width; xOffset++) {
+            for (int zOffset = 0; zOffset < controller.width; zOffset++) {
+                BlockPos pos = controllerPos.offset(xOffset, -1, zOffset);
+                BlockState blockState = level.getBlockState(pos);
+                float heat = BoilerHeaters.getActiveHeat(level, pos, blockState);
+                if (heat == 0) {
+                    passiveHeat = true;
+                } else if (heat > 0) {
+                    activeHeat += heat;
+                }
+            }
+        }
+
+        passiveHeat &= activeHeat == 0;
+
+        return prevActive != activeHeat || prevPassive != passiveHeat;
+    }
+
+    public boolean isActive() {
+        return attachedEngines > 0 || attachedWhistles > 0;
+    }
+
+    public void clear() {
+        waterSupply = 0;
+        activeHeat = 0;
+        passiveHeat = false;
+        attachedEngines = 0;
+        Arrays.fill(supplyOverTime, 0);
+    }
+
+    public CompoundTag write() {
+        CompoundTag nbt = new CompoundTag();
+        nbt.putFloat("Supply", waterSupply);
+        nbt.putInt("ActiveHeat", activeHeat);
+        nbt.putBoolean("PassiveHeat", passiveHeat);
+        nbt.putInt("Engines", attachedEngines);
+        nbt.putInt("Whistles", attachedWhistles);
+        nbt.putBoolean("Update", needsHeatLevelUpdate);
+        return nbt;
+    }
+
+    public void read(CompoundTag nbt, int boilerSize) {
+        waterSupply = nbt.getFloat("Supply");
+        activeHeat = nbt.getInt("ActiveHeat");
+        passiveHeat = nbt.getBoolean("PassiveHeat");
+        attachedEngines = nbt.getInt("Engines");
+        attachedWhistles = nbt.getInt("Whistles");
+        needsHeatLevelUpdate = nbt.getBoolean("Update");
+        Arrays.fill(supplyOverTime, (int) waterSupply);
+
+        int forBoilerSize = getMaxHeatLevelForBoilerSize(boilerSize);
+        int forWaterSupply = getMaxHeatLevelForWaterSupply();
+        int actualHeat = Math.min(activeHeat, Math.min(forWaterSupply, forBoilerSize));
+        float target = isPassive(boilerSize) ? 1 / 8f : forBoilerSize == 0 ? 0 : actualHeat / (forBoilerSize * 1f);
+        gauge.chase(target, 0.125f, Chaser.EXP);
+    }
+
+    public BoilerFluidHandler createHandler() {
+        return new BoilerFluidHandler();
+    }
+
+    public class BoilerFluidHandler implements IFluidHandler {
+
+        @Override
+        public int getTanks() {
+            return 1;
+        }
+
+        @Override
+        public FluidStack getFluidInTank(int tank) {
+            return FluidStack.EMPTY;
+        }
+
+        @Override
+        public int getTankCapacity(int tank) {
+            return 10000;
+        }
+
+        @Override
+        public boolean isFluidValid(int tank, FluidStack stack) {
+            return FluidHelper.isWater(stack.getFluid());
+        }
+
+        @Override
+        public int fill(FluidStack resource, FluidAction action) {
+            if (!isFluidValid(0, resource))
+                return 0;
+            int amount = resource.getAmount();
+            if (action.execute())
+                gatheredSupply += amount;
+            return amount;
+        }
+
+        @Override
+        public FluidStack drain(FluidStack resource, FluidAction action) {
+            return FluidStack.EMPTY;
+        }
+
+        @Override
+        public FluidStack drain(int maxDrain, FluidAction action) {
+            return FluidStack.EMPTY;
+        }
+
+    }
 
 }

--- a/src/main/java/com/simibubi/create/content/contraptions/fluids/tank/FluidTankBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/fluids/tank/FluidTankBlock.java
@@ -83,8 +83,8 @@ public class FluidTankBlock extends Block implements IWrenchable, ITE<FluidTankT
 		super(p_i48440_1_);
 		this.creative = creative;
 		registerDefaultState(defaultBlockState().setValue(TOP, true)
-			.setValue(BOTTOM, true)
-			.setValue(SHAPE, Shape.WINDOW));
+					.setValue(BOTTOM, true)
+					.setValue(SHAPE, Shape.WINDOW));
 	}
 
 	public static boolean isTank(BlockState state) {
@@ -126,7 +126,7 @@ public class FluidTankBlock extends Block implements IWrenchable, ITE<FluidTankT
 
 	@Override
 	public VoxelShape getCollisionShape(BlockState pState, BlockGetter pLevel, BlockPos pPos,
-		CollisionContext pContext) {
+						 CollisionContext pContext) {
 		if (pContext == CollisionContext.empty())
 			return CAMPFIRE_SMOKE_CLIP;
 		return pState.getShape(pLevel, pPos);
@@ -139,7 +139,7 @@ public class FluidTankBlock extends Block implements IWrenchable, ITE<FluidTankT
 
 	@Override
 	public BlockState updateShape(BlockState pState, Direction pDirection, BlockState pNeighborState,
-		LevelAccessor pLevel, BlockPos pCurrentPos, BlockPos pNeighborPos) {
+					  LevelAccessor pLevel, BlockPos pCurrentPos, BlockPos pNeighborPos) {
 		if (pDirection == Direction.DOWN && pNeighborState.getBlock() != this)
 			withTileEntityDo(pLevel, pCurrentPos, FluidTankTileEntity::updateBoilerTemperature);
 		return pState;
@@ -147,7 +147,7 @@ public class FluidTankBlock extends Block implements IWrenchable, ITE<FluidTankT
 
 	@Override
 	public InteractionResult use(BlockState state, Level world, BlockPos pos, Player player, InteractionHand hand,
-		BlockHitResult ray) {
+					 BlockHitResult ray) {
 		ItemStack heldItem = player.getItemInHand(hand);
 		boolean onClient = world.isClientSide;
 
@@ -175,7 +175,7 @@ public class FluidTankBlock extends Block implements IWrenchable, ITE<FluidTankT
 
 		if (exchange == null) {
 			if (EmptyingByBasin.canItemBeEmptied(world, heldItem)
-				|| GenericItemFilling.canItemBeFilled(world, heldItem))
+			    || GenericItemFilling.canItemBeFilled(world, heldItem))
 				return InteractionResult.SUCCESS;
 			return InteractionResult.PASS;
 		}
@@ -244,7 +244,7 @@ public class FluidTankBlock extends Block implements IWrenchable, ITE<FluidTankT
 
 						Vec3 vec = ray.getLocation();
 						vec = new Vec3(vec.x, controllerTE.getBlockPos()
-							.getY() + level * (controllerTE.height - .5f) + .25f, vec.z);
+								 .getY() + level * (controllerTE.height - .5f) + .25f, vec.z);
 						Vec3 motion = player.position()
 							.subtract(vec)
 							.scale(1 / 20f);
@@ -337,13 +337,13 @@ public class FluidTankBlock extends Block implements IWrenchable, ITE<FluidTankT
 	// Tanks are less noisy when placed in batch
 	public static final SoundType SILENCED_METAL =
 		new ForgeSoundType(0.1F, 1.5F, () -> SoundEvents.METAL_BREAK, () -> SoundEvents.METAL_STEP,
-			() -> SoundEvents.METAL_PLACE, () -> SoundEvents.METAL_HIT, () -> SoundEvents.METAL_FALL);
+				     () -> SoundEvents.METAL_PLACE, () -> SoundEvents.METAL_HIT, () -> SoundEvents.METAL_FALL);
 
 	@Override
 	public SoundType getSoundType(BlockState state, LevelReader world, BlockPos pos, Entity entity) {
 		SoundType soundType = super.getSoundType(state, world, pos, entity);
 		if (entity != null && entity.getPersistentData()
-			.contains("SilenceTankSound"))
+		    .contains("SilenceTankSound"))
 			return SILENCED_METAL;
 		return soundType;
 	}
@@ -356,7 +356,55 @@ public class FluidTankBlock extends Block implements IWrenchable, ITE<FluidTankT
 	@Override
 	public int getAnalogOutputSignal(BlockState blockState, Level worldIn, BlockPos pos) {
 		return getTileEntityOptional(worldIn, pos).map(FluidTankTileEntity::getControllerTE)
-			.map(te -> ComparatorUtil.fractionToRedstoneLevel(te.getFillState()))
+			.map(te -> {
+					int output = 0;
+					if (te.isBoiler()) {
+						BoilerData boiler = te.getBoilerData();
+
+						if (boiler.isPassive()) {
+							output = 1;
+						} else {
+							switch (boiler.getBoilerLevel()) {
+							case 0  : break; // boiler is idle
+							case 1  : output = 2;
+								break;
+							case 2  : output = 3;
+								break;
+							case 3  : output = 4;
+								break;
+							case 4  : output = 5;
+								break;
+							case 5  :
+							case 6  : output = 6;
+								break;
+							case 7  :
+							case 8  : output = 7;
+								break;
+							case 9  : output = 8;
+								break;
+							case 10 : output = 9;
+								break;
+							case 11 :
+							case 12 : output = 10;
+								break;
+							case 13 :
+							case 14 : output = 11;
+								break;
+							case 15 : output = 12;
+								break;
+							case 16 : output = 13;
+								break;
+							case 17 : output = 14;
+								break;
+							case 18 : output = 15;
+								break;
+							}
+						}
+					} else {
+						output = ComparatorUtil.fractionToRedstoneLevel(te.getFillState());
+					}
+					return output;
+				})
 			.orElse(0);
 	}
 

--- a/src/main/java/com/simibubi/create/content/contraptions/fluids/tank/FluidTankTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/fluids/tank/FluidTankTileEntity.java
@@ -157,7 +157,7 @@ public class FluidTankTileEntity extends SmartTileEntity implements IHaveGoggleI
 					if (tankAt == null)
 						continue;
 					level.updateNeighbourForOutputSignal(pos, tankAt.getBlockState()
-						.getBlock());
+														 .getBlock());
 					if (tankAt.luminosity == actualLuminosity)
 						continue;
 					tankAt.setLuminosity(actualLuminosity);
@@ -315,7 +315,7 @@ public class FluidTankTileEntity extends SmartTileEntity implements IHaveGoggleI
 				for (int xOffset = 0; xOffset < width; xOffset++)
 					for (int zOffset = 0; zOffset < width; zOffset++)
 						if (level.getBlockEntity(
-							worldPosition.offset(xOffset, yOffset, zOffset))instanceof FluidTankTileEntity fte)
+												 worldPosition.offset(xOffset, yOffset, zOffset))instanceof FluidTankTileEntity fte)
 							fte.refreshCapability();
 		}
 
@@ -323,6 +323,14 @@ public class FluidTankTileEntity extends SmartTileEntity implements IHaveGoggleI
 			notifyUpdate();
 			boiler.checkPipeOrganAdvancement(this);
 		}
+	}
+
+	public boolean isBoiler() {
+		return boiler.isActive();
+	}
+
+	public BoilerData getBoilerData() {
+		return boiler;
 	}
 
 	@Override
@@ -377,7 +385,7 @@ public class FluidTankTileEntity extends SmartTileEntity implements IHaveGoggleI
 		if (controllerTE.boiler.addToGoggleTooltip(tooltip, isPlayerSneaking, controllerTE.getTotalTankSize()))
 			return true;
 		return containedFluidTooltip(tooltip, isPlayerSneaking,
-			controllerTE.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY));
+									 controllerTE.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY));
 	}
 
 	@Override


### PR DESCRIPTION
### Let the analog output signal for a boiler reflect the state of the boiler. 

#### What is the rationale for adding this feature?: 
1. Add more dynamism and visual flair to power plants
2. Automatically activate or deactivate contraptions based on how much power is available

#### What are the gameplay changes?
A comparator reading from a FluidTank as a boiler will have the following output . These numbers were selected to represent idle to max boiler level with level 9 (half max boiler level) giving signal of 8 (half max redstone level).

| Boiler Level | Comparator Output |
|-----------------|---------------------------|
| Idle | 0 |
| Passive |  1 | 
| 1 | 2 |
| 2 | 3 |
| 3 | 4 |
| 4 | 5 |
| 5 | 6 |
| 6 | 6 |
| 7 | 7 |
| 8 | 7 | 
| 9 | 8 |
| 10 | 9 |
| 11 | 10 |
| 12 | 10 |
| 13 | 11 |
| 14 | 11 |
| 15 | 12 |
| 16 | 13 |
| 17 | 14 |
| 18 | 15 | 

#### What are the risks?
There is more work done to update the tile blocks' neighbors when ever the boiler tick reassesses the water supply. This should be minor though.

Screenshot: 
Enable/Disable machines based on comparator output of boiler
![Dynamic power output based on boiler level](https://i.ibb.co/1Z8TVX2/2023-01-30-00-05-57.png)

PS: My editor introduced some whitespace changes, if there is a code formatter I should run please let me know. For now it is possible to disable whitespaces changes for viewing PRs and I suggest using that to review the changes. Also feel free to just lift these changes into your own commit if that's easier.

PPS: sorry for the double post, I had some problems with my initial PR so I had to close it and recreate it.

Cheers,
Mitch
