### PR TITLE
fix: move the check to run before any data is read

### DIFF
--- a/src/main/java/com/simibubi/create/content/trains/entity/Navigation.java
+++ b/src/main/java/com/simibubi/create/content/trains/entity/Navigation.java
@@ -805,8 +805,7 @@ public class Navigation {
 		}
 
 		if (nullEntriesPresent)
-			Create.LOGGER.error("Found null values in path of train with name: " + train.name.getString() + ", id: "
-				+ train.id.toString());
+			Create.LOGGER.error("Found null values in path of train with name: {}, id: {}", train.name.getString(), train.id.toString());
 	}
 
 }

--- a/src/main/java/com/simibubi/create/content/trains/entity/Navigation.java
+++ b/src/main/java/com/simibubi/create/content/trains/entity/Navigation.java
@@ -767,6 +767,8 @@ public class Navigation {
 		if (destination == null)
 			return;
 
+		removeBrokenPathEntries();
+
 		distanceToDestination = tag.getDouble("DistanceToDestination");
 		distanceStartedAt = tag.getDouble("DistanceStartedAt");
 		destinationBehindTrain = tag.getBoolean("BehindTrain");
@@ -776,9 +778,7 @@ public class Navigation {
 			c -> currentPath.add(Couple
 				.deserializeEach(c.getList("Nodes", Tag.TAG_COMPOUND), c2 -> TrackNodeLocation.read(c2, dimensions))
 				.map(graph::locateNode)));
-		
-		removeBrokenPathEntries();
-		
+
 		waitingForSignal = tag.contains("BlockingSignal")
 			? Pair.of(tag.getUUID("BlockingSignal"), tag.getBoolean("BlockingSignalSide"))
 			: null;
@@ -793,7 +793,7 @@ public class Navigation {
 		 * Trains might load or save with null entries in their path, this method avoids
 		 * that anomaly from causing NPEs. The underlying issue has not been found.
 		 */
-		
+
 		boolean nullEntriesPresent = false;
 
 		for (Iterator<Couple<TrackNode>> iterator = currentPath.iterator(); iterator.hasNext();) {

--- a/src/main/java/com/simibubi/create/content/trains/entity/Train.java
+++ b/src/main/java/com/simibubi/create/content/trains/entity/Train.java
@@ -384,6 +384,15 @@ public class Train {
 			int carriageType = first ? last ? Carriage.BOTH : Carriage.FIRST : last ? Carriage.LAST : Carriage.MIDDLE;
 			double actualDistance =
 				carriage.travel(level, graph, distance + totalStress, toFollowForward, toFollowBackward, carriageType);
+
+			TravellingPoint point = carriage.leadingBogey().isLeading ? carriage.getLeadingPoint() : carriage.getTrailingPoint();
+
+			// Remove trains with null point.edge fixing a rare crash that could occur
+			if (point.edge == null) {
+				Create.LOGGER.error("Found null 'point.edge' in train with name: " + carriage.train.name.getString() + ", id: " + carriage.train.id.toString());
+				carriage.train.invalid = true;
+			}
+
 			blocked |= carriage.blocked || carriage.isOnIncompatibleTrack();
 
 			boolean onTwoBogeys = carriage.isOnTwoBogeys();

--- a/src/main/java/com/simibubi/create/content/trains/entity/Train.java
+++ b/src/main/java/com/simibubi/create/content/trains/entity/Train.java
@@ -384,15 +384,6 @@ public class Train {
 			int carriageType = first ? last ? Carriage.BOTH : Carriage.FIRST : last ? Carriage.LAST : Carriage.MIDDLE;
 			double actualDistance =
 				carriage.travel(level, graph, distance + totalStress, toFollowForward, toFollowBackward, carriageType);
-
-			TravellingPoint point = carriage.leadingBogey().isLeading ? carriage.getLeadingPoint() : carriage.getTrailingPoint();
-
-			// Remove trains with null point.edge fixing a rare crash that could occur
-			if (point.edge == null) {
-				Create.LOGGER.error("Found null 'point.edge' in train with name: " + carriage.train.name.getString() + ", id: " + carriage.train.id.toString());
-				carriage.train.invalid = true;
-			}
-
 			blocked |= carriage.blocked || carriage.isOnIncompatibleTrack();
 
 			boolean onTwoBogeys = carriage.isOnTwoBogeys();


### PR DESCRIPTION
appears that if create checks the nbt while it has null values it will still crash the server moving it above and having it run before any nbt is read fixes this