### PR TITLE
Fix for Bug#2393

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/base/GeneratingKineticTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/base/GeneratingKineticTileEntity.java
@@ -92,7 +92,7 @@ public abstract class GeneratingKineticTileEntity extends KineticTileEntity {
 		float speed = getGeneratedSpeed();
 		float prevSpeed = this.speed;
 
-		if (level.isClientSide)
+		if (level != null && level.isClientSide)
 			return;
 
 		if (prevSpeed != speed) {


### PR DESCRIPTION
Resolving NPE by doing a null check on level before calling level.isClientSide in updateGeneratedRotation().