### PR TITLE
Add a few new ponder instructions

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/ponder/SceneBuilder.java
+++ b/src/main/java/com/simibubi/create/foundation/ponder/SceneBuilder.java
@@ -296,7 +296,7 @@ public class SceneBuilder {
 			addInstruction(scene -> SuperGlueItem.spawnParticles(scene.getWorld(), pos, side, fullBlock));
 		}
 
-		private void rotationIndicator(BlockPos pos, boolean direction) {
+				private void rotationIndicator(BlockPos pos, boolean direction, BlockPos displayPos) {
 			addInstruction(scene -> {
 				BlockState blockState = scene.getWorld()
 					.getBlockState(pos);
@@ -318,7 +318,7 @@ public class SceneBuilder {
 				int particleSpeed = speedLevel.getParticleSpeed();
 				particleSpeed *= Math.signum(speed);
 
-				Vec3 location = VecHelper.getCenterOf(pos);
+				Vec3 location = VecHelper.getCenterOf(displayPos);
 				RotationIndicatorParticleData particleData = new RotationIndicatorParticleData(color, particleSpeed,
 					kb.getParticleInitialRadius(), kb.getParticleTargetRadius(), 20, rotationAxis.name()
 						.charAt(0));
@@ -330,11 +330,19 @@ public class SceneBuilder {
 		}
 
 		public void rotationSpeedIndicator(BlockPos pos) {
-			rotationIndicator(pos, false);
+			rotationIndicator(pos, false, pos);
 		}
 
 		public void rotationDirectionIndicator(BlockPos pos) {
-			rotationIndicator(pos, true);
+			rotationIndicator(pos, true, pos);
+		}
+
+		public void rotationSpeedIndicator(BlockPos pos, BlockPos displayPos) {
+			rotationIndicator(pos, false, displayPos);
+		}
+
+		public void rotationDirectionIndicator(BlockPos pos, BlockPos displayPos) {
+			rotationIndicator(pos, true, displayPos);
 		}
 
 		public void indicateRedstone(BlockPos pos) {

--- a/src/main/java/com/simibubi/create/foundation/ponder/SceneBuilder.java
+++ b/src/main/java/com/simibubi/create/foundation/ponder/SceneBuilder.java
@@ -523,6 +523,13 @@ public class SceneBuilder {
 			return instruction.createLink(scene);
 		}
 
+		public ElementLink<WorldSectionElement> showIndependentSection(Selection selection, Direction fadeInDirection, int duration) {
+			DisplayWorldSectionInstruction instruction =
+				new DisplayWorldSectionInstruction(duration, fadeInDirection, selection, Optional.empty());
+			addInstruction(instruction);
+			return instruction.createLink(scene);
+		}
+
 		public ElementLink<WorldSectionElement> showIndependentSectionImmediately(Selection selection) {
 			DisplayWorldSectionInstruction instruction =
 				new DisplayWorldSectionInstruction(0, Direction.DOWN, selection, Optional.empty());
@@ -548,6 +555,15 @@ public class SceneBuilder {
 		public void hideIndependentSection(ElementLink<WorldSectionElement> link, Direction fadeOutDirection) {
 			addInstruction(new FadeOutOfSceneInstruction<>(15, fadeOutDirection, link));
 		}
+
+		public void hideIndependentSection(ElementLink<WorldSectionElement> link, Direction fadeOutDirection, int duration) {
+			addInstruction(new FadeOutOfSceneInstruction<>(duration, fadeOutDirection, link));
+		}
+
+		public void hideIndependentSectionImmediately(ElementLink<WorldSectionElement> link) {
+			addInstruction(new FadeOutOfSceneInstruction<>(0, Direction.DOWN, link));
+		}
+		
 
 		public void restoreBlocks(Selection selection) {
 			addInstruction(scene -> scene.getWorld()


### PR DESCRIPTION
Adds a few new ponder instructions related to showing and hiding independent sections. A list of added instructions and how they were modified from other instructions is below.

- A modified version of `showIndependentSection()` has been added that also has a duration in ticks that changes how long the fade in takes.
- A modified version of `hideIndependentSection()` has been added that does the same thing as above, but for hiding and fading out instead of showing.
- A `hideIndependentSectionImmediately()` has been added that automatically makes the duration 0 and sets the fade out direction to down, just like `showIndependentSectionImmediately()`.

_Note, I tested this on 1.19.2, not 1.18.2, and while I'm 99% sure that nothing changes in the ponder system between versions that should cause any problems, you should still tell me if it doesn't work._