### PR TITLE
Fix Goggles only working in first Curios slot

### DIFF
--- a/src/main/java/com/simibubi/create/compat/curios/Curios.java
+++ b/src/main/java/com/simibubi/create/compat/curios/Curios.java
@@ -27,8 +27,16 @@ public class Curios {
 					return false;
 				if (stacksHandler.getSlots() == 0)
 					return false;
-				return AllItems.GOGGLES.isIn(stacksHandler.getStacks()
-					.getStackInSlot(0));
+
+				int slotCount = stacksHandler.getSlots();
+				for (int slot = 0; slot < slotCount; slot++) {
+					if (AllItems.GOGGLES.isIn(stacksHandler.getStacks()
+							.getStackInSlot(slot))) {
+						return true;
+					}
+				}
+
+				return false;
 			})
 			.orElse(false));
 


### PR DESCRIPTION
@estoner6338 explained the issue perfectly in #4403. Create wrongly assumed Curios to have only a single head slot.

To test the code, you can simply type `/curios set @a head 2`[^curios] to have 2 head slots. Before, only the 1st would work, now both do.

Feel free to ask for a rebase or backport if needed.

[^curios]: https://github.com/TheIllusiveC4/Curios/wiki/Commands