### PR TITLE
add brass tunnel speed setting

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/block/belts/tunnel/BrassTunnelTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/belts/tunnel/BrassTunnelTileEntity.java
@@ -66,7 +66,7 @@ public class BrassTunnelTileEntity extends BeltTunnelTileEntity implements IHave
 
 	ItemStack stackToDistribute;
 	Direction stackEnteredFrom;
-	
+
 	float distributionProgress;
 	int distributionDistanceLeft;
 	int distributionDistanceRight;
@@ -174,7 +174,7 @@ public class BrassTunnelTileEntity extends BeltTunnelTileEntity implements IHave
 				return;
 
 			if (selectionMode.get() != SelectionMode.SYNCHRONIZE || syncedOutputActive) {
-				distributionProgress = 10;
+				distributionProgress = AllConfigs.SERVER.logistics.brassTunnelTimer.get();
 				sendData();
 			}
 			return;
@@ -528,7 +528,7 @@ public class BrassTunnelTileEntity extends BeltTunnelTileEntity implements IHave
 					continue;
 				if (!tunnelTE.sides.contains(direction))
 					continue;
-				
+
 				BlockPos offset = tunnelTE.worldPosition.below()
 					.relative(direction);
 
@@ -579,11 +579,11 @@ public class BrassTunnelTileEntity extends BeltTunnelTileEntity implements IHave
 		compound.putBoolean("SyncedOutput", syncedOutputActive);
 		compound.putBoolean("ConnectedLeft", connectedLeft);
 		compound.putBoolean("ConnectedRight", connectedRight);
-		
+
 		compound.put("StackToDistribute", stackToDistribute.serializeNBT());
 		if (stackEnteredFrom != null)
 			NBTHelper.writeEnum(compound, "StackEnteredFrom", stackEnteredFrom);
-		
+
 		compound.putFloat("DistributionProgress", distributionProgress);
 		compound.putInt("PreviousIndex", previousOutputIndex);
 		compound.putInt("DistanceLeft", distributionDistanceLeft);
@@ -611,7 +611,7 @@ public class BrassTunnelTileEntity extends BeltTunnelTileEntity implements IHave
 		syncedOutputActive = compound.getBoolean("SyncedOutput");
 		connectedLeft = compound.getBoolean("ConnectedLeft");
 		connectedRight = compound.getBoolean("ConnectedRight");
-		
+
 		stackToDistribute = ItemStack.of(compound.getCompound("StackToDistribute"));
 		stackEnteredFrom =
 			compound.contains("StackEnteredFrom") ? NBTHelper.readEnum(compound, "StackEnteredFrom", Direction.class)
@@ -719,7 +719,7 @@ public class BrassTunnelTileEntity extends BeltTunnelTileEntity implements IHave
 		super.invalidate();
 		tunnelCapability.invalidate();
 	}
-	
+
 	@Override
 	public void destroy() {
 		super.destroy();
@@ -782,7 +782,7 @@ public class BrassTunnelTileEntity extends BeltTunnelTileEntity implements IHave
 		List<ItemStack> allStacks = grabAllStacksOfGroup(true);
 		if (allStacks.isEmpty())
 			return false;
-		
+
 		tooltip.add(componentSpacing.plainCopy()
 			.append(Lang.translateDirect("tooltip.brass_tunnel.contains"))
 			.withStyle(ChatFormatting.WHITE));
@@ -795,7 +795,7 @@ public class BrassTunnelTileEntity extends BeltTunnelTileEntity implements IHave
 		tooltip.add(componentSpacing.plainCopy()
 			.append(Lang.translateDirect("tooltip.brass_tunnel.retrieve"))
 			.withStyle(ChatFormatting.DARK_GRAY));
-		
+
 		return true;
 	}
 

--- a/src/main/java/com/simibubi/create/content/logistics/block/belts/tunnel/BrassTunnelTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/block/belts/tunnel/BrassTunnelTileEntity.java
@@ -11,6 +11,8 @@ import java.util.Set;
 
 import javax.annotation.Nullable;
 
+import com.simibubi.create.foundation.config.AllConfigs;
+
 import org.apache.commons.lang3.tuple.Pair;
 
 import com.simibubi.create.AllBlocks;

--- a/src/main/java/com/simibubi/create/foundation/config/CLogistics.java
+++ b/src/main/java/com/simibubi/create/foundation/config/CLogistics.java
@@ -10,7 +10,7 @@ public class CLogistics extends ConfigBase {
 	public final ConfigInt linkRange = i(256, 1, "linkRange", Comments.linkRange);
 	public final ConfigInt displayLinkRange = i(64, 1, "displayLinkRange", Comments.displayLinkRange);
 	public final ConfigInt vaultCapacity = i(20, 1, "vaultCapacity", Comments.vaultCapacity);
-	public final ConfigInt brassTunnelTimer = i(1,10,10, "brassTunnelTimer",Comments.brassTunnelTimer);
+	public final ConfigInt brassTunnelTimer = i(10,1,10, "brassTunnelTimer",Comments.brassTunnelTimer);
 	@Override
 	public String getName() {
 		return "logistics";

--- a/src/main/java/com/simibubi/create/foundation/config/CLogistics.java
+++ b/src/main/java/com/simibubi/create/foundation/config/CLogistics.java
@@ -10,7 +10,7 @@ public class CLogistics extends ConfigBase {
 	public final ConfigInt linkRange = i(256, 1, "linkRange", Comments.linkRange);
 	public final ConfigInt displayLinkRange = i(64, 1, "displayLinkRange", Comments.displayLinkRange);
 	public final ConfigInt vaultCapacity = i(20, 1, "vaultCapacity", Comments.vaultCapacity);
-
+	public final ConfigInt brassTunnelTimer = i(1,10,10, "brassTunnelTimer",Comments.brassTunnelTimer);
 	@Override
 	public String getName() {
 		return "logistics";
@@ -28,6 +28,7 @@ public class CLogistics extends ConfigBase {
 			"The amount of ticks a portable storage interface waits for transfers until letting contraptions move along.";
 		static String mechanicalArmRange = "Maximum distance in blocks a Mechanical Arm can reach across.";
 		static String vaultCapacity = "The total amount of stacks a vault can hold per block in size.";
+		static String brassTunnelTimer = "The amount of ticks a brass tunnel waits between distributions";
 	}
 
 }


### PR DESCRIPTION
This should make #2944 fixable by adding a setting which allows lowering the ticks to next distribution from 10 ticks to down to 1 tick. The default value for this is still 10 ticks so it is up to the user to set this up.
As i do not know very much about how the code works and if this change is the best possible solution, i strongly recommend to look over it again.

Here is the comparison between the before (10 ticks):

https://user-images.githubusercontent.com/80287602/235437700-a581bdc8-aa10-4f85-876a-7bb436185b3d.mp4


And when the config is set to 1 tick:


https://user-images.githubusercontent.com/80287602/235437708-28d23f85-bc91-4990-a901-fb2ad263a171.mp4

The setting looks like this:
![2023-05-01 11_54_31-Create Live 4](https://user-images.githubusercontent.com/80287602/235441629-2256b685-39d1-4148-8de2-1fa25e4ffeaa.png)

