### PR TITLE
Add TrackGraph merge event to API

### DIFF
--- a/src/main/java/com/simibubi/create/api/event/TrackGraphMergeEvent.java
+++ b/src/main/java/com/simibubi/create/api/event/TrackGraphMergeEvent.java
@@ -1,0 +1,22 @@
+package com.simibubi.create.api.event;
+
+import com.simibubi.create.content.logistics.trains.TrackGraph;
+
+import net.minecraftforge.eventbus.api.Event;
+
+public class TrackGraphMergeEvent extends Event{
+	private TrackGraph mergedInto, mergedFrom;
+	
+	public TrackGraphMergeEvent(TrackGraph from, TrackGraph into) {
+		mergedInto = into;
+		mergedFrom = from;
+	}
+	
+	public TrackGraph getGraphMergedInto() {
+		return mergedInto;
+	}
+	
+	public TrackGraph getGraphMergedFrom() {
+		return mergedFrom;
+	}
+}

--- a/src/main/java/com/simibubi/create/content/logistics/trains/TrackGraph.java
+++ b/src/main/java/com/simibubi/create/content/logistics/trains/TrackGraph.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 import com.simibubi.create.Create;
+import com.simibubi.create.api.event.TrackGraphMergeEvent;
 import com.simibubi.create.content.logistics.trains.TrackNodeLocation.DiscoveredLocation;
 import com.simibubi.create.content.logistics.trains.entity.Train;
 import com.simibubi.create.content.logistics.trains.management.edgePoint.EdgeData;
@@ -41,6 +42,7 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.common.MinecraftForge;
 
 public class TrackGraph {
 
@@ -247,6 +249,7 @@ public class TrackGraph {
 	}
 
 	public void transferAll(TrackGraph toOther) {
+		MinecraftForge.EVENT_BUS.post(new TrackGraphMergeEvent(this, toOther));
 		nodes.forEach((loc, node) -> {
 			if (toOther.addNodeIfAbsent(node))
 				Create.RAILWAYS.sync.nodeAdded(toOther, node);


### PR DESCRIPTION
Can't test it due to java shenanigans, but I think this will work.

Essentially, when TrackGraphs are merged, it raises a TrackGraphMergeEvent, which contains references to the two TrackGraphs being merged. The getters are also named to clearly indicate which graph is merging into which. 

It's worth noting that this will only be specific to merging as long as transferAll is. If anything else ends up using transferAll, all that needs to be changed is adding an intermediate method that posts the event then calls transferAll, instead of transferAll posting it. 