### PR TITLE
Schedule Runtime Reworks

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/processing/burner/BlazeBurnerInteractionBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/processing/burner/BlazeBurnerInteractionBehaviour.java
@@ -71,7 +71,7 @@ public class BlazeBurnerInteractionBehaviour extends MovingInteractionBehaviour 
 
 				AllSoundEvents.playItemPickup(player);
 				player.displayClientMessage(Lang.translateDirect(
-					train.runtime.isAutoSchedule ? "schedule.auto_removed_from_train" : "schedule.removed_from_train"),
+					train.runtime.isAutoSchedule() ? "schedule.auto_removed_from_train" : "schedule.removed_from_train"),
 					true);
 				player.setItemInHand(activeHand, train.runtime.returnSchedule());
 				return true;

--- a/src/main/java/com/simibubi/create/content/contraptions/processing/burner/BlazeBurnerInteractionBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/processing/burner/BlazeBurnerInteractionBehaviour.java
@@ -71,7 +71,7 @@ public class BlazeBurnerInteractionBehaviour extends MovingInteractionBehaviour 
 
 				AllSoundEvents.playItemPickup(player);
 				player.displayClientMessage(Lang.translateDirect(
-					train.runtime.isAutoSchedule() ? "schedule.auto_removed_from_train" : "schedule.removed_from_train"),
+					(train.runtime.isAutoSchedule() || train.runtime.hasSuspendedSchedule()) ? "schedule.auto_removed_from_train" : "schedule.removed_from_train"),
 					true);
 				player.setItemInHand(activeHand, train.runtime.returnSchedule());
 				return true;

--- a/src/main/java/com/simibubi/create/content/logistics/trains/management/edgePoint/station/StationTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/trains/management/edgePoint/station/StationTileEntity.java
@@ -719,7 +719,19 @@ public class StationTileEntity extends SmartTileEntity implements ITransformable
 			return;
 
 		award(AllAdvancements.CONDUCTOR);
-		imminentTrain.runtime.setSuspendedSchedule(schedule);
+
+		if (!imminentTrain.runtime.setSuspendedSchedule(schedule)) {
+			AllSoundEvents.DENY.playOnServer(level, worldPosition, 1, 1);
+
+			if (!(level instanceof ServerLevel server))
+				return;
+
+			Vec3 v = Vec3.atBottomCenterOf(worldPosition.above());
+			server.sendParticles(ParticleTypes.ANGRY_VILLAGER, v.x, v.y, v.z, 6, 0.35, 0.05, 0.35, 1);
+
+			return;
+		}
+
 		AllSoundEvents.CONFIRM.playOnServer(level, worldPosition, 1, 1);
 
 		if (!(level instanceof ServerLevel server))

--- a/src/main/java/com/simibubi/create/content/logistics/trains/management/edgePoint/station/StationTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/trains/management/edgePoint/station/StationTileEntity.java
@@ -231,7 +231,7 @@ public class StationTileEntity extends SmartTileEntity implements ITransformable
 		boolean canDisassemble = trainPresent && imminentTrain.canDisassemble();
 		UUID imminentID = imminentTrain != null ? imminentTrain.id : null;
 		boolean trainHasSchedule = trainPresent && imminentTrain.runtime.getSchedule() != null;
-		boolean trainHasAutoSchedule = trainHasSchedule && imminentTrain.runtime.isAutoSchedule;
+		boolean trainHasAutoSchedule = trainHasSchedule && imminentTrain.runtime.isAutoSchedule();
 		boolean newlyArrived = this.trainPresent != trainPresent;
 
 		if (trainPresent && imminentTrain.runtime.displayLinkUpdateRequested) {
@@ -719,7 +719,7 @@ public class StationTileEntity extends SmartTileEntity implements ITransformable
 			return;
 
 		award(AllAdvancements.CONDUCTOR);
-		imminentTrain.runtime.setSchedule(schedule, true);
+		imminentTrain.runtime.setSuspendedSchedule(schedule);
 		AllSoundEvents.CONFIRM.playOnServer(level, worldPosition, 1, 1);
 
 		if (!(level instanceof ServerLevel server))

--- a/src/main/java/com/simibubi/create/content/logistics/trains/management/schedule/ScheduleItemEntityInteraction.java
+++ b/src/main/java/com/simibubi/create/content/logistics/trains/management/schedule/ScheduleItemEntityInteraction.java
@@ -108,7 +108,7 @@ public class ScheduleItemEntityInteraction {
 			AllSoundEvents.playItemPickup(player);
 			player.displayClientMessage(
 				Lang.translateDirect(
-					train.runtime.isAutoSchedule() ? "schedule.auto_removed_from_train" : "schedule.removed_from_train"),
+					(train.runtime.isAutoSchedule() || train.runtime.hasSuspendedSchedule()) ? "schedule.auto_removed_from_train" : "schedule.removed_from_train"),
 				true);
 
 			player.getInventory()

--- a/src/main/java/com/simibubi/create/content/logistics/trains/management/schedule/ScheduleItemEntityInteraction.java
+++ b/src/main/java/com/simibubi/create/content/logistics/trains/management/schedule/ScheduleItemEntityInteraction.java
@@ -108,7 +108,7 @@ public class ScheduleItemEntityInteraction {
 			AllSoundEvents.playItemPickup(player);
 			player.displayClientMessage(
 				Lang.translateDirect(
-					train.runtime.isAutoSchedule ? "schedule.auto_removed_from_train" : "schedule.removed_from_train"),
+					train.runtime.isAutoSchedule() ? "schedule.auto_removed_from_train" : "schedule.removed_from_train"),
 				true);
 
 			player.getInventory()

--- a/src/main/java/com/simibubi/create/foundation/config/CTrains.java
+++ b/src/main/java/com/simibubi/create/foundation/config/CTrains.java
@@ -7,12 +7,13 @@ public class CTrains extends ConfigBase {
 	public final ConfigInt maxAssemblyLength = i(128, 5, "maxAssemblyLength", Comments.maxAssemblyLength);
 	public final ConfigInt maxBogeyCount = i(20, 1, "maxBogeyCount", Comments.maxBogeyCount);
 	public final ConfigFloat manualTrainSpeedModifier = f(.75f, 0, "manualTrainSpeedModifier", Comments.manualTrainSpeedModifier);
-	
+	public final ConfigInt maxAutoSchedules = i(5, 1, 10, "maxAutoSchedules", Comments.maxAutoSchedules);
+
 	public final ConfigGroup trainStats = group(1, "trainStats", "Standard Trains");
 	public final ConfigFloat trainTopSpeed = f(28, 0, "trainTopSpeed", Comments.mps, Comments.trainTopSpeed);
 	public final ConfigFloat trainTurningTopSpeed = f(14, 0, "trainTurningTopSpeed", Comments.mps, Comments.trainTurningTopSpeed);
 	public final ConfigFloat trainAcceleration = f(3, 0, "trainAcceleration", Comments.acc, Comments.trainAcceleration);
-	
+
 	public final ConfigGroup poweredTrainStats = group(1, "poweredTrainStats", "Powered Trains");
 	public final ConfigFloat poweredTrainTopSpeed = f(40, 0, "poweredTrainTopSpeed", Comments.mps, Comments.poweredTrainTopSpeed);
 	public final ConfigFloat poweredTrainTurningTopSpeed = f(20, 0, "poweredTrainTurningTopSpeed", Comments.mps, Comments.poweredTrainTurningTopSpeed);
@@ -38,6 +39,7 @@ public class CTrains extends ConfigBase {
 		static String maxAssemblyLength = "Maximum length of a Train Stations' assembly track.";
 		static String maxBogeyCount = "Maximum amount of bogeys assembled as a single Train.";
 		static String manualTrainSpeedModifier = "Relative speed of a manually controlled Train compared to a Scheduled one.";
+		static String maxAutoSchedules = "Maximum amount of auto schedules stored in each train.";
 	}
 
 }

--- a/src/main/java/com/simibubi/create/foundation/config/CTrains.java
+++ b/src/main/java/com/simibubi/create/foundation/config/CTrains.java
@@ -18,7 +18,7 @@ public class CTrains extends ConfigBase {
 	public final ConfigFloat poweredTrainTopSpeed = f(40, 0, "poweredTrainTopSpeed", Comments.mps, Comments.poweredTrainTopSpeed);
 	public final ConfigFloat poweredTrainTurningTopSpeed = f(20, 0, "poweredTrainTurningTopSpeed", Comments.mps, Comments.poweredTrainTurningTopSpeed);
 	public final ConfigFloat poweredTrainAcceleration = f(3, 0, "poweredTrainAcceleration", Comments.acc, Comments.poweredTrainAcceleration);
-	
+
 
 	@Override
 	public String getName() {
@@ -39,7 +39,7 @@ public class CTrains extends ConfigBase {
 		static String maxAssemblyLength = "Maximum length of a Train Stations' assembly track.";
 		static String maxBogeyCount = "Maximum amount of bogeys assembled as a single Train.";
 		static String manualTrainSpeedModifier = "Relative speed of a manually controlled Train compared to a Scheduled one.";
-		static String maxAutoSchedules = "Maximum amount of auto schedules stored in each train.";
+		static String maxAutoSchedules = "Maximum amount of auto schedules stored in each Train.";
 	}
 
 }


### PR DESCRIPTION
Reworks parts of the schedule runtime class of trains to better support auto schedules and train automation. The main changes include schedule condition checks running even if a new auto schedule has been applied at a station and trains can now have multiple schedules.

This is done by having the schedule stored in `ScheduleRuntime` has been broken in to 3 locations: `schedule`, `autoSchedules`, and `suspendedSchedule`.

### `schedule`

- Contains the only schedule that is actually in item form
- Cannot be changed unless there are no auto schedules
- Does not delete when completed

### `autoSchedules`

- Array of schedules not given in item form - must be applied by a station
- Array acts like a stack, only the last item in the array is read
- Auto schedules take priority over `schedule`
- Once completed, an auto schedule will pop itself off the stack and the next will resume
- If an auto schedule is cyclic, all other auto schedules will be removed leaving just the cyclic one. (Prevents auto schedules from building up under a cyclic one which cannot be automatically canceled).
- Limited by "Max Auto Schedules" config option under gameplay settings then trains. (min: 1, max: 10(?), default: 5).

### `suspendedSchedule`

- Stations can only write to this
- Once set, it will be pushed to auto schedule stack only when the conditions for the current station are completed

Also fixes #4217 