### PR TITLE
Make NBT display key safe

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/utility/NBTProcessors.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/NBTProcessors.java
@@ -106,6 +106,8 @@ public final class NBTProcessors {
 			return false;
 		if (name.contains("Damage"))
 			return false;
+		if (name.equals("display"))
+			return false;
 		return true;
 	}
 


### PR DESCRIPTION
This is really just a stopgap fix for my particular issue. Ideally a tag blacklist would be used instead of the current whitelist approach to avoid messing up other mod's items that might store really important stuff in their NBT.

Fixes #4997 