### PR TITLE
Small tweaks to the wiki pages for ComputerCraft integration

### DIFF
--- a/wiki/Lua-Display-Link.md
+++ b/wiki/Lua-Display-Link.md
@@ -3,8 +3,8 @@
 | [`setCursorPos(x, y)`](#setCursorPos) | Sets the cursor position                             |
 | [`getCursorPos()`](#getCursorPos)     | Gets the current cursor position                     |
 | [`getSize()`](#getSize)               | Gets the display size of the connected target        |
-| [`isColor()`](#isColor)               | Whether the connected display target colors          |
-| [`isColour()`](#isColour)             | Whether the connected display target supports colours |
+| [`isColor()`](#isColor)               | Whether the connected display target supports color  |
+| [`isColour()`](#isColour)             | Whether the connected display target supports colour |
 | [`write(text)`](#writetext)           | Writes text at the current cursor position           |
 | [`clearLine()`](#clearLine)           | Clears the line at the current cursor position       |
 | [`clear()`](#clear)                   | Clears the whole display                             |
@@ -15,49 +15,49 @@
 Sets the cursor position. Can be outside the bounds of the connected display.
 
 **Parameters**
-- _x:_ `number` The cursor x position
-- _y:_ `number` The cursor y position
+- _x:_ `number` The cursor x position.
+- _y:_ `number` The cursor y position.
 
 ---
 ### `getCursorPos()`
 Gets the current cursor position.
 
 **Returns**
-- `number` The cursor x position
-- `number` The cursor y position
+- `number` The cursor x position.
+- `number` The cursor y position.
 
 ---
 ### `getSize()`
-Gets the size of the connected display target
+Gets the size of the connected display target.
 
 **Returns**
-- `number` The width of the display
-- `number` The height of the display
+- `number` The width of the display.
+- `number` The height of the display.
 
 ---
 ### `isColor()`
-Checks whether the connected display target supports color
+Checks whether the connected display target supports color.
 
 **Returns**
-- `boolean` Whether the display support color
+- `boolean` Whether the display supports color.
 
 ---
 ### `isColour()`
-Checks whether the connected display target supports colour
+Checks whether the connected display target supports colour.
 
 **Returns**
-- `boolean` Whether the display support colour
+- `boolean` Whether the display supports colour.
 
 ---
 ### `write(text)`
 Writes text at the current cursor position, moving the cursor to the end of the text.
 This only writes to an internal buffer. For the changes to show up on the display [`update()`](#update) must be used.
-If the cursor is outside the bounds of the connected display the text will not show up on the display.
+If the cursor is outside the bounds of the connected display, the text will not show up on the display.
 
-This will overwrite any text currently at cursor position.
+This will overwrite any text currently at the cursor position.
 
 **Parameters**
-- _text:_ `string` Text to write.
+- _text:_ `string` The text to write.
 
 **See also**
 - [`update()`](#update) To push the changes to the display target.

--- a/wiki/Lua-Rotation-Speed-Controller.md
+++ b/wiki/Lua-Rotation-Speed-Controller.md
@@ -1,18 +1,18 @@
-| Method                                           | Description                            |
-|--------------------------------------------------|----------------------------------------|
-| [`setTargetSpeed(speed)`](#setTargetSpeedspeed)  | Sets the target rotation speed         |
-| [`getTargetSpeed()`](#getTargetSpeed)            | Gets the current target rotation speed |
+| Method                                          | Description                            |
+|-------------------------------------------------|----------------------------------------|
+| [`setTargetSpeed(speed)`](#setTargetSpeedspeed) | Sets the target rotation speed         |
+| [`getTargetSpeed()`](#getTargetSpeed)           | Gets the current target rotation speed |
 
 ---
 ### `setTargetSpeed(speed)`
 Sets the rotation speed controller's target speed.
 
 **Parameters**
-- _speed:_ `number` Target speed. Must be an integer within range of [-256..256]. Values outside of this range will be clamped.
+- _speed:_ `number` The target speed in RPM. Must be an integer within the range of [-256..256]. Values outside of this range will be clamped.
 
 ---
 ### `getTargetSpeed()`
 Gets the rotation speed controller's current target speed.
 
 **Returns**
-- `number` Current target rotation speed.
+- `number` The current target rotation speed in RPM.

--- a/wiki/Lua-Sequenced-Gearshift.md
+++ b/wiki/Lua-Sequenced-Gearshift.md
@@ -2,23 +2,23 @@
 |--------------------------------------------------------|--------------------------------------------------------------|
 | [`rotate(angle, [modifier])`](#rotateangle-modifier)   | Rotates shaft by a set angle                                 |
 | [`move(distance, [modifier])`](#movedistance-modifier) | Rotates shaft to move Piston/Pulley/Gantry by a set distance |
-| [`isRunning()`](#isRunning)                            | Checks if the gearshift is spinning                          |
+| [`isRunning()`](#isRunning)                            | Whether the gearshift is currently spinning                  |
 
 ---
 ### `rotate(angle, [modifier])`
 Rotates connected components by a set angle.
 
 **Parameters**
-- _angle:_ `number` Angle to rotate shaft by. Must be a positive integer.
-- _modifier?:_ `number = 1` Speed modifier which can be used to reverse rotation. Must be an integer within range of [-2..2]. Values out of this range will cause the modifier to revert to its default of 1.
+- _angle:_ `number` Angle to rotate the shaft by in degrees. Must be a positive integer. To do backwards rotation, set _modifier_ to a negative value.
+- _modifier?:_ `number = 1` Speed modifier which can be used to reverse rotation. Must be an integer within the range of [-2..2]. Values out of this range are ignored and the default of 1 is used.
 
 ---
 ### `move(distance, [modifier])`
 Rotates connected components to move connected piston, pulley or gantry contractions by a set distance.
 
 **Parameters**
-- _distance:_ `number` Distance to move connected piston, pulley or gantry contraptions by. Must be a positive integer.
-- _modifier?:_ `number = 1` Speed modifier which can be used to reverse rotation. Must be an integer within range of [-2..2]. Values out of this range will cause the modifier to revert to its default of 1.
+- _distance:_ `number` Distance to move connected piston, pulley or gantry contraptions by. Must be a positive integer. To do backwards movement, set _modifier_ to a negative value.
+- _modifier?:_ `number = 1` Speed modifier which can be used to reverse direction. Must be an integer within the range of [-2..2]. Values out of this range are ignored and the default of 1 is used.
 
 ---
 ### `isRunning()`

--- a/wiki/Lua-Speedometer.md
+++ b/wiki/Lua-Speedometer.md
@@ -4,7 +4,7 @@
 
 ---
 ### `getSpeed()`
-Gets the current rotation speed of the attached components
+Gets the current rotation speed of the attached components.
 
 **Returns**
-- `number` The current rotation speed
+- `number` The current rotation speed in RPM.

--- a/wiki/Lua-Stressometer.md
+++ b/wiki/Lua-Stressometer.md
@@ -5,14 +5,14 @@
 
 ---
 ### `getStress()`
-Gets the connected network's current stress level
+Gets the connected network's current stress level.
 
 **Returns**
-- `number` The current stress level
+- `number` The current stress level in SU.
 
 ---
 ### `getStressCapacity()`
-Gets the connected network's total stress capacity
+Gets the connected network's total stress capacity.
 
 **Returns**
-- `number` The total stress capacity
+- `number` The total stress capacity in SU.

--- a/wiki/Lua-Train-Schedule.md
+++ b/wiki/Lua-Train-Schedule.md
@@ -1,4 +1,5 @@
-Train schedules are represented by a table in Lua. The table contains a list of entries where each entry has a single instruction and multiple conditions. Each instruction and condition has a `data` table that stores specific data about the instruction or condition.
+Train schedules are represented by a table in Lua. The table contains a list of entries where each entry has a single instruction and multiple conditions.
+Each instruction and condition has a `data` table that stores specific data about the instruction or condition.
 
 ```lua
 schedule = {
@@ -53,7 +54,7 @@ schedule = {
 Moves the train to the chosen train station. This instruction must have at least one condition.
 
 **Data**
-- _text:_ `string` The name of the station to travel to.
+- _text:_ `string` The name of the station to travel to. Can include * as a wildcard.
 
 ---
 ### `"create:rename"`
@@ -67,11 +68,12 @@ Renames the schedule. This name shows up on display link targets. This instructi
 Changes the throttle of the train. This instruction cannot have conditions.
 
 **Data**
-- _value:_ `number` The throttle to set the train to. Must be an integer with in the range of [5..100].
+- _value:_ `number` The throttle to set the train to. Must be an integer within the range of [5..100].
 
 ---
 ## Conditions
-Conditions are stored in a list of lists of conditions. The inner lists contain conditions that get `AND`'d together. They must all be met for that group to be true. The outer list contains the `AND`'d groups of conditions that get `OR`'d together. Only one of the groups needs to be true for the schedule to move onto the next instruction.
+Conditions are stored in a list of lists of conditions. The inner lists contain conditions that get `AND`'ed together. They must all be met for that group to be true.
+The outer list contains the `AND`'ed groups of conditions that get `OR`'ed together. Only one of the groups needs to be true for the schedule to move onto the next instruction.
 
 | ID                                                  | Description                                         |
 |-----------------------------------------------------|-----------------------------------------------------|
@@ -107,15 +109,15 @@ Wait for a time of day, then repeat at a specified interval.
 | Rotation | Time Interval    |
 |----------|------------------|
 | 0        | Every Day        |
-| 1        | Every 12 hours   |
-| 2        | Every 6 hours    |
-| 3        | Every 4 hours    |
-| 4        | Every 3 hours    |
-| 5        | Every 2 hours    |
-| 6        | Every hour       |
-| 7        | Every 45 minutes |
-| 8        | Every 30 minutes |
-| 9        | Every 15 minutes |
+| 1        | Every 12 Hours   |
+| 2        | Every 6 Hours    |
+| 3        | Every 4 Hours    |
+| 4        | Every 3 Hours    |
+| 5        | Every 2 Hours    |
+| 6        | Every Hour       |
+| 7        | Every 45 Minutes |
+| 8        | Every 30 Minutes |
+| 9        | Every 15 Minutes |
 
 ---
 ### `"create:fluid_threshold"`
@@ -128,7 +130,7 @@ Wait for a certain amount of a specific fluid to be loaded onto the train.
 - _measure:_ `number` The unit to measure the fluid in. This condition supports buckets as the only unit. Set to 0.
 
 **See also**
-- [Items](#items) How items are represented in Lua
+- [Items](#items) How items are represented in Lua.
 
 ---
 ### `"create:item_threshold"`
@@ -141,7 +143,7 @@ Wait for a certain amount of a specific item to be loaded onto the train.
 - _measure:_ `number` The unit to measure the items in. 0 for items. 1 for stacks of items.
 
 **See also**
-- [Items](#items) How items are represented in Lua
+- [Items](#items) How items are represented in Lua.
 
 ---
 ### `"create:redstone_link"`
@@ -152,7 +154,7 @@ Wait for a redstone link to be powered.
 - _inverted:_ `number` Whether the redstone link should be powered or not to meet the condition. 0 for powered. 1 for not powered.
 
 **See also**
-- [Items](#items) How items are represented in Lua
+- [Items](#items) How items are represented in Lua.
 
 ---
 ### `"create:player_count"`
@@ -184,8 +186,8 @@ In Lua, items are represented with an ID and a count.
 
 ```lua
 item = {
-    id = "minecraft:stone",
-    count = 1,
+  id = "minecraft:stone",
+  count = 1,
 }
 ```
 

--- a/wiki/Lua-Train-Station.md
+++ b/wiki/Lua-Train-Station.md
@@ -1,19 +1,19 @@
-| Method                                                        | Description                                        |
-|---------------------------------------------------------------|----------------------------------------------------|
-| [`assemble()`](#assemble)                                     | Assembles a new train at the station               |
-| [`disassemble()`](#disassemble)                               | Disassembles the currently present train           |
+| Method                                                          | Description                                        |
+|-----------------------------------------------------------------|----------------------------------------------------|
+| [`assemble()`](#assemble)                                       | Assembles a new train at the station               |
+| [`disassemble()`](#disassemble)                                 | Disassembles the currently present train           |
 | [`setAssemblyMode(assemblyMode)`](#setAssemblyModeassemblyMode) | Sets the station's assembly mode                   |
-| [`isInAssemblyMode()`](#isInAssemblyMode)                     | Whether the station is in assembly mode            |
-| [`getStationName()`](#getStationName)                         | Gets the station's current name                    |
-| [`setStationName(name)`](#setStationNamename)                 | Sets the station's name                            |
-| [`isTrainPresent()`](#isTrainPresent)                         | Whether a train is present at the station          |
-| [`isTrainImminent()`](#isTrainImminent)                       | Whether a train is imminent to the station         |
-| [`isTrainEnroute()`](#isTrainEnroute)                         | Whether a train is enroute to the station          |
-| [`getTrainName()`](#getTrainName)                             | Gets the currently present train's name            |
-| [`setTrainName(name)`](#setTrainNamename)                     | Sets the currently present train's name            |
-| [`hasSchedule()`](#hasSchedule)                               | Whether the currently present train has a schedule |
-| [`getSchedule()`](#getSchedule)                               | Gets the currently present train's schedule        |
-| [`setSchedule(schedule)`](#setScheduleschedule)               | Sets the currently present train's schedule        |
+| [`isInAssemblyMode()`](#isInAssemblyMode)                       | Whether the station is in assembly mode            |
+| [`getStationName()`](#getStationName)                           | Gets the station's current name                    |
+| [`setStationName(name)`](#setStationNamename)                   | Sets the station's name                            |
+| [`isTrainPresent()`](#isTrainPresent)                           | Whether a train is present at the station          |
+| [`isTrainImminent()`](#isTrainImminent)                         | Whether a train is imminent to the station         |
+| [`isTrainEnroute()`](#isTrainEnroute)                           | Whether a train is enroute to the station          |
+| [`getTrainName()`](#getTrainName)                               | Gets the currently present train's name            |
+| [`setTrainName(name)`](#setTrainNamename)                       | Sets the currently present train's name            |
+| [`hasSchedule()`](#hasSchedule)                                 | Whether the currently present train has a schedule |
+| [`getSchedule()`](#getSchedule)                                 | Gets the currently present train's schedule        |
+| [`setSchedule(schedule)`](#setScheduleschedule)                 | Sets the currently present train's schedule        |
 
 ---
 ### `assemble()`
@@ -36,7 +36,7 @@ Disassembles the station's currently present train. The station must not be in a
 **Throws**
 - If the station is in assembly mode.
 - If the station is not connected to a track.
-- If there is no currently present train at the station.
+- If there is currently no train present at the station.
 - If the train failed to disassemble.
 
 **See also**
@@ -47,7 +47,7 @@ Disassembles the station's currently present train. The station must not be in a
 Sets the station's assembly mode.
 
 **Parameters**
-- _assemblyMode:_ `boolean` Whether the station should enter or exit assembly mode.
+- _assemblyMode:_ `boolean` Whether the station should be in assembly mode.
 
 **Throws**
 - If the station fails to enter or exit assembly mode.
@@ -75,7 +75,7 @@ Gets the station's current name.
 Sets the station's name.
 
 **Parameters**
-- _name:_ `string` The name to set the station to.
+- _name:_ `string` What to set the station's name to.
 
 **Throws**
 - If the station name fails to be set.
@@ -86,7 +86,7 @@ Sets the station's name.
 Checks whether a train is currently present at the station.
 
 **Returns**
-- Whether a train is present at the station.
+- `boolean` Whether a train is present at the station.
 
 **Throws**
 - If the station is not connected to a track.
@@ -94,11 +94,11 @@ Checks whether a train is currently present at the station.
 ---
 ### `isTrainImminent()`
 Checks whether a train is imminently arriving at the station.
-Imminent is defined as being within 30 meters of the station.
+Imminent is defined as being within 30 blocks of the station.
 This will not be true if the train has arrived and stopped at the station.
 
 **Returns**
-- Whether a train is imminent to the station.
+- `boolean` Whether a train is imminent to the station.
 
 **Throws**
 - If the station is not connected to a track.
@@ -125,18 +125,18 @@ Gets the currently present train's name.
 
 **Throws**
 - If the station is not connected to a track.
-- If there is no currently present train at the station.
+- If there is currently no train present at the station.
 
 ---
 ### `setTrainName(name)`
 Sets the currently present train's name.
 
 **Parameters**
-- _name:_ `string` The name to set the currently present train to.
+- _name:_ `string` What to set the currently present train's name to.
 
 **Throws**
 - If the station is not connected to a track.
-- If there is no currently present train at the station.
+- If there is currently no train present at the station.
 
 ---
 ### `hasSchedule()`
@@ -147,7 +147,7 @@ Checks whether the currently present train has a schedule.
 
 **Throws**
 - If the station is not connected to a track.
-- If there is no currently present train at the station.
+- If there is currently no train present at the station.
 
 ---
 ### `getSchedule()`
@@ -158,7 +158,7 @@ Gets the currently present train's schedule.
 
 **Throws**
 - If the station is not connected to a track.
-- If there is no currently present train at the station.
+- If there is currently no train present at the station.
 - If the present train doesn't have a schedule.
 
 **See also**
@@ -173,7 +173,7 @@ Sets the currently present train's schedule. This will overwrite the currently s
 
 **Throws**
 - If the station is not connected to a track.
-- If there is no currently present train at the station.
+- If there is currently no train present at the station.
 
 **See also**
 - [Lua Train Schedules](#Lua-Train-Schedules) How train schedules are represented in Lua.


### PR DESCRIPTION
Do a bunch of small tweaks to the wiki pages for the ComputerCraft integration PR.
These mainly include adding missing periods/full stops, adding units, a bit extra info here and there, and a few rephrasings.