### PR TITLE
Miscellaneous improvements to the config api

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/config/ConfigBase.java
+++ b/src/main/java/com/simibubi/create/foundation/config/ConfigBase.java
@@ -22,6 +22,8 @@ public abstract class ConfigBase {
 	protected List<ConfigBase> children;
 
 	public void registerAll(final ForgeConfigSpec.Builder builder) {
+		if(allValues == null) // avoid null pointer exception if config class is empty
+			allValues = new ArrayList<>();
 		for (CValue<?, ?> cValue : allValues)
 			cValue.register(builder);
 	}

--- a/src/main/java/com/simibubi/create/foundation/config/ui/BaseConfigScreen.java
+++ b/src/main/java/com/simibubi/create/foundation/config/ui/BaseConfigScreen.java
@@ -34,27 +34,38 @@ public class BaseConfigScreen extends ConfigScreen {
 	private static final Map<String, UnaryOperator<BaseConfigScreen>> DEFAULTS = new HashMap<>();
 
 	static {
-		setDefaultActionFor(Create.ID, (base) -> base
+		setDefaultActionFor(Create.ID, base -> base
 				.withTitles("Client Settings", "World Generation Settings", "Gameplay Settings")
 				.withSpecs(AllConfigs.client().specification, AllConfigs.common().specification, AllConfigs.server().specification)
 		);
+		// also set titles for jei and computercraft
+		setDefaultActionFor("jei", base -> base.withTitle("Just Enough Items"));
+		setDefaultActionFor("computercraft", base -> base.withTitle("ComputerCraft"));
 	}
 
 	/**
-	 * If you are a Create Addon dev and want to change the config labels,
-	 * add a default action here.
-	 *
+	 * If you are a Create Addon dev and want to change the config labels or title, add a default action here.
+	 * <p>
 	 * Make sure you call either {@link #withSpecs(ForgeConfigSpec, ForgeConfigSpec, ForgeConfigSpec)}
 	 * or {@link #searchForSpecsInModContainer()}
 	 *
 	 * @param modID     the modID of your addon/mod
 	 */
 	public static void setDefaultActionFor(String modID, UnaryOperator<BaseConfigScreen> transform) {
-		if (!DEFAULTS.containsKey(modID)) {
+		if (DEFAULTS.containsKey(modID)) {
 			Create.LOGGER.error("Somebody tried to set default action for mod {}, but it was already set!", modID);
 			return;
+			// or throw an exception
 		}
 		DEFAULTS.put(modID, transform);
+	}
+
+	public static String getCustomTitleIfExists(String modID) {
+		for(Map.Entry<String, UnaryOperator<BaseConfigScreen>> entry : DEFAULTS.entrySet()) {
+			if(entry.getKey().equals(modID))
+				return entry.getValue().apply(new BaseConfigScreen(null, modID)).titleString;
+		}
+		return modID;
 	}
 
 	public static BaseConfigScreen forCreate(Screen parent) {

--- a/src/main/java/com/simibubi/create/foundation/config/ui/ConfigModListScreen.java
+++ b/src/main/java/com/simibubi/create/foundation/config/ui/ConfigModListScreen.java
@@ -99,7 +99,7 @@ public class ConfigModListScreen extends ConfigScreen {
 		protected String id;
 
 		public ModEntry(String id, Screen parent) {
-			super(BaseConfigScreen.getCustomTitleIfExists(id).equals(id) ? toHumanReadable(id) : BaseConfigScreen.getCustomTitleIfExists(id));
+			super(BaseConfigScreen.getCustomTitle(id).orElse(toHumanReadable(id)));
 			this.id = id;
 
 			button = new BoxWidget(0, 0, 35, 16)
@@ -112,7 +112,7 @@ public class ConfigModListScreen extends ConfigScreen {
 				button.active = false;
 				button.updateColorsFromState();
 				button.modifyElement(e -> ((DelegatedStencilElement) e).withElementRenderer(BaseConfigScreen.DISABLED_RENDERER));
-				labelTooltip.add(Components.literal(BaseConfigScreen.getCustomTitleIfExists(id).equals(id) ? toHumanReadable(id) : BaseConfigScreen.getCustomTitleIfExists(id)));
+				labelTooltip.add(Components.literal(BaseConfigScreen.getCustomTitle(id).orElse(toHumanReadable(id))));
 				labelTooltip.addAll(TooltipHelper.cutStringTextComponent("This Mod does not have any configs registered or is not using Forge's config system", Palette.ALL_GRAY));
 			}
 

--- a/src/main/java/com/simibubi/create/foundation/config/ui/ConfigModListScreen.java
+++ b/src/main/java/com/simibubi/create/foundation/config/ui/ConfigModListScreen.java
@@ -99,7 +99,7 @@ public class ConfigModListScreen extends ConfigScreen {
 		protected String id;
 
 		public ModEntry(String id, Screen parent) {
-			super(toHumanReadable(id));
+			super(BaseConfigScreen.getCustomTitleIfExists(id).equals(id) ? toHumanReadable(id) : BaseConfigScreen.getCustomTitleIfExists(id));
 			this.id = id;
 
 			button = new BoxWidget(0, 0, 35, 16)
@@ -112,7 +112,7 @@ public class ConfigModListScreen extends ConfigScreen {
 				button.active = false;
 				button.updateColorsFromState();
 				button.modifyElement(e -> ((DelegatedStencilElement) e).withElementRenderer(BaseConfigScreen.DISABLED_RENDERER));
-				labelTooltip.add(Components.literal(toHumanReadable(id)));
+				labelTooltip.add(Components.literal(BaseConfigScreen.getCustomTitleIfExists(id).equals(id) ? toHumanReadable(id) : BaseConfigScreen.getCustomTitleIfExists(id)));
 				labelTooltip.addAll(TooltipHelper.cutStringTextComponent("This Mod does not have any configs registered or is not using Forge's config system", Palette.ALL_GRAY));
 			}
 


### PR DESCRIPTION
Mainly allows addon devs to add custom names for their mods, since Create's `toHumanReadable` method doesn't improve all-lowercase strings (aka pretty much every mod id ever) very much. Two examples that I’ve included are ComputerCraft (which used to read "Computercraft") and Just Enough Items (which used to read "Jei"). These overridden titles are shown in the config screen and the mod list. Additionally, there’s an option if creators don’t want their mod name uppercases in the config screen.

I also added a check so mods can't overwrite each other's default actions, and added a null check against empty config classes.