### PR TITLE
replace references to ObfuscationReflectionHelper with mixin accessors

### DIFF
--- a/src/main/java/com/simibubi/create/content/trains/track/TrackPlacementOverlay.java
+++ b/src/main/java/com/simibubi/create/content/trains/track/TrackPlacementOverlay.java
@@ -2,13 +2,13 @@ package com.simibubi.create.content.trains.track;
 
 import com.mojang.blaze3d.platform.Window;
 import com.mojang.blaze3d.vertex.PoseStack;
+import com.simibubi.create.foundation.mixin.accessor.GuiAccessor;
 import com.simibubi.create.foundation.utility.Color;
 import com.simibubi.create.foundation.utility.Components;
 import com.simibubi.create.foundation.utility.Lang;
 
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.Gui;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.util.Mth;
 import net.minecraft.world.level.GameType;
@@ -16,7 +16,6 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.gui.ForgeIngameGui;
 import net.minecraftforge.client.gui.IIngameOverlay;
-import net.minecraftforge.fml.util.ObfuscationReflectionHelper;
 
 public class TrackPlacementOverlay {
 
@@ -35,15 +34,14 @@ public class TrackPlacementOverlay {
 			return;
 		if (TrackPlacement.extraTipWarmup < 4)
 			return;
-	
-		if (ObfuscationReflectionHelper.getPrivateValue(Gui.class, gui,
-			"toolHighlightTimer") instanceof Integer toolHighlightTimer && toolHighlightTimer > 0)
+
+		if (((GuiAccessor)gui).getToolHighlightTimer() > 0)
 			return;
-	
+
 		boolean active = mc.options.keySprint.isDown();
 		MutableComponent text = Lang.translateDirect("track.hold_for_smooth_curve", Components.keybind("key.sprint")
 			.withStyle(active ? ChatFormatting.WHITE : ChatFormatting.GRAY));
-	
+
 		Window window = mc.getWindow();
 		int x = (window.getGuiScaledWidth() - gui.getFont()
 			.width(text)) / 2;
@@ -51,7 +49,7 @@ public class TrackPlacementOverlay {
 		Color color = new Color(0x4ADB4A).setAlpha(Mth.clamp((TrackPlacement.extraTipWarmup - 4) / 3f, 0.1f, 1));
 		gui.getFont()
 			.draw(poseStack, text, x, y, color.getRGB());
-	
+
 	}
 
 }

--- a/src/main/java/com/simibubi/create/foundation/block/CopperBlockSet.java
+++ b/src/main/java/com/simibubi/create/foundation/block/CopperBlockSet.java
@@ -7,6 +7,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
 
+import com.simibubi.create.foundation.mixin.accessor.StairBlockAccessor;
+
 import org.apache.commons.lang3.ArrayUtils;
 
 import com.simibubi.create.foundation.data.TagGen;
@@ -39,7 +41,6 @@ import net.minecraft.world.level.block.WeatheringCopperStairBlock;
 import net.minecraft.world.level.block.state.BlockBehaviour.Properties;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.client.model.generators.ModelProvider;
-import net.minecraftforge.fml.util.ObfuscationReflectionHelper;
 
 public class CopperBlockSet {
 	protected static final WeatherState[] WEATHER_STATES = WeatherState.values();
@@ -327,8 +328,7 @@ public class CopperBlockSet {
 						new WeatheringCopperStairBlock(state, Blocks.AIR.defaultBlockState(), p);
 					// WeatheringCopperStairBlock does not have a constructor that takes a Supplier,
 					// so setting the field directly is the easiest solution
-					ObfuscationReflectionHelper.setPrivateValue(StairBlock.class, block, defaultStateSupplier,
-						"stateSupplier");
+					((StairBlockAccessor)block).setStateSupplier(defaultStateSupplier);
 					return block;
 				};
 			}

--- a/src/main/java/com/simibubi/create/foundation/block/CopperBlockSet.java
+++ b/src/main/java/com/simibubi/create/foundation/block/CopperBlockSet.java
@@ -9,6 +9,8 @@ import java.util.function.Supplier;
 
 import com.simibubi.create.foundation.mixin.accessor.StairBlockAccessor;
 
+import net.minecraftforge.fml.util.ObfuscationReflectionHelper;
+
 import org.apache.commons.lang3.ArrayUtils;
 
 import com.simibubi.create.foundation.data.TagGen;
@@ -328,7 +330,8 @@ public class CopperBlockSet {
 						new WeatheringCopperStairBlock(state, Blocks.AIR.defaultBlockState(), p);
 					// WeatheringCopperStairBlock does not have a constructor that takes a Supplier,
 					// so setting the field directly is the easiest solution
-					((StairBlockAccessor)block).setStateSupplier(defaultStateSupplier);
+					//((StairBlockAccessor)block).setStateSupplier(defaultStateSupplier);
+					ObfuscationReflectionHelper.setPrivateValue(StairBlock.class, block, defaultStateSupplier, "stateSupplier");
 					return block;
 				};
 			}

--- a/src/main/java/com/simibubi/create/foundation/config/ui/ConfigHelper.java
+++ b/src/main/java/com/simibubi/create/foundation/config/ui/ConfigHelper.java
@@ -19,6 +19,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.simibubi.create.Create;
+import com.simibubi.create.foundation.mixin.accessor.ModContainerAcessor;
 import com.simibubi.create.foundation.utility.Pair;
 import com.simibubi.create.infrastructure.config.AllConfigs;
 
@@ -27,7 +28,6 @@ import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.config.IConfigSpec;
 import net.minecraftforge.fml.config.ModConfig;
-import net.minecraftforge.fml.util.ObfuscationReflectionHelper;
 
 public class ConfigHelper {
 
@@ -49,8 +49,7 @@ public class ConfigHelper {
 		ModContainer modContainer = ModList.get()
 			.getModContainerById(modID)
 			.orElseThrow(() -> new IllegalArgumentException("Unable to find ModContainer for id: " + modID));
-		EnumMap<ModConfig.Type, ModConfig> configs =
-			ObfuscationReflectionHelper.getPrivateValue(ModContainer.class, modContainer, "configs");
+		EnumMap<ModConfig.Type, ModConfig> configs = ((ModContainerAcessor)modContainer).getConfigs();
 		return Objects.requireNonNull(configs);
 	}
 

--- a/src/main/java/com/simibubi/create/foundation/mixin/accessor/GuiAccessor.java
+++ b/src/main/java/com/simibubi/create/foundation/mixin/accessor/GuiAccessor.java
@@ -1,0 +1,12 @@
+package com.simibubi.create.foundation.mixin.accessor;
+
+import net.minecraft.client.gui.Gui;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(Gui.class)
+public interface GuiAccessor {
+	@Accessor("toolHighlightTimer")
+	int getToolHighlightTimer();
+}

--- a/src/main/java/com/simibubi/create/foundation/mixin/accessor/ModContainerAcessor.java
+++ b/src/main/java/com/simibubi/create/foundation/mixin/accessor/ModContainerAcessor.java
@@ -1,0 +1,16 @@
+package com.simibubi.create.foundation.mixin.accessor;
+
+import net.minecraftforge.fml.ModContainer;
+
+import net.minecraftforge.fml.config.ModConfig;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.EnumMap;
+
+@Mixin(ModContainer.class)
+public interface ModContainerAcessor {
+	@Accessor("configs")
+	EnumMap<ModConfig.Type, ModConfig> getConfigs();
+}

--- a/src/main/java/com/simibubi/create/foundation/mixin/accessor/StairBlockAccessor.java
+++ b/src/main/java/com/simibubi/create/foundation/mixin/accessor/StairBlockAccessor.java
@@ -1,0 +1,15 @@
+package com.simibubi.create.foundation.mixin.accessor;
+
+import net.minecraft.world.level.block.StairBlock;
+import net.minecraft.world.level.block.state.BlockState;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.function.Supplier;
+
+@Mixin(StairBlock.class)
+public interface StairBlockAccessor {
+	@Accessor("stateSupplier")
+	void setStateSupplier(Supplier<BlockState> stateSupplier);
+}

--- a/src/main/resources/create.mixins.json
+++ b/src/main/resources/create.mixins.json
@@ -7,7 +7,6 @@
   "mixins": [
     "ClientboundMapItemDataPacketMixin",
     "ContraptionDriverInteractMixin",
-    "WaterWheelFluidSpreadMixin",
     "CustomItemUseEffectsMixin",
     "EnchantmentHelperMixin",
     "EntityMixin",
@@ -15,15 +14,23 @@
     "MainMixin",
     "MapItemSavedDataMixin",
     "TestCommandMixin",
+    "WaterWheelFluidSpreadMixin",
     "accessor.AbstractProjectileDispenseBehaviorAccessor",
     "accessor.DispenserBlockAccessor",
     "accessor.FallingBlockEntityAccessor",
     "accessor.GameTestHelperAccessor",
     "accessor.LivingEntityAccessor",
+    "accessor.ModContainerAcessor",
     "accessor.NbtAccounterAccessor",
-    "accessor.ServerLevelAccessor"
+    "accessor.ServerLevelAccessor",
+    "accessor.StairBlockAccessor"
   ],
   "client": [
+    "accessor.AgeableListModelAccessor",
+    "accessor.GameRendererAccessor",
+    "accessor.GuiAccessor",
+    "accessor.HumanoidArmorLayerAccessor",
+    "accessor.ParticleEngineAccessor",
     "client.BlockDestructionProgressMixin",
     "client.CameraMixin",
     "client.EntityContraptionInteractionMixin",
@@ -35,11 +42,7 @@
     "client.MapRendererMapInstanceMixin",
     "client.ModelDataRefreshMixin",
     "client.PlayerRendererMixin",
-    "client.WindowResizeMixin",
-    "accessor.AgeableListModelAccessor",
-    "accessor.GameRendererAccessor",
-    "accessor.HumanoidArmorLayerAccessor",
-    "accessor.ParticleEngineAccessor"
+    "client.WindowResizeMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
fixes #5000

idk what to say lol it removes the reflection and replaces it with accessors, which are safer and faster

The warning thrown [here](https://github.com/rhysdh540/Create/blob/6d4f9aa4e2aaeb5aed21c936cfd5942953dc01a6/src/main/java/com/simibubi/create/foundation/block/CopperBlockSet.java#L331) causes a crash at startup and will need some looking at, I can't quite figure out what's causing it (other than the obviously weird WeatheringCopperStairBlock -> StairBlock -> StairBlockAccessor cast) or how to fix it.