### PR TITLE
Fix `Matrix3d#asYRotation`

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/AbstractContraptionEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/AbstractContraptionEntity.java
@@ -876,7 +876,7 @@ public abstract class AbstractContraptionEntity extends Entity implements IEntit
 			if (xRotation != 0)
 				matrix.multiply(new Matrix3d().asXRotation(AngleHelper.rad(-xRotation)));
 			if (yRotation != 0)
-				matrix.multiply(new Matrix3d().asYRotation(AngleHelper.rad(yRotation)));
+				matrix.multiply(new Matrix3d().asYRotation(AngleHelper.rad(-yRotation)));
 			if (zRotation != 0)
 				matrix.multiply(new Matrix3d().asZRotation(AngleHelper.rad(-zRotation)));
 			return matrix;

--- a/src/main/java/com/simibubi/create/foundation/collision/Matrix3d.java
+++ b/src/main/java/com/simibubi/create/foundation/collision/Matrix3d.java
@@ -40,8 +40,8 @@ public class Matrix3d {
 		double s = Mth.sin(radians);
 		double c = Mth.cos(radians);
 		m00 = m22 = c;
-		m20 = s;
-		m02 = -s;
+		m02 = s;
+		m20 = -s;
 		return this;
 	}
 


### PR DESCRIPTION
Compared to `Matrix3d#asXRotation` and  `Matrix3d#asZRotation`, the implementation for `asYRotation`
```java
public Matrix3d asYRotation(float radians) {
    asIdentity();
    if (radians == 0)
        return this;

    double s = Mth.sin(radians);
    double c = Mth.cos(radians);
    m00 = m22 = c;
    m20 = s;
    m02 = -s;
    return this;
}
```
inverts the arguement according to wikipedia.
![image](https://github.com/Creators-of-Create/Create/assets/58920010/e6abaddd-0763-4bb2-b212-e72dc3fc6d89)

Indeed, its one call is at `ContraptionRotationState#asMatrix` accounts for this asymmetrically.
```java
public Matrix3d asMatrix() {
	if (matrix != null)
		return matrix;

	matrix = new Matrix3d().asIdentity();
	if (xRotation != 0)
		matrix.multiply(new Matrix3d().asXRotation(AngleHelper.rad(-xRotation)));
	if (yRotation != 0)
		matrix.multiply(new Matrix3d().asYRotation(AngleHelper.rad(yRotation)));
	if (zRotation != 0)
		matrix.multiply(new Matrix3d().asZRotation(AngleHelper.rad(-zRotation)));
	return matrix;
}
```

This pull request fixes the method and thus restores the symmetry.