### PR TITLE
Miscellaneous improvements to the config api

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/config/ConfigBase.java
+++ b/src/main/java/com/simibubi/create/foundation/config/ConfigBase.java
@@ -2,6 +2,7 @@ package com.simibubi.create.foundation.config;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -133,6 +134,18 @@ public abstract class ConfigBase {
 
 		public String getName() {
 			return name;
+		}
+
+		public V getDefault() {
+			return value.getDefault();
+		}
+
+		public boolean isDefault() {
+			return Objects.equals(get(), getDefault());
+		}
+
+		public void reset() {
+			set(getDefault());
 		}
 	}
 

--- a/src/main/java/com/simibubi/create/foundation/config/ConfigBase.java
+++ b/src/main/java/com/simibubi/create/foundation/config/ConfigBase.java
@@ -22,6 +22,8 @@ public abstract class ConfigBase {
 	protected List<ConfigBase> children;
 
 	public void registerAll(final ForgeConfigSpec.Builder builder) {
+		if(allValues == null)
+			allValues = new ArrayList<>();
 		for (CValue<?, ?> cValue : allValues)
 			cValue.register(builder);
 	}
@@ -39,7 +41,7 @@ public abstract class ConfigBase {
 	public abstract String getName();
 
 	@FunctionalInterface
-	protected static interface IValueProvider<V, T extends ConfigValue<V>>
+	public interface IValueProvider<V, T extends ConfigValue<V>>
 		extends Function<ForgeConfigSpec.Builder, T> {
 	}
 

--- a/src/main/java/com/simibubi/create/foundation/config/ui/ConfigModListScreen.java
+++ b/src/main/java/com/simibubi/create/foundation/config/ui/ConfigModListScreen.java
@@ -3,6 +3,7 @@ package com.simibubi.create.foundation.config.ui;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 
 import org.lwjgl.glfw.GLFW;
 
@@ -42,7 +43,11 @@ public class ConfigModListScreen extends ConfigScreen {
 		addRenderableWidget(list);
 
 		allEntries = new ArrayList<>();
-		ModList.get().getMods().stream().map(IModInfo::getModId).forEach(id -> allEntries.add(new ModEntry(id, this)));
+		ModList.get()
+				.getMods()
+				.stream()
+				.map(IModInfo::getModId)
+				.forEach(title -> allEntries.add(new ModEntry(title, this)));
 		allEntries.sort((e1, e2) -> {
 			int empty = (e2.button.active ? 1 : 0) - (e1.button.active ? 1 : 0);
 			if (empty != 0)
@@ -86,7 +91,7 @@ public class ConfigModListScreen extends ConfigScreen {
 				.forEach(list.children()::add);
 
 		list.setScrollAmount(list.getScrollAmount());
-		if (list.children().size() > 0) {
+		if (!list.children().isEmpty()) {
 			this.search.setTextColor(Theme.i(Theme.Key.TEXT));
 		} else {
 			this.search.setTextColor(Theme.i(Theme.Key.BUTTON_FAIL));
@@ -99,7 +104,7 @@ public class ConfigModListScreen extends ConfigScreen {
 		protected String id;
 
 		public ModEntry(String id, Screen parent) {
-			super(toHumanReadable(id));
+			super(BaseConfigScreen.getCustomTitle(id).orElse(toHumanReadable(id)));
 			this.id = id;
 
 			button = new BoxWidget(0, 0, 35, 16)
@@ -112,7 +117,7 @@ public class ConfigModListScreen extends ConfigScreen {
 				button.active = false;
 				button.updateColorsFromState();
 				button.modifyElement(e -> ((DelegatedStencilElement) e).withElementRenderer(BaseConfigScreen.DISABLED_RENDERER));
-				labelTooltip.add(Components.literal(toHumanReadable(id)));
+				labelTooltip.add(Components.literal(BaseConfigScreen.getCustomTitle(id).orElse(toHumanReadable(id))));
 				labelTooltip.addAll(TooltipHelper.cutStringTextComponent("This Mod does not have any configs registered or is not using Forge's config system", Palette.ALL_GRAY));
 			}
 


### PR DESCRIPTION
Mainly allows addon devs to add custom names for their mods, since Create's toHumanReadable method doesn't improve all-lowercase strings (aka pretty much every mod id ever) very much. Two examples that I’ve included are ComputerCraft (which used to read "Computercraft") and Just Enough Items (which used to read "Jei"). These overridden titles are shown in the config screen and the mod list. Additionally, there’s an option if creators don’t want their mod name uppercased in the config screen.

I also added a check so mods can't overwrite each other's default actions, and added a null check against empty config classes.

new for 1.19 edition: methods related to default config values (setting, getting, and checking if something is default) - they didn't exist on 1.18