### PR TITLE
Mechanical Crafter use forge:crafting_tables tag for compat

### DIFF
--- a/src/generated/resources/data/create/recipes/crafting/kinetics/mechanical_crafter.json
+++ b/src/generated/resources/data/create/recipes/crafting/kinetics/mechanical_crafter.json
@@ -8,7 +8,7 @@
       "item": "create:brass_casing"
     },
     "R": {
-      "item": "minecraft:crafting_table"
+      "tag": "forge:crafting_tables"
     }
   },
   "pattern": [

--- a/src/generated/resources/data/forge/tags/items/crafting_tables
+++ b/src/generated/resources/data/forge/tags/items/crafting_tables
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:crafting_table",
+    "#blue_skies:crafting_tables"
+  ]
+}


### PR DESCRIPTION
Change mechanical crafter to use forge:crafting_tables tag for better compatibility with other mods that do use and offer modded crafting tables from other wood types