### PR TITLE
Fix Track Normal Usage

### DIFF
--- a/src/main/java/com/simibubi/create/content/trains/graph/TrackEdge.java
+++ b/src/main/java/com/simibubi/create/content/trains/graph/TrackEdge.java
@@ -105,7 +105,7 @@ public class TrackEdge {
 
 	public Vec3 getNormal(@Nullable TrackGraph trackGraph, double t) {
 		if (isTurn())
-			return turn.getNormal(Mth.clamp(t, 0, 1));
+			return turn.getFaceNormal(Mth.clamp(t, 0, 1));
 		if (trackGraph != null && (node1.location.yOffsetPixels != 0 || node2.location.yOffsetPixels != 0)) {
 			Vec3 normalSmoothed = getNormalSmoothed(trackGraph, t);
 			if (normalSmoothed != null)

--- a/src/main/java/com/simibubi/create/content/trains/track/BezierConnection.java
+++ b/src/main/java/com/simibubi/create/content/trains/track/BezierConnection.java
@@ -223,19 +223,32 @@ public class BezierConnection implements Iterable<BezierConnection.Segment> {
 		return bounds;
 	}
 
-	public Vec3 getNormal(double t) {
+	public Vec3 getFaceNormal(double t) {
 		resolve();
+		Vec3 end1 = starts.getFirst();
+		Vec3 end2 = starts.getSecond();
+
+		Vec3 derivative = VecHelper.bezierDerivative(end1, end2, finish1, finish2, (float) t)
+				.normalize();
+		return derivative.cross(getNormal(t, false));
+	}
+
+	public Vec3 getNormal(double t) {
+		return getNormal(t, true);
+	}
+
+	public Vec3 getNormal(double t, boolean resolve) {
+		if (resolve)
+			resolve();
 		Vec3 end1 = starts.getFirst();
 		Vec3 end2 = starts.getSecond();
 		Vec3 fn1 = normals.getFirst();
 		Vec3 fn2 = normals.getSecond();
 
 		Vec3 derivative = VecHelper.bezierDerivative(end1, end2, finish1, finish2, (float) t)
-			.normalize();
+				.normalize();
 		Vec3 faceNormal = fn1.equals(fn2) ? fn1 : VecHelper.slerp((float) t, fn1, fn2);
-		Vec3 normal = faceNormal.cross(derivative)
-			.normalize();
-		return derivative.cross(normal);
+		return faceNormal.cross(derivative).normalize();
 	}
 
 	private void resolve() {

--- a/src/main/java/com/simibubi/create/content/trains/track/TrackBlock.java
+++ b/src/main/java/com/simibubi/create/content/trains/track/TrackBlock.java
@@ -715,7 +715,7 @@ public class TrackBlock extends Block
 				double tpost = (seg + 1) / length;
 
 				offset = bc.getPosition(t);
-				normal = bc.getNormal(t);
+				normal = bc.getFaceNormal(t);
 				diff = bc.getPosition(tpost)
 					.subtract(bc.getPosition(tpre))
 					.normalize();

--- a/src/main/java/com/simibubi/create/content/trains/track/TrackPlacement.java
+++ b/src/main/java/com/simibubi/create/content/trains/track/TrackPlacement.java
@@ -735,10 +735,7 @@ public class TrackPlacement {
 		for (int i = 0; i <= segCount; i++) {
 			float t = i / (float) segCount;
 			Vec3 result = VecHelper.bezier(end1, end2, finish1, finish2, t);
-			Vec3 derivative = VecHelper.bezierDerivative(end1, end2, finish1, finish2, t)
-				.normalize();
 			Vec3 normal = bc.getNormal(t)
-				.cross(derivative)
 				.scale(15 / 16f);
 			Vec3 rail1 = result.add(normal)
 				.add(up);


### PR DESCRIPTION
Bezier Connection segments appear to have 2 types of normals, `faceNormal` and `normal`. The function to get the `faceNormal` of the each segment on the curve was `getNormal` however this method was also being used to get the normal for `TrackRenderer.getModelAngles` which takes in a normal vector - specifically the `normal`, not `faceNormal` - and a vector pointing in the direction of the track. This request just fixes the uses and adds a new method called `getFaceNormal`.