### PR TITLE
Add Curio Support for Backtank and Upgrade BacktankUtil

### DIFF
--- a/src/main/java/com/simibubi/create/compat/curios/CopperBacktankCurioRenderer.java
+++ b/src/main/java/com/simibubi/create/compat/curios/CopperBacktankCurioRenderer.java
@@ -64,7 +64,7 @@ public class CopperBacktankCurioRenderer implements ICurioRenderer {
 
 		// If we have a backtank in the armor slot, shift it around so the "back" slot is a micro backtank
 		ItemStack chestItemSlot = slotContext.entity().getItemBySlot(EquipmentSlot.CHEST);
-		if(AllItems.COPPER_BACKTANK.isIn(chestItemSlot)) {
+		if (AllItems.COPPER_BACKTANK.isIn(chestItemSlot)) {
 			matrixStack.translate(0.125f, 10 / 16f, 0.125f);
 			matrixStack.scale(0.75f, 0.75f, 0.75f);
 		}

--- a/src/main/java/com/simibubi/create/compat/curios/CopperBacktankCurioRenderer.java
+++ b/src/main/java/com/simibubi/create/compat/curios/CopperBacktankCurioRenderer.java
@@ -1,0 +1,96 @@
+package com.simibubi.create.compat.curios;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.simibubi.create.AllBlockPartials;
+import com.simibubi.create.AllBlocks;
+import com.simibubi.create.AllItems;
+import com.simibubi.create.Create;
+
+import com.simibubi.create.content.curiosities.armor.CopperBacktankBlock;
+import com.simibubi.create.foundation.render.CachedBufferer;
+import com.simibubi.create.foundation.render.SuperByteBuffer;
+import com.simibubi.create.foundation.utility.AngleHelper;
+import com.simibubi.create.foundation.utility.AnimationTickHolder;
+
+import net.minecraft.client.model.EntityModel;
+import net.minecraft.client.model.HumanoidModel;
+import net.minecraft.client.model.geom.ModelLayerLocation;
+import net.minecraft.client.model.geom.ModelPart;
+import net.minecraft.client.model.geom.PartPose;
+import net.minecraft.client.model.geom.builders.CubeDeformation;
+import net.minecraft.client.model.geom.builders.CubeListBuilder;
+import net.minecraft.client.model.geom.builders.MeshDefinition;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.Sheets;
+import net.minecraft.client.renderer.entity.RenderLayerParent;
+import net.minecraft.core.Direction;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import top.theillusivec4.curios.api.SlotContext;
+import top.theillusivec4.curios.api.client.ICurioRenderer;
+
+@OnlyIn(Dist.CLIENT)
+public class CopperBacktankCurioRenderer implements ICurioRenderer {
+	public static final ModelLayerLocation LAYER = new ModelLayerLocation(new ResourceLocation(Create.ID, "copper_backtank"), "copper_backtank");
+
+	private final HumanoidModel<LivingEntity> model;
+
+	public CopperBacktankCurioRenderer(ModelPart part) {
+		this.model = new HumanoidModel<>(part);
+	}
+
+	@Override
+	public <T extends LivingEntity, M extends EntityModel<T>> void render(ItemStack stack, SlotContext slotContext, PoseStack matrixStack, RenderLayerParent<T, M> renderLayerParent, MultiBufferSource buffer, int light, float limbSwing, float limbSwingAmount, float partialTicks, float ageInTicks, float netHeadYaw, float headPitch) {
+		// Copied from com.simibubi.create.content.curiosities.armor.CopperBacktankArmorLayer
+		// with minor changes (ms -> matrixStack, entity.level -> slotContext.entity().level)
+
+		RenderType renderType = Sheets.cutoutBlockSheet();
+		BlockState renderedState = AllBlocks.COPPER_BACKTANK.getDefaultState()
+				.setValue(CopperBacktankBlock.HORIZONTAL_FACING, Direction.SOUTH);
+		SuperByteBuffer backtank = CachedBufferer.block(renderedState);
+		SuperByteBuffer cogs = CachedBufferer.partial(AllBlockPartials.COPPER_BACKTANK_COGS, renderedState);
+
+		matrixStack.pushPose();
+
+		model.body.translateAndRotate(matrixStack);
+		matrixStack.translate(-1 / 2f, 10 / 16f, 1f);
+		matrixStack.scale(1, -1, -1);
+
+		// If we have a backtank in the armor slot, shift it around so the "back" slot is a micro backtank
+		ItemStack chestItemSlot = slotContext.entity().getItemBySlot(EquipmentSlot.CHEST);
+		if(AllItems.COPPER_BACKTANK.isIn(chestItemSlot)) {
+			matrixStack.translate(0.125f, 10 / 16f, 0.125f);
+			matrixStack.scale(0.75f, 0.75f, 0.75f);
+		}
+
+		backtank.forEntityRender()
+				.light(light)
+				.renderInto(matrixStack, buffer.getBuffer(renderType));
+
+		cogs.centre()
+				.rotateY(180)
+				.unCentre()
+				.translate(0, 6.5f / 16, 11f / 16)
+				.rotate(Direction.EAST, AngleHelper.rad(2 * AnimationTickHolder.getRenderTime(slotContext.entity().level) % 360))
+				.translate(0, -6.5f / 16, -11f / 16);
+
+		cogs.forEntityRender()
+				.light(light)
+				.renderInto(matrixStack, buffer.getBuffer(renderType));
+
+		matrixStack.popPose();
+	}
+
+	public static MeshDefinition mesh() {
+		CubeListBuilder builder = new CubeListBuilder();
+		MeshDefinition mesh = HumanoidModel.createMesh(CubeDeformation.NONE, 0);
+		mesh.getRoot().addOrReplaceChild("back", builder, PartPose.ZERO);
+		return mesh;
+	}
+}

--- a/src/main/java/com/simibubi/create/compat/curios/Curios.java
+++ b/src/main/java/com/simibubi/create/compat/curios/Curios.java
@@ -33,11 +33,13 @@ public class Curios {
 
 	/**
 	 * Resolves the Stacks Handler Map given an Entity.
-	 * It is recommended to then use a
+	 * It is recommended to then use a `.map(curiosMap -> curiosMap.get({key})`,
+	 * which can be null and would therefore be caught by the Optional::map function.
+	 *
 	 * @param entity The entity which possibly has a Curio Inventory capability
 	 * @return An optional of the Stacks Handler Map
 	 */
-	private static Optional<Map<String, ICurioStacksHandler>> resolveCurios(LivingEntity entity) {
+	private static Optional<Map<String, ICurioStacksHandler>> resolveCuriosMap(LivingEntity entity) {
 		return entity.getCapability(CuriosCapability.INVENTORY).map(ICuriosItemHandler::getCurios);
 	}
 
@@ -47,7 +49,7 @@ public class Curios {
 		// Enable if the backtank should remove back slots
 		// forgeEventBus.addListener(Curios::onEquipmentChanged);
 
-		GogglesItem.addIsWearingPredicate(player -> resolveCurios(player)
+		GogglesItem.addIsWearingPredicate(player -> resolveCuriosMap(player)
 			.map(curiosMap -> curiosMap.get("head"))
 			.map(stacksHandler -> {
 				// Check all the Head slots for Goggles existing
@@ -60,10 +62,10 @@ public class Curios {
 			})
 			.orElse(false));
 
-		BackTankUtil.addBacktankSupplier(entity -> resolveCurios(entity)
+		BackTankUtil.addBacktankSupplier(entity -> resolveCuriosMap(entity)
 			.map(curiosMap -> {
 				List<ItemStack> stacks = new ArrayList<>();
-				for(ICurioStacksHandler stacksHandler : curiosMap.values()) {
+				for (ICurioStacksHandler stacksHandler : curiosMap.values()) {
 					// Search all the curio slots for pressurized air sources, and add them to the list
 					int slots = stacksHandler.getSlots();
 					for (int slot = 0; slot < slots; slot++) {
@@ -102,16 +104,17 @@ public class Curios {
 	/**
 	 * A listener for the LivingEquipmentChangeEvent event, handling changes to Curio slots that should happen
 	 * when particular equipment is equipped.
+	 *
 	 * @param event The event.
 	 */
 	private static void onEquipmentChanged(final LivingEquipmentChangeEvent event) {
-		final Optional<ICurioStacksHandler> optStacksHandler = resolveCurios(event.getEntityLiving()).map(curiosMap -> curiosMap.get("back"));
+		final Optional<ICurioStacksHandler> optStacksHandler = resolveCuriosMap(event.getEntityLiving()).map(curiosMap -> curiosMap.get("back"));
 		if (optStacksHandler.isEmpty())
 			return;
 		final ICurioStacksHandler stacksHandler = optStacksHandler.get();
 
 		// Test for if the backtank is being added to the chest slot -- if so, remove all back slots.
-		if(event.getSlot() == EquipmentSlot.CHEST) {
+		if (event.getSlot() == EquipmentSlot.CHEST) {
 
 			final boolean removing = AllItems.COPPER_BACKTANK.isIn(event.getFrom());
 			final boolean adding = AllItems.COPPER_BACKTANK.isIn(event.getTo());

--- a/src/main/java/com/simibubi/create/compat/curios/Curios.java
+++ b/src/main/java/com/simibubi/create/compat/curios/Curios.java
@@ -3,7 +3,14 @@ package com.simibubi.create.compat.curios;
 import com.simibubi.create.AllItems;
 import com.simibubi.create.content.contraptions.goggles.GogglesItem;
 
+import com.simibubi.create.content.curiosities.armor.BackTankUtil;
+
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
+import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.event.entity.living.LivingEquipmentChangeEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.InterModComms;
@@ -14,26 +21,54 @@ import top.theillusivec4.curios.api.SlotTypeMessage;
 import top.theillusivec4.curios.api.SlotTypePreset;
 import top.theillusivec4.curios.api.type.inventory.ICurioStacksHandler;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
 public class Curios {
+
+	/**
+	 * Resolves the Stacks Handler given an Entity and the slot key
+	 * @param entity The entity which possibly has a Curio Inventory capability
+	 * @param key The key of the Curio slot
+	 * @return An optional of the Stacks Handler
+	 */
+	private static Optional<ICurioStacksHandler> resolveCuriosStacksHandler(LivingEntity entity, String key) {
+		return entity.getCapability(CuriosCapability.INVENTORY).map(handler -> handler.getCurios().get(key));
+	}
+
 	public static void init(IEventBus modEventBus, IEventBus forgeEventBus) {
 		modEventBus.addListener(Curios::onInterModEnqueue);
 		modEventBus.addListener(Curios::onClientSetup);
+		// Enable if the backtank should remove back slots
+		// forgeEventBus.addListener(Curios::onEquipmentChanged);
 
-		GogglesItem.addIsWearingPredicate(player -> player.getCapability(CuriosCapability.INVENTORY)
-			.map(handler -> {
-				ICurioStacksHandler stacksHandler = handler.getCurios()
-					.get("head");
-				if (stacksHandler == null)
-					return false;
+		GogglesItem.addIsWearingPredicate(player -> resolveCuriosStacksHandler(player, "head")
+			.map(stacksHandler -> {
+				// Check all the Head slots for Goggles existing
 				int slots = stacksHandler.getSlots();
 				for (int slot = 0; slot < slots; slot++)
-					if (AllItems.GOGGLES.isIn(stacksHandler.getStacks()
-						.getStackInSlot(slot)))
+					if (AllItems.GOGGLES.isIn(stacksHandler.getStacks().getStackInSlot(slot)))
 						return true;
 
 				return false;
 			})
 			.orElse(false));
+
+		BackTankUtil.addBacktankSupplier(entity -> resolveCuriosStacksHandler(entity, "back")
+			.map(stacksHandler -> {
+				// Check all the Back Slots for a backtank existing in one of them
+				List<ItemStack> stacks = new ArrayList<>();
+				int slots = stacksHandler.getSlots();
+				for (int slot = 0; slot < slots; slot++) {
+					final ItemStack stack = stacksHandler.getStacks().getStackInSlot(slot);
+					if (AllItems.COPPER_BACKTANK.isIn(stack))
+						stacks.add(stack);
+				}
+
+				return stacks;
+			}).orElse(new ArrayList<>()));
 
 		DistExecutor.unsafeRunWhenOn(Dist.CLIENT,
 			() -> () -> modEventBus.addListener(CuriosRenderers::onLayerRegister));
@@ -42,9 +77,48 @@ public class Curios {
 	private static void onInterModEnqueue(final InterModEnqueueEvent event) {
 		InterModComms.sendTo("curios", SlotTypeMessage.REGISTER_TYPE, () -> SlotTypePreset.HEAD.getMessageBuilder()
 			.build());
+		InterModComms.sendTo("curios", SlotTypeMessage.REGISTER_TYPE, () -> SlotTypePreset.BACK.getMessageBuilder()
+			.build());
 	}
 
 	private static void onClientSetup(final FMLClientSetupEvent event) {
 		CuriosRenderers.register();
+	}
+
+
+	/**
+	 * The AttributeModifier which removes all Back Slots from Curios (A 0 multiplier on the Back slot total)
+	 */
+	public static final AttributeModifier backtankRemovesBackSlotsModifier =
+		new AttributeModifier(UUID.fromString("c1f7e0de-9e55-464f-a7ea-f1b535cc010e"), "Backtank Removes Back Slots", 0,
+			AttributeModifier.Operation.MULTIPLY_TOTAL);
+
+	/**
+	 * A listener for the LivingEquipmentChangeEvent event, handling changes to Curio slots that should happen
+	 * when particular equipment is equipped.
+	 * @param event The event.
+	 */
+	private static void onEquipmentChanged(final LivingEquipmentChangeEvent event) {
+		final Optional<ICurioStacksHandler> optStacksHandler = resolveCuriosStacksHandler(event.getEntityLiving(), "back");
+		if (optStacksHandler.isEmpty())
+			return;
+		final ICurioStacksHandler stacksHandler = optStacksHandler.get();
+
+		// Test for if the backtank is being added to the chest slot -- if so, remove all back slots.
+		if(event.getSlot() == EquipmentSlot.CHEST) {
+
+			final boolean removing = AllItems.COPPER_BACKTANK.isIn(event.getFrom());
+			final boolean adding = AllItems.COPPER_BACKTANK.isIn(event.getTo());
+
+			if (removing == adding)
+				return;
+
+			final boolean containsModifier = stacksHandler.getModifiers().containsKey(backtankRemovesBackSlotsModifier.getId());
+
+			if (removing && containsModifier)
+				stacksHandler.removeModifier(backtankRemovesBackSlotsModifier.getId());
+			else if (adding && !containsModifier)
+				stacksHandler.addTransientModifier(backtankRemovesBackSlotsModifier);
+		}
 	}
 }

--- a/src/main/java/com/simibubi/create/compat/curios/CuriosRenderers.java
+++ b/src/main/java/com/simibubi/create/compat/curios/CuriosRenderers.java
@@ -13,9 +13,11 @@ import top.theillusivec4.curios.api.client.CuriosRendererRegistry;
 public class CuriosRenderers {
 	public static void register() {
 		CuriosRendererRegistry.register(AllItems.GOGGLES.get(), () -> new GogglesCurioRenderer(Minecraft.getInstance().getEntityModels().bakeLayer(GogglesCurioRenderer.LAYER)));
+		CuriosRendererRegistry.register(AllItems.COPPER_BACKTANK.get(), () -> new CopperBacktankCurioRenderer(Minecraft.getInstance().getEntityModels().bakeLayer(CopperBacktankCurioRenderer.LAYER)));
 	}
 
 	public static void onLayerRegister(final EntityRenderersEvent.RegisterLayerDefinitions event) {
 		event.registerLayerDefinition(GogglesCurioRenderer.LAYER, () -> LayerDefinition.create(GogglesCurioRenderer.mesh(), 1, 1));
+		event.registerLayerDefinition(CopperBacktankCurioRenderer.LAYER, () -> LayerDefinition.create(CopperBacktankCurioRenderer.mesh(), 1, 1));
 	}
 }

--- a/src/main/java/com/simibubi/create/content/curiosities/armor/BackTankUtil.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/armor/BackTankUtil.java
@@ -189,7 +189,7 @@ public class BackTankUtil {
 			return backtanks.get(0).getItem().getBarColor(backtanks.get(0));
 
 		ItemStack mostFull = backtanks.get(0);
-		float mostFullPercent = maxAir(mostFull);
+		float mostFullPercent = getAir(mostFull) / maxAir(mostFull);
 
 		for(ItemStack backtank : backtanks) {
 			float fullPercent = getAir(backtank) / maxAir(backtank);

--- a/src/main/java/com/simibubi/create/content/curiosities/armor/BackTankUtil.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/armor/BackTankUtil.java
@@ -43,11 +43,11 @@ public class BackTankUtil {
 
 	public static ItemStack get(LivingEntity entity) {
 
-		for(Function<LivingEntity, List<ItemStack>> supplier : BACKTANK_SUPPLIERS) {
+		for (Function<LivingEntity, List<ItemStack>> supplier : BACKTANK_SUPPLIERS) {
 			List<ItemStack> result = supplier.apply(entity);
 
-			for(ItemStack stack : result)
-				if(!stack.isEmpty())
+			for (ItemStack stack : result)
+				if (!stack.isEmpty())
 					return stack;
 		}
 
@@ -57,11 +57,11 @@ public class BackTankUtil {
 	public static List<ItemStack> getAllWithAir(LivingEntity entity) {
 		List<ItemStack> all = new ArrayList<>();
 
-		for(Function<LivingEntity, List<ItemStack>> supplier : BACKTANK_SUPPLIERS) {
+		for (Function<LivingEntity, List<ItemStack>> supplier : BACKTANK_SUPPLIERS) {
 			List<ItemStack> result = supplier.apply(entity);
 
-			for(ItemStack stack : result)
-				if(hasAirRemaining(stack))
+			for (ItemStack stack : result)
+				if (hasAirRemaining(stack))
 					all.add(stack);
 		}
 
@@ -165,6 +165,7 @@ public class BackTankUtil {
 		if (backtanks.size() == 1)
 			return backtanks.get(0).getItem().getBarWidth(backtanks.get(0));
 
+		// If there is more than one backtank, average the bar widths.
 		int sumBarWidth = backtanks.stream()
 			.map(backtank -> backtank.getItem().getBarWidth(backtank))
 			.reduce(0 , Integer::sum);
@@ -188,10 +189,11 @@ public class BackTankUtil {
 		if (backtanks.size() == 1)
 			return backtanks.get(0).getItem().getBarColor(backtanks.get(0));
 
+		// If there is more than one backtank, use the most full for the bar color.
 		ItemStack mostFull = backtanks.get(0);
 		float mostFullPercent = getAir(mostFull) / maxAir(mostFull);
 
-		for(ItemStack backtank : backtanks) {
+		for (ItemStack backtank : backtanks) {
 			float fullPercent = getAir(backtank) / maxAir(backtank);
 			if(fullPercent <= mostFullPercent)
 				continue;

--- a/src/main/java/com/simibubi/create/content/curiosities/armor/DivingHelmetItem.java
+++ b/src/main/java/com/simibubi/create/content/curiosities/armor/DivingHelmetItem.java
@@ -16,6 +16,8 @@ import net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 
+import java.util.List;
+
 @EventBusSubscriber
 public class DivingHelmetItem extends CopperArmorItem {
 
@@ -44,10 +46,8 @@ public class DivingHelmetItem extends CopperArmorItem {
 		if (entity instanceof Player && ((Player) entity).isCreative())
 			return;
 
-		ItemStack backtank = BackTankUtil.get(entity);
-		if (backtank.isEmpty())
-			return;
-		if (!BackTankUtil.hasAirRemaining(backtank))
+		List<ItemStack> backtanks = BackTankUtil.getAllWithAir(entity);
+		if (backtanks.isEmpty())
 			return;
 
 		if (lavaDiving) {
@@ -61,7 +61,7 @@ public class DivingHelmetItem extends CopperArmorItem {
 
 		if (world.isClientSide)
 			entity.getPersistentData()
-				.putInt("VisualBacktankAir", (int) BackTankUtil.getAir(backtank));
+				.putInt("VisualBacktankAir", Math.round(backtanks.stream().map(BackTankUtil::getAir).reduce(0f, Float::sum)));
 
 		if (!second)
 			return;
@@ -71,7 +71,7 @@ public class DivingHelmetItem extends CopperArmorItem {
 
 		entity.setAirSupply(Math.min(entity.getMaxAirSupply(), entity.getAirSupply() + 10));
 		entity.addEffect(new MobEffectInstance(MobEffects.WATER_BREATHING, 30, 0, true, false, true));
-		BackTankUtil.consumeAir(entity, backtank, 1);
+		BackTankUtil.consumeAir(entity, backtanks.get(0), 1);
 	}
 
 }

--- a/src/main/resources/data/curios/tags/items/back.json
+++ b/src/main/resources/data/curios/tags/items/back.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "create:copper_backtank"
+  ]
+}


### PR DESCRIPTION
This PR adds Curio support for the Copper Backtank to be in the back slot, upgrades the BacktankUtil (as well as some of its consumers, e.g. the diving mask) to handle multiple backtank/air suppliers, and adds support for any Curio which has a `PRESSURIZED_AIR_SOURCES` tag, instead of just those in the Armor slots.

Originally I had also planned to upgrade the ExtendoGrip to support the Curio "Hand" slot, but found it to be overly complicated when it came to rendering (particularly with the logic in the use case of dual wielding ExtendoGrips and also having it in the hand slot).

There is also an optional Event Listener (`com.simibubi.create.compat.curios.Curios::onEquipmentChanged`) which can remove the Curio "Back" slot when the Backtank is equipped in the Armor slot, removing the option for users to use curios that may overlap with it (such as with a backpack).

Currently this is disabled, and (just for fun) when two Backtanks are used it makes a cute double-backtank instead:

![image](https://user-images.githubusercontent.com/13156131/232615333-1a79d92b-2f53-4bd7-9bc2-f21f00e652e6.png)

This also helped me test whether it was reading multiple backtanks, and it was, showing me a timer of 30 minutes (for two unenchanted backtanks) instead of 15.
