### PR TITLE
Recipe type ban

### DIFF
--- a/src/generated/resources/.cache/c756bc74e6a76802ef8f804e37d3430a34b26a1d
+++ b/src/generated/resources/.cache/c756bc74e6a76802ef8f804e37d3430a34b26a1d
@@ -1,0 +1,2 @@
+// 1.20.1	2023-08-07T17:19:33.1663144	Tags for minecraft:recipe_type mod id create
+0d8718f7383761bc5d7bc45306ed266ebf25dc1d data/create/tags/recipe_type/automation_ignore.json

--- a/src/generated/resources/data/create/tags/recipe_type/automation_ignore.json
+++ b/src/generated/resources/data/create/tags/recipe_type/automation_ignore.json
@@ -1,0 +1,12 @@
+{
+  "values": [
+    {
+      "id": "occultism:spirit_trade",
+      "required": false
+    },
+    {
+      "id": "occultism:ritual",
+      "required": false
+    }
+  ]
+}

--- a/src/main/java/com/simibubi/create/AllRecipeTypes.java
+++ b/src/main/java/com/simibubi/create/AllRecipeTypes.java
@@ -1,12 +1,10 @@
 package com.simibubi.create;
 
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Supplier;
 
 import org.jetbrains.annotations.Nullable;
 
-import com.google.common.collect.ImmutableSet;
 import com.simibubi.create.compat.jei.ConversionRecipe;
 import com.simibubi.create.content.equipment.sandPaper.SandPaperPolishingRecipe;
 import com.simibubi.create.content.equipment.toolbox.ToolboxDyeingRecipe;
@@ -29,7 +27,6 @@ import com.simibubi.create.content.processing.recipe.ProcessingRecipeSerializer;
 import com.simibubi.create.content.processing.sequenced.SequencedAssemblyRecipeSerializer;
 import com.simibubi.create.foundation.recipe.IRecipeTypeInfo;
 import com.simibubi.create.foundation.utility.Lang;
-import com.simibubi.create.foundation.utility.RegisteredObjects;
 
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
@@ -127,12 +124,9 @@ public enum AllRecipeTypes implements IRecipeTypeInfo {
 			.getRecipeFor(getType(), inv, world);
 	}
 
-	public static final Set<ResourceLocation> RECIPE_DENY_SET =
-		ImmutableSet.of(new ResourceLocation("occultism", "spirit_trade"), new ResourceLocation("occultism", "ritual"));
-
 	public static boolean shouldIgnoreInAutomation(Recipe<?> recipe) {
-		RecipeSerializer<?> serializer = recipe.getSerializer();
-		if (serializer != null && RECIPE_DENY_SET.contains(RegisteredObjects.getKeyOrThrow(serializer)))
+		RecipeType<?> recipeType = recipe.getType();
+		if (recipeType != null && AllTags.AllRecipeTypeTags.AUTOMATION_IGNORE.matches(recipeType))
 			return true;
 		return recipe.getId()
 			.getPath()

--- a/src/main/java/com/simibubi/create/AllTags.java
+++ b/src/main/java/com/simibubi/create/AllTags.java
@@ -356,7 +356,7 @@ public class AllTags {
 		}
 		
 		public boolean matches(RecipeType<?> recipeType) {
-			return BuiltInRegistries.RECIPE_TYPE.getOrCreateTag(tag).contains(Holder.direct(recipeType));
+			return BuiltInRegistries.RECIPE_TYPE.getOrCreateTag(tag).contains(ForgeRegistries.RECIPE_TYPES.getHolder(recipeType).orElseThrow());
 		}
 		
 		private static void init() {}

--- a/src/main/java/com/simibubi/create/AllTags.java
+++ b/src/main/java/com/simibubi/create/AllTags.java
@@ -9,6 +9,8 @@ import java.util.Collections;
 
 import com.simibubi.create.foundation.utility.Lang;
 
+import net.minecraft.core.Holder;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
@@ -20,6 +22,7 @@ import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Fluid;
@@ -316,11 +319,54 @@ public class AllTags {
 		private static void init() {}
 		
 	}
+	
+	public enum AllRecipeTypeTags {
+		
+		AUTOMATION_IGNORE,
+		
+		;
+		
+		public final TagKey<RecipeType<?>> tag;
+		public final boolean alwaysDatagen;
+		
+		AllRecipeTypeTags() {
+			this(MOD);
+		}
+		
+		AllRecipeTypeTags(NameSpace namespace) {
+			this(namespace, namespace.optionalDefault, namespace.alwaysDatagenDefault);
+		}
+		
+		AllRecipeTypeTags(NameSpace namespace, String path) {
+			this(namespace, path, namespace.optionalDefault, namespace.alwaysDatagenDefault);
+		}
+		
+		AllRecipeTypeTags(NameSpace namespace, boolean optional, boolean alwaysDatagen) {
+			this(namespace, null, optional, alwaysDatagen);
+		}
+		
+		AllRecipeTypeTags(NameSpace namespace, String path, boolean optional, boolean alwaysDatagen) {
+			ResourceLocation id = new ResourceLocation(namespace.id, path == null ? Lang.asId(name()) : path);
+			if (optional) {
+				tag = optionalTag(ForgeRegistries.RECIPE_TYPES, id);
+			} else {
+				tag = TagKey.create(Registries.RECIPE_TYPE, id);
+			}
+			this.alwaysDatagen = alwaysDatagen;
+		}
+		
+		public boolean matches(RecipeType<?> recipeType) {
+			return BuiltInRegistries.RECIPE_TYPE.getOrCreateTag(tag).contains(Holder.direct(recipeType));
+		}
+		
+		private static void init() {}
+	}
 
 	public static void init() {
 		AllBlockTags.init();
 		AllItemTags.init();
 		AllFluidTags.init();
 		AllEntityTags.init();
+		AllRecipeTypeTags.init();
 	}
 }

--- a/src/main/java/com/simibubi/create/Create.java
+++ b/src/main/java/com/simibubi/create/Create.java
@@ -30,6 +30,7 @@ import com.simibubi.create.foundation.damageTypes.DamageTypeDataProvider;
 import com.simibubi.create.foundation.damageTypes.DamageTypeTagGen;
 import com.simibubi.create.foundation.data.CreateRegistrate;
 import com.simibubi.create.foundation.data.LangMerger;
+import com.simibubi.create.foundation.data.RecipeTypeTagGen;
 import com.simibubi.create.foundation.data.TagGen;
 import com.simibubi.create.foundation.data.recipe.MechanicalCraftingRecipeGen;
 import com.simibubi.create.foundation.data.recipe.ProcessingRecipeGen;
@@ -184,6 +185,8 @@ public class Create {
 			gen.addProvider(true, DamageTypeDataProvider.makeFactory(event.getLookupProvider()));
 			gen.addProvider(true,
 				new DamageTypeTagGen(output, event.getLookupProvider(), event.getExistingFileHelper()));
+			gen.addProvider(true, 
+				new RecipeTypeTagGen(output, event.getLookupProvider(), event.getExistingFileHelper()));
 		}
 	}
 

--- a/src/main/java/com/simibubi/create/foundation/data/RecipeTypeTagGen.java
+++ b/src/main/java/com/simibubi/create/foundation/data/RecipeTypeTagGen.java
@@ -1,0 +1,36 @@
+package com.simibubi.create.foundation.data;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.simibubi.create.AllTags;
+import com.simibubi.create.Create;
+
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.HolderLookup.Provider;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.data.PackOutput;
+import net.minecraft.data.tags.TagsProvider;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.crafting.RecipeType;
+import net.minecraftforge.common.data.ExistingFileHelper;
+
+public class RecipeTypeTagGen extends TagsProvider<RecipeType<?>> {
+	public RecipeTypeTagGen(String namespace, PackOutput pOutput,
+			CompletableFuture<HolderLookup.Provider> pLookupProvider, ExistingFileHelper existingFileHelper) {
+		super(pOutput, Registries.RECIPE_TYPE, pLookupProvider, namespace, existingFileHelper);
+	}
+	
+	public RecipeTypeTagGen(PackOutput pOutput, CompletableFuture<HolderLookup.Provider> pLookupProvider, 
+			ExistingFileHelper existingFileHelper) {
+		this(Create.ID, pOutput, pLookupProvider, existingFileHelper);
+	}
+
+	@Override
+	protected void addTags(@NotNull Provider pProvider) {
+		tag(AllTags.AllRecipeTypeTags.AUTOMATION_IGNORE.tag)
+			.addOptional(new ResourceLocation("occultism", "spirit_trade"))
+			.addOptional(new ResourceLocation("occultism", "ritual"));
+	}
+}


### PR DESCRIPTION
This pull request attempts to replace the hard-coded set of automation-banned recipe types with a tag.  This tag can then be modified by other mods or datapacks without the need for code updates in Create.  Fixes #4580.