### PR TITLE
Add recipes to create Cobbled Deepslate, Tuff, and Netherrack

### DIFF
--- a/src/generated/resources/data/create/recipes/compacting/cobbled_deepslate_from_clay.json
+++ b/src/generated/resources/data/create/recipes/compacting/cobbled_deepslate_from_clay.json
@@ -1,0 +1,35 @@
+{
+  "type": "create:compacting",
+  "ingredients": [
+    {
+      "item": "minecraft:clay_ball"
+    },
+    {
+      "item": "minecraft:clay_ball"
+    },
+    {
+      "item": "minecraft:clay_ball"
+    },
+    {
+      "item": "minecraft:clay_ball"
+    },
+    {
+      "item": "minecraft:clay_ball"
+    },
+    {
+      "item": "minecraft:clay_ball"
+    },
+    {
+      "item": "minecraft:clay_ball"
+    },
+    {
+      "item": "minecraft:clay_ball"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:cobbled_deepslate"
+    }
+  ],
+  "heatRequirement": "superheated"
+}

--- a/src/generated/resources/data/create/recipes/crushing/cobbled_deepslate.json
+++ b/src/generated/resources/data/create/recipes/crushing/cobbled_deepslate.json
@@ -1,0 +1,14 @@
+{
+  "type": "create:crushing",
+  "ingredients": [
+    {
+      "item": "minecraft:cobbled_deepslate"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:tuff"
+    }
+  ],
+  "processingTime": 500
+}

--- a/src/generated/resources/data/create/recipes/haunting/netherrack.json
+++ b/src/generated/resources/data/create/recipes/haunting/netherrack.json
@@ -1,0 +1,13 @@
+{
+  "type": "create:haunting",
+  "ingredients": [
+    {
+      "item": "minecraft:tuff"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:netherrack"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds recipes to create a few blocks:

- Cobbled Deepslate, by a **superheated press** with 8x Clay Balls
  - [Slate](https://en.wikipedia.org/wiki/Slate) "is composed of clay... through low grade regional metamorphism."
  - This is meant to be difficult so that it is an end-game process
-  Tuff, by grinding Cobbled Deepslate (similar to Gravel from Cobblestone)
- Netherrack, by haunting Tuff (they have similar breakable properties)

These additions allow the following to be created infinitely:

- Deepslate
- Tuff
  - and therefore Iron, Gold, Copper, and Zinc via washing Tuff
  - and therefore Brass via alloying
- Netherrack
  - and therefore Cinder Flour
  - and therefore Lava & Blaze Cakes
  - and therefore Andesite

---

Some concerns which may rise:

- Infinitely generating Ore can be seen as "too powerful", but Iron (via washing Gravel) and Gold (via washing Sand) are already doable -- adding Copper and Zinc is rather necessary in some form or fashion.
- Infinitely generating Lava is somewhat awkward as that is supposed to "get you into the nether". However, given the ease of harvesting chestfuls of Netherrack, having some way to automate, especially if through an expensive process, seems negligible.

And a final note:

The limiting factor of an easily-created infinite lava/blaze-cake factory seems to be clay creation, as 8x clay balls is rather expensive given the time it takes to wash sand and it being a 25% success rate. However, again, it was never supposed to be *easy*, so this might be alright.

This is my example/test factory to display the complexity required to generate infinite Blaze Cakes (the clay portion on the top left still needs to be optimized):

![image](https://user-images.githubusercontent.com/13156131/235577253-39809765-0a72-46de-bed8-10eff1f77309.png)


---

Closes #4031 
Closes #3430 
Helps with #3356
