### PR TITLE
Fix "Lighter  than air" fluids display in spouts

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/fluids/actors/SpoutRenderer.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/fluids/actors/SpoutRenderer.java
@@ -38,14 +38,24 @@ public class SpoutRenderer extends SafeTileEntityRenderer<SpoutTileEntity> {
 			.getValue(partialTicks);
 
 		if (!fluidStack.isEmpty() && level != 0) {
+			boolean top = fluidStack.getFluid()
+					.getAttributes()
+					.isLighterThanAir();
+
 			level = Math.max(level, 0.175f);
 			float min = 2.5f / 16f;
 			float max = min + (11 / 16f);
 			float yOffset = (11 / 16f) * level;
+
 			ms.pushPose();
-			ms.translate(0, yOffset, 0);
-			FluidRenderer.renderFluidBox(fluidStack, min, min - yOffset, min, max, min, max, buffer, ms, light,
-				false);
+			if (!top) ms.translate(0, yOffset, 0);
+			else ms.translate(0, max - min, 0);
+
+			FluidRenderer.renderFluidBox(fluidStack,
+					min, min - yOffset, min,
+					max, min, max,
+					buffer, ms, light, false);
+
 			ms.popPose();
 		}
 


### PR DESCRIPTION
### Current (This is steam added by an addon mod I'm making):
![image](https://user-images.githubusercontent.com/65340665/228365255-f0fa5a67-02a1-46f5-a937-42b932873a5b.png)
_Notice how the top does not render, as the `FluidRenderer.renderFluidBox` detects it is lighter than air, and renders the bottom instead of the top, but because of the positioning, the bottom does not show, and the top which does not render._

### Fixed (Honey's density was set to -1400 for testing):
![image](https://user-images.githubusercontent.com/65340665/228364882-53ffca96-a633-4ec1-ac42-6f57ac73d746.png)
_The root cause can be fixed by essentially a copy of a similar system in fluid tanks_

Amazing mod btw!