### PR TITLE
Implement null point.edge protection

### DIFF
--- a/src/main/java/com/simibubi/create/content/trains/entity/Train.java
+++ b/src/main/java/com/simibubi/create/content/trains/entity/Train.java
@@ -384,6 +384,15 @@ public class Train {
 			int carriageType = first ? last ? Carriage.BOTH : Carriage.FIRST : last ? Carriage.LAST : Carriage.MIDDLE;
 			double actualDistance =
 				carriage.travel(level, graph, distance + totalStress, toFollowForward, toFollowBackward, carriageType);
+
+			TravellingPoint point = carriage.leadingBogey().isLeading ? carriage.getLeadingPoint() : carriage.getTrailingPoint();
+
+			// Remove trains with null point.edge fixing a rare crash that could occur
+			if (point.edge == null) {
+				Create.LOGGER.error("Found null 'point.edge' in train with name: " + carriage.train.name.getString() + ", id: " + carriage.train.id.toString());
+				carriage.train.invalid = true;
+			}
+
 			blocked |= carriage.blocked || carriage.isOnIncompatibleTrack();
 
 			boolean onTwoBogeys = carriage.isOnTwoBogeys();


### PR DESCRIPTION
<details>
<summary>Big Explaination of how this was found etc</summary>

So Lemme Explain how i found this out and the story behind it

Today the SnR server restarted as normal and then crashed because of a `NullPointerExceptation: Cant Invoke ...TrackEdge.getTrackMaterial() because "point.edge" is null` after seeing that i cloned Create again went through where that occured and found its cause of a train without couple points that was messed up and started working on a patch after i got it to work and foundout which train was doing this i went through the tracks nbt and found the train and as i thought if you look at the attached pictures its a train thats basically broken? 
### Broken Train NBT
![image](https://github.com/Creators-of-Create/Create/assets/74031881/09ac2b2c-e07b-4dde-a914-f1e8535aadbd)

### Normal Train NBT
![image](https://github.com/Creators-of-Create/Create/assets/74031881/6e6786bd-687c-481e-a5f3-db829f076e59)

</details>


## TLDR

null values in Bogey couple points inside the train NBT crash a server and this PR just deletes the train and logs to console

i havent found a way to fix this without removing the train but if you have any better suggestions on how to handle this im open to hearing them :)