### PR TITLE
Add tag to ban recipe serializers from automation

### DIFF
--- a/src/generated/resources/.cache/cache
+++ b/src/generated/resources/.cache/cache
@@ -5371,6 +5371,7 @@ d063e12c9ef75f39518c6d129ea35d833464d547 data/create/tags/items/toolboxes.json
 50936b211d94167a35ec78c89954082a336b6269 data/create/tags/items/valve_handles.json
 f8d83f446d0a2071dca4481251339c4249b2fd3f data/create/tags/items/vanilla_stripped_logs.json
 f3e20d8b3ca5652d3975da680740cc36326fdfc9 data/create/tags/items/vanilla_stripped_wood.json
+747204dc59a2198feb2bb579d586ea3975b6e0d1 data/create/tags/recipe_serializer/automation_ignore.json
 16bcb8fcbe9170c2c11f1ca8d99d8b36cd812bbd data/forge/tags/blocks/glass/colorless.json
 81d3eb40b048160fcc2d6bb7ff12b49276297efd data/forge/tags/blocks/glass_panes.json
 6eec92869baa44d3ac53aec6a7a92c15147b59f0 data/forge/tags/blocks/ores.json

--- a/src/generated/resources/data/create/tags/recipe_serializer/automation_ignore.json
+++ b/src/generated/resources/data/create/tags/recipe_serializer/automation_ignore.json
@@ -1,0 +1,13 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "occultism:spirit_trade",
+      "required": false
+    },
+    {
+      "id": "occultism:ritual",
+      "required": false
+    }
+  ]
+}

--- a/src/main/java/com/simibubi/create/AllRecipeTypes.java
+++ b/src/main/java/com/simibubi/create/AllRecipeTypes.java
@@ -29,7 +29,6 @@ import com.simibubi.create.content.processing.recipe.ProcessingRecipeSerializer;
 import com.simibubi.create.content.processing.sequenced.SequencedAssemblyRecipeSerializer;
 import com.simibubi.create.foundation.recipe.IRecipeTypeInfo;
 import com.simibubi.create.foundation.utility.Lang;
-import com.simibubi.create.foundation.utility.RegisteredObjects;
 
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceLocation;
@@ -137,12 +136,9 @@ public enum AllRecipeTypes implements IRecipeTypeInfo {
 			.getRecipeFor(getType(), inv, world);
 	}
 
-	public static final Set<ResourceLocation> RECIPE_DENY_SET =
-		ImmutableSet.of(new ResourceLocation("occultism", "spirit_trade"), new ResourceLocation("occultism", "ritual"));
-
 	public static boolean shouldIgnoreInAutomation(Recipe<?> recipe) {
 		RecipeSerializer<?> serializer = recipe.getSerializer();
-		if (serializer != null && RECIPE_DENY_SET.contains(RegisteredObjects.getKeyOrThrow(serializer)))
+		if (serializer != null && AllTags.AllRecipeSerializerTags.AUTOMATION_IGNORE.matches(serializer))
 			return true;
 		return recipe.getId()
 			.getPath()

--- a/src/main/java/com/simibubi/create/AllTags.java
+++ b/src/main/java/com/simibubi/create/AllTags.java
@@ -20,6 +20,7 @@ import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Fluid;
@@ -317,11 +318,55 @@ public class AllTags {
 		private static void init() {}
 		
 	}
+	
+	public enum AllRecipeSerializerTags {
+
+		AUTOMATION_IGNORE,
+
+		;
+
+		public final TagKey<RecipeSerializer<?>> tag;
+		public final boolean alwaysDatagen;
+
+		AllRecipeSerializerTags() {
+			this(MOD);
+		}
+
+		AllRecipeSerializerTags(NameSpace namespace) {
+			this(namespace, namespace.optionalDefault, namespace.alwaysDatagenDefault);
+		}
+
+		AllRecipeSerializerTags(NameSpace namespace, String path) {
+			this(namespace, path, namespace.optionalDefault, namespace.alwaysDatagenDefault);
+		}
+
+		AllRecipeSerializerTags(NameSpace namespace, boolean optional, boolean alwaysDatagen) {
+			this(namespace, null, optional, alwaysDatagen);
+		}
+
+		AllRecipeSerializerTags(NameSpace namespace, String path, boolean optional, boolean alwaysDatagen) {
+			ResourceLocation id = new ResourceLocation(namespace.id, path == null ? Lang.asId(name()) : path);
+			if (optional) {
+				tag = optionalTag(ForgeRegistries.RECIPE_SERIALIZERS, id);
+			} else {
+				tag = TagKey.create(Registry.RECIPE_SERIALIZER_REGISTRY, id);
+			}
+			this.alwaysDatagen = alwaysDatagen;
+		}
+
+		public boolean matches(RecipeSerializer<?> recipeSerializer) {
+			return Registry.RECIPE_SERIALIZER.getOrCreateTag(tag).contains(ForgeRegistries.RECIPE_SERIALIZERS.getHolder(recipeSerializer).orElseThrow());
+		}
+
+		private static void init() {}
+	}
+
 
 	public static void init() {
 		AllBlockTags.init();
 		AllItemTags.init();
 		AllFluidTags.init();
 		AllEntityTags.init();
+		AllRecipeSerializerTags.init();
 	}
 }

--- a/src/main/java/com/simibubi/create/Create.java
+++ b/src/main/java/com/simibubi/create/Create.java
@@ -30,6 +30,7 @@ import com.simibubi.create.foundation.block.CopperRegistries;
 import com.simibubi.create.foundation.data.AllLangPartials;
 import com.simibubi.create.foundation.data.CreateRegistrate;
 import com.simibubi.create.foundation.data.LangMerger;
+import com.simibubi.create.foundation.data.RecipeSerializerTagGen;
 import com.simibubi.create.foundation.data.TagGen;
 import com.simibubi.create.foundation.data.recipe.MechanicalCraftingRecipeGen;
 import com.simibubi.create.foundation.data.recipe.ProcessingRecipeGen;
@@ -182,6 +183,7 @@ public class Create {
 			gen.addProvider(new SequencedAssemblyRecipeGen(gen));
 			ProcessingRecipeGen.registerAll(gen);
 //			AllOreFeatureConfigEntries.gatherData(event);
+			gen.addProvider(new RecipeSerializerTagGen(gen, event.getExistingFileHelper()));
 		}
 	}
 

--- a/src/main/java/com/simibubi/create/foundation/data/RecipeSerializerTagGen.java
+++ b/src/main/java/com/simibubi/create/foundation/data/RecipeSerializerTagGen.java
@@ -1,0 +1,31 @@
+package com.simibubi.create.foundation.data;
+
+import org.jetbrains.annotations.Nullable;
+
+import com.simibubi.create.AllTags;
+import com.simibubi.create.Create;
+
+import net.minecraft.core.Registry;
+import net.minecraft.data.DataGenerator;
+import net.minecraft.data.tags.TagsProvider;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.crafting.RecipeSerializer;
+import net.minecraftforge.common.data.ExistingFileHelper;
+
+public class RecipeSerializerTagGen extends TagsProvider<RecipeSerializer<?>> {
+	public RecipeSerializerTagGen(DataGenerator pGenerator, @Nullable ExistingFileHelper existingFileHelper) {
+		super(pGenerator, Registry.RECIPE_SERIALIZER, Create.ID, existingFileHelper);
+	}
+
+	@Override
+	public String getName() {
+		return "Create Recipe Serializer Tags";
+	}
+
+	@Override
+	protected void addTags() {
+		this.tag(AllTags.AllRecipeSerializerTags.AUTOMATION_IGNORE.tag)
+				.addOptional(new ResourceLocation("occultism", "spirit_trade"))
+				.addOptional(new ResourceLocation("occultism", "ritual"));
+	}
+}


### PR DESCRIPTION
This pull request attempts to replace the hard-coded set of automation-banned recipe serializers with a tag. This tag can then be modified by other mods or datapacks without the need for code updates in Create.  Fixes #4580.