### PR TITLE
rename AbstractSimiWidget#renderButton

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/gui/widget/AbstractSimiWidget.java
+++ b/src/main/java/com/simibubi/create/foundation/gui/widget/AbstractSimiWidget.java
@@ -40,7 +40,7 @@ public abstract class AbstractSimiWidget extends AbstractWidget implements Ticka
 	protected AbstractSimiWidget(int x, int y, int width, int height, Component message) {
 		super(x, y, width, height, message);
 	}
-	
+
 	@Override
 	protected ClientTooltipPositioner createTooltipPositioner() {
 		return DefaultTooltipPositioner.INSTANCE;
@@ -72,7 +72,7 @@ public abstract class AbstractSimiWidget extends AbstractWidget implements Ticka
 	@Override
 	public void renderWidget(@Nonnull GuiGraphics graphics, int mouseX, int mouseY, float partialTicks) {
 		beforeRender(graphics, mouseX, mouseY, partialTicks);
-		renderButton(graphics, mouseX, mouseY, partialTicks);
+		doRender(graphics, mouseX, mouseY, partialTicks);
 		afterRender(graphics, mouseX, mouseY, partialTicks);
 		wasHovered = isHoveredOrFocused();
 	}
@@ -81,7 +81,7 @@ public abstract class AbstractSimiWidget extends AbstractWidget implements Ticka
 		graphics.pose().pushPose();
 	}
 
-	protected void renderButton(@Nonnull GuiGraphics graphics, int mouseX, int mouseY, float partialTicks) {
+	protected void doRender(@Nonnull GuiGraphics graphics, int mouseX, int mouseY, float partialTicks) {
 	}
 
 	protected void afterRender(@Nonnull GuiGraphics graphics, int mouseX, int mouseY, float partialTicks) {

--- a/src/main/java/com/simibubi/create/foundation/gui/widget/BoxWidget.java
+++ b/src/main/java/com/simibubi/create/foundation/gui/widget/BoxWidget.java
@@ -121,7 +121,7 @@ public class BoxWidget extends ElementWidget {
 	}
 
 	@Override
-	public void renderButton(GuiGraphics graphics, int mouseX, int mouseY, float partialTicks) {
+	public void doRender(GuiGraphics graphics, int mouseX, int mouseY, float partialTicks) {
 		float fadeValue = fade.getValue(partialTicks);
 		if (fadeValue < .1f)
 			return;
@@ -133,7 +133,7 @@ public class BoxWidget extends ElementWidget {
 				.withBounds(width, height)
 				.render(graphics);
 
-		super.renderButton(graphics, mouseX, mouseY, partialTicks);
+		super.doRender(graphics, mouseX, mouseY, partialTicks);
 
 		wasHovered = isHovered;
 	}
@@ -148,7 +148,7 @@ public class BoxWidget extends ElementWidget {
 
 		return getX() - padX <= mX && getY() - padY <= mY && mX < getX() + padX + width && mY < getY() + padY + height;
 	}
-	
+
 	@Override
 	protected boolean clicked(double pMouseX, double pMouseY) {
 		if (!active || !visible)

--- a/src/main/java/com/simibubi/create/foundation/gui/widget/ElementWidget.java
+++ b/src/main/java/com/simibubi/create/foundation/gui/widget/ElementWidget.java
@@ -130,7 +130,7 @@ public class ElementWidget extends AbstractSimiWidget {
 	}
 
 	@Override
-	public void renderButton(GuiGraphics graphics, int mouseX, int mouseY, float partialTicks) {
+	public void doRender(GuiGraphics graphics, int mouseX, int mouseY, float partialTicks) {
 		PoseStack ms = graphics.pose();
 		ms.pushPose();
 		ms.translate(getX() + paddingX, getY() + paddingY, z);

--- a/src/main/java/com/simibubi/create/foundation/gui/widget/IconButton.java
+++ b/src/main/java/com/simibubi/create/foundation/gui/widget/IconButton.java
@@ -14,14 +14,14 @@ public class IconButton extends AbstractSimiWidget {
 	public IconButton(int x, int y, ScreenElement icon) {
 		this(x, y, 18, 18, icon);
 	}
-	
+
 	public IconButton(int x, int y, int w, int h, ScreenElement icon) {
 		super(x, y, w, h);
 		this.icon = icon;
 	}
 
 	@Override
-	public void renderButton(GuiGraphics graphics, int mouseX, int mouseY, float partialTicks) {
+	public void doRender(GuiGraphics graphics, int mouseX, int mouseY, float partialTicks) {
 		if (visible) {
 			isHovered = mouseX >= getX() && mouseY >= getY() && mouseX < getX() + width && mouseY < getY() + height;
 

--- a/src/main/java/com/simibubi/create/foundation/gui/widget/Label.java
+++ b/src/main/java/com/simibubi/create/foundation/gui/widget/Label.java
@@ -71,7 +71,7 @@ public class Label extends AbstractSimiWidget {
 	}
 
 	@Override
-	protected void renderButton(@Nonnull GuiGraphics graphics, int mouseX, int mouseY, float partialTicks) {
+	protected void doRender(@Nonnull GuiGraphics graphics, int mouseX, int mouseY, float partialTicks) {
 		if (text == null || text.getString().isEmpty())
 			return;
 

--- a/src/main/java/com/simibubi/create/foundation/ponder/ui/ChapterLabel.java
+++ b/src/main/java/com/simibubi/create/foundation/ponder/ui/ChapterLabel.java
@@ -31,7 +31,7 @@ public class ChapterLabel extends AbstractSimiWidget {
 		graphics.drawString(Minecraft.getInstance().font, chapter.getTitle(), getX() + 50,
 			getY() + 20, Theme.i(Theme.Key.TEXT_ACCENT_SLIGHT), false);
 
-		button.renderButton(graphics, mouseX, mouseY, partialTicks);
+		button.doRender(graphics, mouseX, mouseY, partialTicks);
 		super.render(graphics, mouseX, mouseY, partialTicks);
 	}
 

--- a/src/main/java/com/simibubi/create/foundation/ponder/ui/PonderButton.java
+++ b/src/main/java/com/simibubi/create/foundation/ponder/ui/PonderButton.java
@@ -88,8 +88,8 @@ public class PonderButton extends BoxWidget {
 	}
 
 	@Override
-	public void renderButton(GuiGraphics graphics, int mouseX, int mouseY, float partialTicks) {
-		super.renderButton(graphics, mouseX, mouseY, partialTicks);
+	public void doRender(GuiGraphics graphics, int mouseX, int mouseY, float partialTicks) {
+		super.doRender(graphics, mouseX, mouseY, partialTicks);
 		float fadeValue = fade.getValue();
 
 		if (fadeValue < .1f)

--- a/src/main/java/com/simibubi/create/foundation/ponder/ui/PonderProgressBar.java
+++ b/src/main/java/com/simibubi/create/foundation/ponder/ui/PonderProgressBar.java
@@ -83,9 +83,9 @@ public class PonderProgressBar extends AbstractSimiWidget {
 	}
 
 	@Override
-	public void renderButton(GuiGraphics graphics, int mouseX, int mouseY, float partialTicks) {
+	public void doRender(GuiGraphics graphics, int mouseX, int mouseY, float partialTicks) {
 		PoseStack ms = graphics.pose();
-		
+
 		isHovered = clicked(mouseX, mouseY);
 
 		new BoxElement()


### PR DESCRIPTION
the current name makes it impossible to use Create in an environment using Yarn due to mapping conflicts.

I have renamed the method to `doRender`. Plain `render` would cause a different unintentional override.

If a better name is suggested changing it is fine.