### PR TITLE
Lang merger generic in the constructor rollback

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/data/LangMerger.java
+++ b/src/main/java/com/simibubi/create/foundation/data/LangMerger.java
@@ -53,7 +53,7 @@ public class LangMerger implements DataProvider {
 	private PackOutput output;
 
 	public <T extends LangPartial> LangMerger(PackOutput output, String modid, String displayName,
-		AllLangPartials[] allLangPartials) {
+		T[] allLangPartials) {
 		this.output = output;
 		this.modid = modid;
 		this.displayName = displayName;


### PR DESCRIPTION
Rolled back the generic in the constructor. Somehow was lost and changed from the 1.18 and 1.19 branches.

May be it's necesary for the 1.20.1 in a way I don't see.
Ran the data generation and works well.
It's super usefull for addons.