### PR TITLE
Add a command to copy debug information

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.2-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/simibubi/create/AllPackets.java
+++ b/src/main/java/com/simibubi/create/AllPackets.java
@@ -93,6 +93,8 @@ import com.simibubi.create.foundation.utility.ServerSpeedProvider;
 import com.simibubi.create.infrastructure.command.HighlightPacket;
 import com.simibubi.create.infrastructure.command.SConfigureConfigPacket;
 
+import com.simibubi.create.infrastructure.debugInfo.ServerDebugInfoPacket;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
@@ -203,7 +205,7 @@ public enum AllPackets {
 	CONTRAPTION_ACTOR_TOGGLE(ContraptionDisableActorPacket.class, ContraptionDisableActorPacket::new, PLAY_TO_CLIENT),
 	CONTRAPTION_COLLIDER_LOCK(ContraptionColliderLockPacket.class, ContraptionColliderLockPacket::new, PLAY_TO_CLIENT),
 	ATTACHED_COMPUTER(AttachedComputerPacket.class, AttachedComputerPacket::new, PLAY_TO_CLIENT),
-
+	SERVER_DEBUG_INFO(ServerDebugInfoPacket.class, ServerDebugInfoPacket::new, PLAY_TO_CLIENT)
 	;
 
 	public static final ResourceLocation CHANNEL_NAME = Create.asResource("main");

--- a/src/main/java/com/simibubi/create/foundation/mixin/accessor/SystemReportAccessor.java
+++ b/src/main/java/com/simibubi/create/foundation/mixin/accessor/SystemReportAccessor.java
@@ -1,0 +1,24 @@
+package com.simibubi.create.foundation.mixin.accessor;
+
+import net.minecraft.SystemReport;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.Map;
+
+@Mixin(SystemReport.class)
+public interface SystemReportAccessor {
+	@Accessor
+	static String getOPERATING_SYSTEM() {
+		throw new AssertionError();
+	}
+
+	@Accessor
+	static String getJAVA_VERSION() {
+		throw new AssertionError();
+	}
+
+	@Accessor
+	Map<String, String> getEntries();
+}

--- a/src/main/java/com/simibubi/create/infrastructure/command/AllCommands.java
+++ b/src/main/java/com/simibubi/create/infrastructure/command/AllCommands.java
@@ -30,6 +30,7 @@ public class AllCommands {
 				.then(OverlayConfigCommand.register())
 				.then(DumpRailwaysCommand.register())
 				.then(FixLightingCommand.register())
+				.then(DebugInfoCommand.register())
 				.then(HighlightCommand.register())
 				.then(KillTrainCommand.register())
 				.then(PassengerCommand.register())
@@ -38,6 +39,7 @@ public class AllCommands {
 				.then(PonderCommand.register())
 				.then(CloneCommand.register())
 				.then(GlueCommand.register())
+
 
 				// utility
 				.then(util);

--- a/src/main/java/com/simibubi/create/infrastructure/command/DebugInfoCommand.java
+++ b/src/main/java/com/simibubi/create/infrastructure/command/DebugInfoCommand.java
@@ -1,0 +1,35 @@
+package com.simibubi.create.infrastructure.command;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.builder.ArgumentBuilder;
+
+import com.simibubi.create.AllPackets;
+import com.simibubi.create.foundation.utility.Components;
+
+import com.simibubi.create.infrastructure.debugInfo.DebugInformation;
+import com.simibubi.create.infrastructure.debugInfo.ServerDebugInfoPacket;
+
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraftforge.network.PacketDistributor;
+
+import static net.minecraft.commands.Commands.literal;
+
+public class DebugInfoCommand {
+	public static ArgumentBuilder<CommandSourceStack, ?> register() {
+		return literal("debuginfo").executes(ctx -> {
+			CommandSourceStack source = ctx.getSource();
+			ServerPlayer player = source.getPlayerOrException();
+			source.sendSuccess(
+					Components.literal("Sending server debug information to your client..."), true
+			);
+			AllPackets.getChannel().send(
+					PacketDistributor.PLAYER.with(() -> player),
+					new ServerDebugInfoPacket(player)
+			);
+			return Command.SINGLE_SUCCESS;
+		});
+	}
+}

--- a/src/main/java/com/simibubi/create/infrastructure/debugInfo/DebugInformation.java
+++ b/src/main/java/com/simibubi/create/infrastructure/debugInfo/DebugInformation.java
@@ -1,0 +1,115 @@
+package com.simibubi.create.infrastructure.debugInfo;
+
+import com.jozufozu.flywheel.Flywheel;
+import com.jozufozu.flywheel.backend.Backend;
+import com.simibubi.create.Create;
+import com.simibubi.create.foundation.mixin.accessor.SystemReportAccessor;
+import com.simibubi.create.infrastructure.debugInfo.element.DebugInfoSection;
+
+import net.minecraft.SharedConstants;
+import net.minecraft.SystemReport;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.fml.ModList;
+import net.minecraftforge.forgespi.language.IModInfo;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Allows for providing easily accessible debugging information.
+ * This info can be retrieved with the "/create debuginfo" command.
+ * This command copies all information to the clipboard, formatted for a GitHub issue.
+ */
+public class DebugInformation {
+	private static DebugInfoSection client = DebugInfoSection.builder("Client Info").build();
+	private static DebugInfoSection server = DebugInfoSection.builder("Server Info").build();
+
+	public static void registerClientInfo(DebugInfoSection section) {
+		client = client.builder().put(section).build();
+	}
+
+	public static void registerServerInfo(DebugInfoSection section) {
+		server = server.builder().put(section).build();
+	}
+
+	public static void registerBothInfo(DebugInfoSection section) {
+		registerClientInfo(section);
+		registerServerInfo(section);
+	}
+
+	public static DebugInfoSection getClientInfo() {
+		return client;
+	}
+
+	public static DebugInfoSection getServerInfo() {
+		return server;
+	}
+
+	static {
+		DebugInfoSection.builder(Create.NAME)
+				.put("Mod Version", Create.VERSION)
+				.put("Forge Version", getVersionOfMod("forge"))
+				.put("Minecraft Version", SharedConstants.getCurrentVersion().getName())
+				.put("Other Mods", listAllOtherMods())
+				.put("Operating System", SystemReportAccessor.getOPERATING_SYSTEM())
+				.put("Java Version", SystemReportAccessor.getJAVA_VERSION())
+				.put("Memory", () -> getMcSystemInfo().get("Memory"))
+				.buildTo(DebugInformation::registerBothInfo);
+
+		DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> {
+			DebugInfoSection.builder(Create.NAME)
+					.put("Flywheel Version", Flywheel.getVersion().toString())
+					.put("Flywheel Backend", () -> Backend.getBackendType().toString())
+					.put("Graphics Cards", DebugInformation.getGraphicsCardsInfo())
+					.buildTo(DebugInformation::registerClientInfo);
+		});
+	}
+
+	public static String getVersionOfMod(String id) {
+		return ModList.get().getModContainerById(id)
+				.map(mod -> mod.getModInfo().getVersion().toString())
+				.orElse("None");
+	}
+
+	public static String listAllOtherMods() {
+		StringBuilder mods = new StringBuilder();
+		ModList.get().forEachModContainer((id, mod) -> {
+			if (!id.equals(Create.ID) && !id.equals("forge") && !id.equals("minecraft")) {
+				IModInfo info = mod.getModInfo();
+				String name = info.getDisplayName();
+				String version = info.getVersion().toString();
+				if (!mods.isEmpty())
+					mods.append('\n');
+				mods.append(name).append(": ").append(version);
+			}
+		});
+		return mods.toString();
+	}
+
+	public static Map<String, String> getMcSystemInfo() {
+		return ((SystemReportAccessor) new SystemReport()).getEntries();
+	}
+
+	public static String getGraphicsCardsInfo() {
+		StringBuilder builder = new StringBuilder();
+		Map<String, String> info = getMcSystemInfo();
+		String[] types = { "name", "vendor", "VRAM (MB)" };
+		cards: for (int i = 0; i < 10; i++) {
+			for (String type : types) {
+				String key = "Graphics card #" + i + " " + type;
+				if (!info.containsKey(key))
+					break cards;
+				if (!builder.isEmpty())
+					builder.append('\n');
+				String value = String.format("%s #%s: %s", type, i, info.get(key));
+				builder.append(value);
+			}
+		}
+		if (builder.isEmpty())
+			return "No GPU found?";
+		return builder.toString();
+	}
+}

--- a/src/main/java/com/simibubi/create/infrastructure/debugInfo/InfoProvider.java
+++ b/src/main/java/com/simibubi/create/infrastructure/debugInfo/InfoProvider.java
@@ -1,5 +1,7 @@
 package com.simibubi.create.infrastructure.debugInfo;
 
+import java.util.Objects;
+
 import net.minecraft.world.entity.player.Player;
 
 import javax.annotation.Nullable;
@@ -12,11 +14,12 @@ public interface InfoProvider {
 	/**
 	 * @param player the player requesting the data. May be null
 	 */
+	@Nullable
 	String getInfo(@Nullable Player player);
 
 	default String getInfoSafe(Player player) {
 		try {
-			return getInfo(player);
+			return Objects.toString(getInfo(player));
 		} catch (Throwable t) {
 			StringBuilder builder = new StringBuilder("Error getting information!");
 			builder.append(' ').append(t.getMessage());

--- a/src/main/java/com/simibubi/create/infrastructure/debugInfo/InfoProvider.java
+++ b/src/main/java/com/simibubi/create/infrastructure/debugInfo/InfoProvider.java
@@ -1,0 +1,29 @@
+package com.simibubi.create.infrastructure.debugInfo;
+
+import net.minecraft.world.entity.player.Player;
+
+import javax.annotation.Nullable;
+
+/**
+ * A supplier of debug information. May be queried on the client or server.
+ */
+@FunctionalInterface
+public interface InfoProvider {
+	/**
+	 * @param player the player requesting the data. May be null
+	 */
+	String getInfo(@Nullable Player player);
+
+	default String getInfoSafe(Player player) {
+		try {
+			return getInfo(player);
+		} catch (Throwable t) {
+			StringBuilder builder = new StringBuilder("Error getting information!");
+			builder.append(' ').append(t.getMessage());
+			for (StackTraceElement element : t.getStackTrace()) {
+				builder.append('\n').append("\t").append(element.toString());
+			}
+			return builder.toString();
+		}
+	}
+}

--- a/src/main/java/com/simibubi/create/infrastructure/debugInfo/ServerDebugInfoPacket.java
+++ b/src/main/java/com/simibubi/create/infrastructure/debugInfo/ServerDebugInfoPacket.java
@@ -1,0 +1,57 @@
+package com.simibubi.create.infrastructure.debugInfo;
+
+import com.simibubi.create.foundation.networking.SimplePacketBase;
+
+import com.simibubi.create.foundation.utility.Components;
+import com.simibubi.create.infrastructure.debugInfo.element.DebugInfoSection;
+
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.network.NetworkEvent;
+
+public class ServerDebugInfoPacket extends SimplePacketBase {
+	public static final Component COPIED = Components.literal(
+			"Debug information has been copied to your clipboard."
+			).withStyle(ChatFormatting.GREEN);
+
+	private final DebugInfoSection serverInfo;
+	private final Player player;
+
+	public ServerDebugInfoPacket(Player player) {
+		this.serverInfo = DebugInformation.getServerInfo();
+		this.player = player;
+	}
+
+	public ServerDebugInfoPacket(FriendlyByteBuf buffer) {
+		buffer.readBoolean(); // excess marker
+		this.serverInfo = DebugInfoSection.read(buffer);
+		this.player = null;
+	}
+
+	@Override
+	public void write(FriendlyByteBuf buffer) {
+		this.serverInfo.write(this.player, buffer);
+	}
+
+	@Override
+	public boolean handle(NetworkEvent.Context context) {
+		context.enqueueWork(() -> DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> {
+			Player player = Minecraft.getInstance().player;
+
+			StringBuilder output = new StringBuilder();
+			serverInfo.print(player, line -> output.append(line).append("\n\n"));
+			output.append("\n\n");
+			DebugInformation.getClientInfo().print(player, line -> output.append(line).append("\n\n"));
+			String text = output.toString();
+
+			Minecraft.getInstance().keyboardHandler.setClipboard(text);
+			player.displayClientMessage(COPIED, true);
+		}));
+		return true;
+	}
+}

--- a/src/main/java/com/simibubi/create/infrastructure/debugInfo/element/DebugInfoSection.java
+++ b/src/main/java/com/simibubi/create/infrastructure/debugInfo/element/DebugInfoSection.java
@@ -1,0 +1,108 @@
+package com.simibubi.create.infrastructure.debugInfo.element;
+
+import com.google.common.collect.ImmutableList;
+
+import com.simibubi.create.infrastructure.debugInfo.InfoProvider;
+
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.world.entity.player.Player;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public record DebugInfoSection(String name, ImmutableList<InfoElement> elements) implements InfoElement {
+	@Override
+	public void write(Player player, FriendlyByteBuf buffer) {
+		buffer.writeBoolean(true);
+		buffer.writeUtf(name);
+		buffer.writeCollection(elements, (buf, element) -> element.write(player, buf));
+	}
+
+	public Builder builder() {
+		return builder(name).putAll(elements);
+	}
+
+	@Override
+	public void print(int depth, @Nullable Player player, Consumer<String> lineConsumer) {
+		String indent = Stream.generate(() -> "\t").limit(depth).collect(Collectors.joining(""));
+		lineConsumer.accept(indent + "<details>");
+		lineConsumer.accept(indent + "<summary>" + name + "</summary>");
+		elements.forEach(element -> element.print(depth + 1, player, lineConsumer));
+		lineConsumer.accept(indent + "</details>");
+
+	}
+
+	public static DebugInfoSection read(FriendlyByteBuf buffer) {
+		String name = buffer.readUtf();
+		ArrayList<InfoElement> elements = buffer.readCollection(ArrayList::new, InfoElement::read);
+		return new DebugInfoSection(name, ImmutableList.copyOf(elements));
+	}
+
+	public static Builder builder(String name) {
+		return new Builder(null, name);
+	}
+
+	public static DebugInfoSection of(String name, Collection<DebugInfoSection> children) {
+		return builder(name).putAll(children).build();
+	}
+
+	public static class Builder {
+		private final Builder parent;
+		private final String name;
+		private final ImmutableList.Builder<InfoElement> elements;
+
+		public Builder(Builder parent, String name) {
+			this.parent = parent;
+			this.name = name;
+			this.elements = ImmutableList.builder();
+		}
+
+		public Builder put(InfoElement element) {
+			this.elements.add(element);
+			return this;
+		}
+
+		public Builder put(String key, InfoProvider provider) {
+			return put(new InfoEntry(key, provider));
+		}
+
+		public Builder put(String key, Supplier<String> value) {
+			return put(key, player -> value.get());
+		}
+
+		public Builder put(String key, String value) {
+			return put(key, player -> value);
+		}
+
+		public Builder putAll(Collection<? extends InfoElement> elements) {
+			elements.forEach(this::put);
+			return this;
+		}
+
+		public Builder section(String name) {
+            return new Builder(this, name);
+		}
+
+		public Builder finishSection() {
+			if (parent == null) {
+				throw new IllegalStateException("Cannot finish the root section");
+			}
+			parent.elements.add(this.build());
+			return parent;
+		}
+
+		public DebugInfoSection build() {
+			return new DebugInfoSection(name, elements.build());
+		}
+
+		public void buildTo(Consumer<DebugInfoSection> consumer) {
+			consumer.accept(this.build());
+		}
+	}
+}

--- a/src/main/java/com/simibubi/create/infrastructure/debugInfo/element/InfoElement.java
+++ b/src/main/java/com/simibubi/create/infrastructure/debugInfo/element/InfoElement.java
@@ -1,0 +1,27 @@
+package com.simibubi.create.infrastructure.debugInfo.element;
+
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.world.entity.player.Player;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Consumer;
+
+public sealed interface InfoElement permits DebugInfoSection, InfoEntry {
+	void write(Player player, FriendlyByteBuf buffer);
+
+	void print(int depth, @Nullable Player player, Consumer<String> lineConsumer);
+
+	default void print(@Nullable Player player, Consumer<String> lineConsumer) {
+		print(0, player, lineConsumer);
+	}
+
+	static InfoElement read(FriendlyByteBuf buffer) {
+		boolean section = buffer.readBoolean();
+		if (section) {
+			return DebugInfoSection.read(buffer);
+		} else {
+			return InfoEntry.read(buffer);
+		}
+	}
+}

--- a/src/main/java/com/simibubi/create/infrastructure/debugInfo/element/InfoEntry.java
+++ b/src/main/java/com/simibubi/create/infrastructure/debugInfo/element/InfoEntry.java
@@ -1,0 +1,47 @@
+package com.simibubi.create.infrastructure.debugInfo.element;
+
+import com.simibubi.create.infrastructure.debugInfo.InfoProvider;
+
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.world.entity.player.Player;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public record InfoEntry(String name, InfoProvider provider) implements InfoElement {
+	@Override
+	public void write(Player player, FriendlyByteBuf buffer) {
+		buffer.writeBoolean(false);
+		buffer.writeUtf(name);
+		buffer.writeUtf(provider.getInfoSafe(player));
+	}
+
+	@Override
+	public void print(int depth, @Nullable Player player, Consumer<String> lineConsumer) {
+		String value = provider.getInfoSafe(player);
+		String indent = Stream.generate(() -> "\t").limit(depth).collect(Collectors.joining(""));
+		if (value.contains("\n")) {
+			lineConsumer.accept(indent + "<details>");
+			lineConsumer.accept(indent + "<summary>" + name + "</summary>");
+
+			for (String line : value.split("\n")) {
+				lineConsumer.accept(indent + '\t' + line);
+			}
+
+			lineConsumer.accept(indent + "</details>");
+		} else {
+			lineConsumer.accept(indent + name + ": " + value);
+		}
+
+	}
+
+	public static InfoEntry read(FriendlyByteBuf buffer) {
+		String name = buffer.readUtf();
+		String value = buffer.readUtf();
+		return new InfoEntry(name, player -> value);
+	}
+}

--- a/src/main/resources/create.mixins.json
+++ b/src/main/resources/create.mixins.json
@@ -22,9 +22,14 @@
     "accessor.GameTestHelperAccessor",
     "accessor.LivingEntityAccessor",
     "accessor.NbtAccounterAccessor",
-    "accessor.ServerLevelAccessor"
+    "accessor.ServerLevelAccessor",
+    "accessor.SystemReportAccessor"
   ],
   "client": [
+    "accessor.AgeableListModelAccessor",
+    "accessor.GameRendererAccessor",
+    "accessor.HumanoidArmorLayerAccessor",
+    "accessor.ParticleEngineAccessor",
     "client.BlockDestructionProgressMixin",
     "client.CameraMixin",
     "client.EntityContraptionInteractionMixin",
@@ -35,11 +40,7 @@
     "client.MapRendererMapInstanceMixin",
     "client.ModelDataRefreshMixin",
     "client.PlayerRendererMixin",
-    "client.WindowResizeMixin",
-    "accessor.AgeableListModelAccessor",
-    "accessor.GameRendererAccessor",
-    "accessor.HumanoidArmorLayerAccessor",
-    "accessor.ParticleEngineAccessor"
+    "client.WindowResizeMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Adds the `/create debuginfo` command to copy debugging information onto the player's clipboard.
This is intended to be used alongside a GitHub issue template. I will PR those at a later date.

This repo has my current plans for issue templates, and issue 1 shows sample command output: https://github.com/TropheusJ/issue-template-testing

This system can be added to by addons easily. Copied information is open to change still.
