### PR TITLE
Fix regex in issue labeler config

### DIFF
--- a/.github/config/labels.yml
+++ b/.github/config/labels.yml
@@ -1,12 +1,12 @@
 1.14:
-    - "1.14"
+    - "### Minecraft Version\n1\.14\.\d"
 1.15:
-    - "1.15"
+    - "### Minecraft Version\n1\.15\.\d"
 1.16:
-    - "1.16"
+    - "### Minecraft Version\n1\.16\.\d"
 1.17:
-    - "1.17"
+    - "### Minecraft Version\n1\.17\.\d"
 1.18:
-    - "1.18"
+    - "### Minecraft Version\n1\.18\.\d"
 1.19:
-    - "1.19"
+    - "### Minecraft Version\n1\.19\.\d"

--- a/.github/config/labels.yml
+++ b/.github/config/labels.yml
@@ -1,12 +1,12 @@
 1.14:
-    - "### Minecraft Version\\n1\\.14(?:\\.\\d)?"
+    - "### Minecraft Version\\n1\\\\.14(?:\\\\.\\\\d)?"
 1.15:
-    - "### Minecraft Version\\n1\\.15(?:\\.\\d)?"
+    - "### Minecraft Version\\n1\\\\.15(?:\\\\.\\\\d)?"
 1.16:
-    - "### Minecraft Version\\n1\\.16(?:\\.\\d)?"
+    - "### Minecraft Version\\n1\\\\.16(?:\\\\.\\\\d)?"
 1.17:
-    - "### Minecraft Version\\n1\\.17(?:\\.\\d)?"
+    - "### Minecraft Version\\n1\\\\.17(?:\\\\.\\\\d)?"
 1.18:
-    - "### Minecraft Version\\n1\\.18(?:\\.\\d)?"
+    - "### Minecraft Version\\n1\\\\.18(?:\\\\.\\\\d)?"
 1.19:
-    - "### Minecraft Version\\n1\\.19(?:\\.\\d)?"
+    - "### Minecraft Version\\n1\\\\.19(?:\\\\.\\\\d)?"

--- a/.github/config/labels.yml
+++ b/.github/config/labels.yml
@@ -1,12 +1,12 @@
 1.14:
-    - "### Minecraft Version\n1\.14\.\d"
+    - "### Minecraft Version\\n1\\.14(?:\\.\\d)?"
 1.15:
-    - "### Minecraft Version\n1\.15\.\d"
+    - "### Minecraft Version\\n1\\.15(?:\\.\\d)?"
 1.16:
-    - "### Minecraft Version\n1\.16\.\d"
+    - "### Minecraft Version\\n1\\.16(?:\\.\\d)?"
 1.17:
-    - "### Minecraft Version\n1\.17\.\d"
+    - "### Minecraft Version\\n1\\.17(?:\\.\\d)?"
 1.18:
-    - "### Minecraft Version\n1\.18\.\d"
+    - "### Minecraft Version\\n1\\.18(?:\\.\\d)?"
 1.19:
-    - "### Minecraft Version\n1\.19\.\d"
+    - "### Minecraft Version\\n1\\.19(?:\\.\\d)?"

--- a/.github/workflows/label_issues.yml
+++ b/.github/workflows/label_issues.yml
@@ -7,7 +7,7 @@ jobs:
     label:
         runs-on: ubuntu-latest
         steps:
-            - uses: github/issue-labeler@v2.0
+            - uses: github/issue-labeler@v3.0
               with:
                   configuration-path: .github/config/labels.yml
                   enable-versioned-regex: 0


### PR DESCRIPTION
The regex was wrongly matching extra characters through the use of `.` which matches any character. This also adds the requirement of the match version number being immediately after the `Minecraft Version` section.