### PR TITLE
Fixed small oversights in bogey API

### DIFF
--- a/src/main/java/com/simibubi/create/content/trains/bogey/AbstractBogeyBlock.java
+++ b/src/main/java/com/simibubi/create/content/trains/bogey/AbstractBogeyBlock.java
@@ -187,7 +187,7 @@ public abstract class AbstractBogeyBlock<T extends AbstractBogeyBlockEntity> ext
 	}
 
 	@Override
-	public InteractionResult use(BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand,
+	public final InteractionResult use(BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand,
 								 BlockHitResult hit) {
 		if (level.isClientSide)
 			return InteractionResult.PASS;
@@ -239,6 +239,12 @@ public abstract class AbstractBogeyBlock<T extends AbstractBogeyBlockEntity> ext
 			return InteractionResult.CONSUME;
 		}
 
+		return onInteractWithBogey(state, level, pos, player, hand, hit);
+	}
+
+	// Allows for custom interactions with bogey block to be added simply
+	protected InteractionResult onInteractWithBogey(BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand,
+													BlockHitResult hit) {
 		return InteractionResult.PASS;
 	}
 
@@ -248,7 +254,6 @@ public abstract class AbstractBogeyBlock<T extends AbstractBogeyBlockEntity> ext
 	protected List<ResourceLocation> getBogeyBlockCycle() {
 		return BOGEYS;
 	}
-
 
 	@Override
 	public BlockState getRotatedBlockState(BlockState state, Direction targetedFace) {

--- a/src/main/java/com/simibubi/create/content/trains/bogey/BackupBogeyRenderer.java
+++ b/src/main/java/com/simibubi/create/content/trains/bogey/BackupBogeyRenderer.java
@@ -4,6 +4,8 @@ import com.jozufozu.flywheel.api.MaterialManager;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 
+import com.simibubi.create.content.trains.entity.CarriageBogey;
+
 import net.minecraft.nbt.CompoundTag;
 
 public class BackupBogeyRenderer extends BogeyRenderer.CommonRenderer {
@@ -15,7 +17,7 @@ public class BackupBogeyRenderer extends BogeyRenderer.CommonRenderer {
 	}
 
 	@Override
-	public void initialiseContraptionModelData(MaterialManager materialManager) {
+	public void initialiseContraptionModelData(MaterialManager materialManager, CarriageBogey carriageBogey) {
 
 	}
 }

--- a/src/main/java/com/simibubi/create/content/trains/bogey/BogeyInstance.java
+++ b/src/main/java/com/simibubi/create/content/trains/bogey/BogeyInstance.java
@@ -30,8 +30,8 @@ public final class BogeyInstance {
 		this.renderer = this.style.createRendererInstance(this.size);
 		this.commonRenderer = this.style.getNewCommonRenderInstance();
 
-		commonRenderer.ifPresent(bogeyRenderer -> bogeyRenderer.initialiseContraptionModelData(materialManager));
-		renderer.initialiseContraptionModelData(materialManager);
+		commonRenderer.ifPresent(bogeyRenderer -> bogeyRenderer.initialiseContraptionModelData(materialManager, bogey));
+		renderer.initialiseContraptionModelData(materialManager, bogey);
 	}
 
 	public void beginFrame(float wheelAngle, PoseStack ms) {

--- a/src/main/java/com/simibubi/create/content/trains/bogey/BogeyRenderer.java
+++ b/src/main/java/com/simibubi/create/content/trains/bogey/BogeyRenderer.java
@@ -38,7 +38,7 @@ public abstract class BogeyRenderer {
 	 * @param size The amount of models needed
 	 * @return A generic transform which can be used for both in-world and in-contraption models
 	 */
-	public Transform<?>[] getTransformsFromPartial(PartialModel model, PoseStack ms, boolean inInstancedContraption, int size) {
+	public Transform<?>[] getTransform(PartialModel model, PoseStack ms, boolean inInstancedContraption, int size) {
 		return (inInstancedContraption) ? transformContraptionModelData(keyFromModel(model), ms) : createModelData(model, size);
 	}
 
@@ -52,7 +52,7 @@ public abstract class BogeyRenderer {
 	 * @param size The amount of models needed
 	 * @return A generic transform which can be used for both in-world and in-contraption models
 	 */
-	public Transform<?>[] getTransformsFromBlockState(BlockState state, PoseStack ms, boolean inContraption, int size) {
+	public Transform<?>[] getTranform(BlockState state, PoseStack ms, boolean inContraption, int size) {
 		return inContraption ? transformContraptionModelData(keyFromModel(state), ms) : createModelData(state, size);
 	}
 
@@ -65,7 +65,7 @@ public abstract class BogeyRenderer {
 	 * @param inInstancedContraption Type of rendering required
 	 * @return A generic transform which can be used for both in-world and in-contraption models
 	 */
-	public Transform<?> getTransformFromPartial(PartialModel model, PoseStack ms, boolean inInstancedContraption) {
+	public Transform<?> getTranform(PartialModel model, PoseStack ms, boolean inInstancedContraption) {
 		BlockState air = Blocks.AIR.defaultBlockState();
 		return inInstancedContraption ? contraptionModelData.get(keyFromModel(model))[0].setTransform(ms)
 				: CachedBufferer.partial(model, air);
@@ -79,7 +79,7 @@ public abstract class BogeyRenderer {
 	 * @param inContraption Type of model required
 	 * @return A generic transform which can be used for both in-world and in-contraption models
 	 */
-	public Transform<?> getTransformFromBlockState(BlockState state, PoseStack ms, boolean inContraption) {
+	public Transform<?> getTransform(BlockState state, PoseStack ms, boolean inContraption) {
 		return (inContraption) ? contraptionModelData.get(keyFromModel(state))[0].setTransform(ms)
 				: CachedBufferer.block(state);
 	}

--- a/src/main/java/com/simibubi/create/content/trains/bogey/StandardBogeyRenderer.java
+++ b/src/main/java/com/simibubi/create/content/trains/bogey/StandardBogeyRenderer.java
@@ -31,14 +31,14 @@ public class StandardBogeyRenderer {
 		@Override
 		public void render(CompoundTag bogeyData, float wheelAngle, PoseStack ms, int light, VertexConsumer vb, boolean inContraption) {
 			boolean inInstancedContraption = vb == null;
-			Transform<?>[] shafts = getTranform(AllBlocks.SHAFT.getDefaultState()
+			BogeyModelData[] shafts = getTransform(AllBlocks.SHAFT.getDefaultState()
 					.setValue(ShaftBlock.AXIS, Direction.Axis.Z), ms, inInstancedContraption, 2);
 			for (int i : Iterate.zeroAndOne) {
 				shafts[i].translate(-.5f, .25f, i * -1)
 						.centre()
 						.rotateZ(wheelAngle)
-						.unCentre();
-				finalize(shafts[i], ms, light, vb);
+						.unCentre()
+						.render(ms, light, vb);
 			}
 		}
 	}
@@ -60,17 +60,17 @@ public class StandardBogeyRenderer {
 		@Override
 		public void render(CompoundTag bogeyData, float wheelAngle, PoseStack ms, int light, VertexConsumer vb, boolean inContraption) {
 			boolean inInstancedContraption = vb == null;
-			Transform<?> transform = getTranform(BOGEY_FRAME, ms, inInstancedContraption);
-			finalize(transform, ms, light, vb);
+			getTransform(BOGEY_FRAME, ms, inInstancedContraption)
+					.render(ms, light, vb);
 
-			Transform<?>[] wheels = getTransform(SMALL_BOGEY_WHEELS, ms, inInstancedContraption, 2);
+			BogeyModelData[] wheels = getTransform(SMALL_BOGEY_WHEELS, ms, inInstancedContraption, 2);
 			for (int side : Iterate.positiveAndNegative) {
 				if (!inInstancedContraption)
 					ms.pushPose();
-				Transform<?> wheel = wheels[(side + 1)/2];
-				wheel.translate(0, 12 / 16f, side)
-						.rotateX(wheelAngle);
-				finalize(wheel, ms, light, vb);
+				wheels[(side + 1)/2]
+					.translate(0, 12 / 16f, side)
+					.rotateX(wheelAngle)
+					.render(ms, light, vb);
 				if (!inInstancedContraption)
 					ms.popPose();
 			}
@@ -94,39 +94,39 @@ public class StandardBogeyRenderer {
 		public void render(CompoundTag bogeyData, float wheelAngle, PoseStack ms, int light, VertexConsumer vb, boolean inContraption) {
 			boolean inInstancedContraption = vb == null;
 
-			Transform<?>[] secondaryShafts = getTranform(AllBlocks.SHAFT.getDefaultState()
+			BogeyModelData[] secondaryShafts = getTransform(AllBlocks.SHAFT.getDefaultState()
 					.setValue(ShaftBlock.AXIS, Direction.Axis.X), ms, inInstancedContraption, 2);
 
 			for (int i : Iterate.zeroAndOne) {
-				Transform<?> secondShaft = secondaryShafts[i];
-				secondShaft.translate(-.5f, .25f, .5f + i * -2)
+				secondaryShafts[i]
+						.translate(-.5f, .25f, .5f + i * -2)
 						.centre()
 						.rotateX(wheelAngle)
-						.unCentre();
-				finalize(secondShaft, ms, light, vb);
+						.unCentre()
+						.render(ms, light, vb);
 			}
 
-			Transform<?> bogeyDrive = getTranform(BOGEY_DRIVE, ms, inInstancedContraption);
-			finalize(bogeyDrive, ms, light, vb);
+			getTransform(BOGEY_DRIVE, ms, inInstancedContraption)
+					.render(ms, light, vb);
 
-			Transform<?> bogeyPiston = getTranform(BOGEY_PISTON, ms, inInstancedContraption)
-					.translate(0, 0, 1 / 4f * Math.sin(AngleHelper.rad(wheelAngle)));
-			finalize(bogeyPiston, ms, light, vb);
+			getTransform(BOGEY_PISTON, ms, inInstancedContraption)
+					.translate(0, 0, 1 / 4f * Math.sin(AngleHelper.rad(wheelAngle)))
+					.render(ms, light, vb);
 
 			if (!inInstancedContraption)
 				ms.pushPose();
 
-			Transform<?> bogeyWheels = getTranform(LARGE_BOGEY_WHEELS, ms, inInstancedContraption)
+			getTransform(LARGE_BOGEY_WHEELS, ms, inInstancedContraption)
 					.translate(0, 1, 0)
-					.rotateX(wheelAngle);
-			finalize(bogeyWheels, ms, light, vb);
+					.rotateX(wheelAngle)
+					.render(ms, light, vb);
 
-			Transform<?> bogeyPin = getTranform(BOGEY_PIN, ms, inInstancedContraption)
+			getTransform(BOGEY_PIN, ms, inInstancedContraption)
 					.translate(0, 1, 0)
 					.rotateX(wheelAngle)
 					.translate(0, 1 / 4f, 0)
-					.rotateX(-wheelAngle);
-			finalize(bogeyPin, ms, light, vb);
+					.rotateX(-wheelAngle)
+					.render(ms, light, vb);
 
 			if (!inInstancedContraption)
 				ms.popPose();

--- a/src/main/java/com/simibubi/create/content/trains/bogey/StandardBogeyRenderer.java
+++ b/src/main/java/com/simibubi/create/content/trains/bogey/StandardBogeyRenderer.java
@@ -13,6 +13,7 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import com.simibubi.create.AllBlocks;
 import com.simibubi.create.content.kinetics.simpleRelays.ShaftBlock;
+import com.simibubi.create.content.trains.entity.CarriageBogey;
 import com.simibubi.create.foundation.utility.AngleHelper;
 import com.simibubi.create.foundation.utility.Iterate;
 
@@ -22,8 +23,8 @@ import net.minecraft.nbt.CompoundTag;
 public class StandardBogeyRenderer {
 	public static class CommonStandardBogeyRenderer extends BogeyRenderer.CommonRenderer {
 		@Override
-		public void initialiseContraptionModelData(MaterialManager materialManager) {
-			createModelInstances(materialManager, AllBlocks.SHAFT.getDefaultState()
+		public void initialiseContraptionModelData(MaterialManager materialManager, CarriageBogey carriageBogey) {
+			createModelInstance(materialManager, AllBlocks.SHAFT.getDefaultState()
 					.setValue(ShaftBlock.AXIS, Direction.Axis.Z), 2);
 		}
 
@@ -45,9 +46,9 @@ public class StandardBogeyRenderer {
 
 	public static class SmallStandardBogeyRenderer extends BogeyRenderer {
 		@Override
-		public void initialiseContraptionModelData(MaterialManager materialManager) {
-			createModelInstances(materialManager, SMALL_BOGEY_WHEELS, 2);
-			createModelInstances(materialManager, BOGEY_FRAME);
+		public void initialiseContraptionModelData(MaterialManager materialManager, CarriageBogey carriageBogey) {
+			createModelInstance(materialManager, SMALL_BOGEY_WHEELS, 2);
+			createModelInstance(materialManager, BOGEY_FRAME);
 		}
 
 
@@ -78,9 +79,9 @@ public class StandardBogeyRenderer {
 
 	public static class LargeStandardBogeyRenderer extends BogeyRenderer {
 		@Override
-		public void initialiseContraptionModelData(MaterialManager materialManager) {
-			createModelInstances(materialManager, LARGE_BOGEY_WHEELS, BOGEY_DRIVE, BOGEY_PISTON, BOGEY_PIN);
-			createModelInstances(materialManager, AllBlocks.SHAFT.getDefaultState()
+		public void initialiseContraptionModelData(MaterialManager materialManager, CarriageBogey carriageBogey) {
+			createModelInstance(materialManager, LARGE_BOGEY_WHEELS, BOGEY_DRIVE, BOGEY_PISTON, BOGEY_PIN);
+			createModelInstance(materialManager, AllBlocks.SHAFT.getDefaultState()
 					.setValue(ShaftBlock.AXIS, Direction.Axis.X), 2);
 		}
 

--- a/src/main/java/com/simibubi/create/content/trains/bogey/StandardBogeyRenderer.java
+++ b/src/main/java/com/simibubi/create/content/trains/bogey/StandardBogeyRenderer.java
@@ -31,7 +31,7 @@ public class StandardBogeyRenderer {
 		@Override
 		public void render(CompoundTag bogeyData, float wheelAngle, PoseStack ms, int light, VertexConsumer vb, boolean inContraption) {
 			boolean inInstancedContraption = vb == null;
-			Transform<?>[] shafts = getTransformsFromBlockState(AllBlocks.SHAFT.getDefaultState()
+			Transform<?>[] shafts = getTranform(AllBlocks.SHAFT.getDefaultState()
 					.setValue(ShaftBlock.AXIS, Direction.Axis.Z), ms, inInstancedContraption, 2);
 			for (int i : Iterate.zeroAndOne) {
 				shafts[i].translate(-.5f, .25f, i * -1)
@@ -60,10 +60,10 @@ public class StandardBogeyRenderer {
 		@Override
 		public void render(CompoundTag bogeyData, float wheelAngle, PoseStack ms, int light, VertexConsumer vb, boolean inContraption) {
 			boolean inInstancedContraption = vb == null;
-			Transform<?> transform = getTransformFromPartial(BOGEY_FRAME, ms, inInstancedContraption);
+			Transform<?> transform = getTranform(BOGEY_FRAME, ms, inInstancedContraption);
 			finalize(transform, ms, light, vb);
 
-			Transform<?>[] wheels = getTransformsFromPartial(SMALL_BOGEY_WHEELS, ms, inInstancedContraption, 2);
+			Transform<?>[] wheels = getTransform(SMALL_BOGEY_WHEELS, ms, inInstancedContraption, 2);
 			for (int side : Iterate.positiveAndNegative) {
 				if (!inInstancedContraption)
 					ms.pushPose();
@@ -94,7 +94,7 @@ public class StandardBogeyRenderer {
 		public void render(CompoundTag bogeyData, float wheelAngle, PoseStack ms, int light, VertexConsumer vb, boolean inContraption) {
 			boolean inInstancedContraption = vb == null;
 
-			Transform<?>[] secondaryShafts = getTransformsFromBlockState(AllBlocks.SHAFT.getDefaultState()
+			Transform<?>[] secondaryShafts = getTranform(AllBlocks.SHAFT.getDefaultState()
 					.setValue(ShaftBlock.AXIS, Direction.Axis.X), ms, inInstancedContraption, 2);
 
 			for (int i : Iterate.zeroAndOne) {
@@ -106,22 +106,22 @@ public class StandardBogeyRenderer {
 				finalize(secondShaft, ms, light, vb);
 			}
 
-			Transform<?> bogeyDrive = getTransformFromPartial(BOGEY_DRIVE, ms, inInstancedContraption);
+			Transform<?> bogeyDrive = getTranform(BOGEY_DRIVE, ms, inInstancedContraption);
 			finalize(bogeyDrive, ms, light, vb);
 
-			Transform<?> bogeyPiston = getTransformFromPartial(BOGEY_PISTON, ms, inInstancedContraption)
+			Transform<?> bogeyPiston = getTranform(BOGEY_PISTON, ms, inInstancedContraption)
 					.translate(0, 0, 1 / 4f * Math.sin(AngleHelper.rad(wheelAngle)));
 			finalize(bogeyPiston, ms, light, vb);
 
 			if (!inInstancedContraption)
 				ms.pushPose();
 
-			Transform<?> bogeyWheels = getTransformFromPartial(LARGE_BOGEY_WHEELS, ms, inInstancedContraption)
+			Transform<?> bogeyWheels = getTranform(LARGE_BOGEY_WHEELS, ms, inInstancedContraption)
 					.translate(0, 1, 0)
 					.rotateX(wheelAngle);
 			finalize(bogeyWheels, ms, light, vb);
 
-			Transform<?> bogeyPin = getTransformFromPartial(BOGEY_PIN, ms, inInstancedContraption)
+			Transform<?> bogeyPin = getTranform(BOGEY_PIN, ms, inInstancedContraption)
 					.translate(0, 1, 0)
 					.rotateX(wheelAngle)
 					.translate(0, 1 / 4f, 0)


### PR DESCRIPTION
- Small cleanup of Bogey Renderer class adding missing methods and making method names more cohesive to avoid confusion

- Provided Carriage Bogey during model data initialisation so that the data can be used to change the model loaded, (for example in Extended Bogeys changing the texture depending on paint colour)

- Provided interface for adding additional interactions when a bogey is clicked

- Implemented wrapper record for generic transform object to allow for more readable, less accident prone rendering crashes. (This has been made to be backwards compatible with the previous syntax to prevent code, legacy methods have been deprecated)

- Added links to resources for implementing custom bogeys in javadocs