### PR TITLE
Open Ended Pipes now correctly handle Builder's Tea

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/fluids/OpenEndedPipe.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/fluids/OpenEndedPipe.java
@@ -25,6 +25,7 @@ import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.FluidTags;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
@@ -39,6 +40,7 @@ import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.phys.AABB;
+import net.minecraftforge.common.ForgeConfig;
 import net.minecraftforge.common.Tags;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.fluids.FluidStack;
@@ -54,6 +56,7 @@ public class OpenEndedPipe extends FlowSource {
 		registerEffectHandler(new MilkEffectHandler());
 		registerEffectHandler(new WaterEffectHandler());
 		registerEffectHandler(new LavaEffectHandler());
+		registerEffectHandler(new TeaEffectHandler());
 	}
 
 	private Level world;
@@ -440,6 +443,25 @@ public class OpenEndedPipe extends FlowSource {
 			List<Entity> entities = world.getEntities((Entity) null, pipe.getAOE(), entity -> !entity.fireImmune());
 			for (Entity entity : entities)
 				entity.setSecondsOnFire(3);
+		}
+	}
+
+	public static class TeaEffectHandler implements IEffectHandler {
+		@Override
+		public boolean canApplyEffects(OpenEndedPipe pipe, FluidStack fluid) {
+			return fluid.getFluid().isSame(AllFluids.TEA.get());
+		}
+
+		@Override
+		public void applyEffects(OpenEndedPipe pipe, FluidStack fluid) {
+			Level world = pipe.getWorld();
+			if (world.getGameTime() % 5 != 0)
+				return;
+			List<LivingEntity> entities = world
+					.getEntitiesOfClass(LivingEntity.class, pipe.getAOE(), LivingEntity::isAffectedByPotions);
+			for (LivingEntity entity : entities) {
+					entity.addEffect(new MobEffectInstance(MobEffects.DIG_SPEED, 21, 0, false, false, false));
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixed a weird inconsistency where Builder's Tea applies haste, potions apply their effects when dripping from pipes, but still the Builder's Tea didn't apply haste when dripping out of a pipe. ( #4559)