### PR TITLE
Fix Deployers not using item's useOn method

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/deployer/DeployerHandler.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/deployer/DeployerHandler.java
@@ -300,9 +300,6 @@ public class DeployerHandler {
 			return;
 		if (useItem == DENY)
 			return;
-		if (item instanceof BlockItem && !(item instanceof CartAssemblerBlockItem)
-			&& !clickedState.canBeReplaced(new BlockPlaceContext(itemusecontext)))
-			return;
 
 		// Reposition fire placement for convenience
 		if (item == Items.FLINT_AND_STEEL) {
@@ -324,6 +321,10 @@ public class DeployerHandler {
 				player.placedTracks = true;
 			return;
 		}
+
+		if (item instanceof BlockItem && !(item instanceof CartAssemblerBlockItem)
+				&& !clickedState.canBeReplaced(new BlockPlaceContext(itemusecontext)))
+			return;
 		if (item == Items.ENDER_PEARL)
 			return;
 		if (AllItemTags.DEPLOYABLE_DRINK.matches(item))


### PR DESCRIPTION
there was an oversight in DeployerHandler that prevented deployers from using BlockItem's useOn method. The oversight was caused by a check that always failed if the BlockItem was interacting with a block before the useOn section of activateInternal could be called.
What I did was simply move that check to after that section of activateInternal was called. This should fix things like deployers with blaze burners not interacting with spawners etc.