### PR TITLE
Add checks on contraption disassembly for Sculk Sensors/Shriekers.

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/Contraption.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/structureMovement/Contraption.java
@@ -1006,7 +1006,7 @@ public abstract class Contraption {
 		if (disassembled)
 			return;
 		disassembled = true;
-		
+
 		for (boolean nonBrittles : Iterate.trueAndFalse) {
 			for (StructureBlockInfo block : blocks.values()) {
 				if (nonBrittles == BlockMovementChecks.isBrittle(block.state))
@@ -1047,6 +1047,10 @@ public abstract class Contraption {
 				if (state.hasProperty(SlidingDoorBlock.VISIBLE))
 					state = state.setValue(SlidingDoorBlock.VISIBLE, !state.getValue(SlidingDoorBlock.OPEN))
 						.setValue(SlidingDoorBlock.POWERED, false);
+				// Stop Sculk shriekers from getting "stuck" if moved mid-shriek.
+				if(state.is(Blocks.SCULK_SHRIEKER)){
+					state = Blocks.SCULK_SHRIEKER.defaultBlockState();
+				}
 
 				world.setBlock(targetPos, state, Block.UPDATE_MOVE_BY_PISTON | Block.UPDATE_ALL);
 
@@ -1060,6 +1064,12 @@ public abstract class Contraption {
 				BlockEntity tileEntity = world.getBlockEntity(targetPos);
 
 				CompoundTag tag = block.nbt;
+
+				// Temporary fix: Calling load(CompoundTag tag) on a Sculk sensor causes it to not react to vibrations.
+				if(state.is(Blocks.SCULK_SENSOR) || state.is(Blocks.SCULK_SHRIEKER)){
+					tag = null;
+				}
+
 				if (tileEntity != null)
 					tag = NBTProcessors.process(tileEntity, tag, false);
 				if (tileEntity != null && tag != null) {


### PR DESCRIPTION
Adds checks when disassembling contraptions such that:

- Skulk Sensors and Skulk Shriekers will ignore NBT tags when being placed. This is due to writing any NBT data to them disabling their ability to respond to vibration events (This was tested in a blank mod, reading and immediately writing the NBT data of a Sculk sensor made it stop responding to vibrations. The `/data` command also causes this). Fixes #4677.

- Skulk Shriekers will have their state reset to the default (Not able to summon the Warden, not shrieking, and not waterlogged). This prevents them from being moved while shrieking and consequently getting 'stuck' in a similar manner to writing NBT data to them.