### PR TITLE
Use appropriate method for sneaky players

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/actors/psi/PortableStorageInterfaceBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/actors/psi/PortableStorageInterfaceBlock.java
@@ -58,7 +58,7 @@ public class PortableStorageInterfaceBlock extends WrenchableDirectionalBlock
 	public BlockState getStateForPlacement(BlockPlaceContext context) {
 		Direction direction = context.getNearestLookingDirection();
 		if (context.getPlayer() != null && context.getPlayer()
-			.isSteppingCarefully())
+			.isShiftKeyDown())
 			direction = direction.getOpposite();
 		return defaultBlockState().setValue(FACING, direction.getOpposite());
 	}

--- a/src/main/java/com/simibubi/create/content/contraptions/actors/trainControls/ControlsBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/actors/trainControls/ControlsBlock.java
@@ -56,7 +56,7 @@ public class ControlsBlock extends HorizontalDirectionalBlock implements IWrench
 		Player player = pContext.getPlayer();
 
 		state = state.setValue(FACING, horizontalDirection.getOpposite());
-		if (player != null && player.isSteppingCarefully())
+		if (player != null && player.isShiftKeyDown())
 			state = state.setValue(FACING, horizontalDirection);
 
 		return state;

--- a/src/main/java/com/simibubi/create/content/contraptions/glue/SuperGlueSelectionHandler.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/glue/SuperGlueSelectionHandler.java
@@ -121,7 +121,7 @@ public class SuperGlueSelectionHandler {
 			return;
 		}
 
-		boolean cancel = player.isSteppingCarefully();
+		boolean cancel = player.isShiftKeyDown();
 		if (cancel && firstPos == null)
 			return;
 
@@ -201,7 +201,7 @@ public class SuperGlueSelectionHandler {
 			return true;
 		}
 
-		if (player.isSteppingCarefully()) {
+		if (player.isShiftKeyDown()) {
 			if (firstPos != null) {
 				discard();
 				return true;

--- a/src/main/java/com/simibubi/create/content/decoration/copycat/CopycatBlock.java
+++ b/src/main/java/com/simibubi/create/content/decoration/copycat/CopycatBlock.java
@@ -316,7 +316,7 @@ public abstract class CopycatBlock extends Block implements IBE<CopycatBlockEnti
 	public ItemStack getCloneItemStack(BlockState state, HitResult target, BlockGetter level, BlockPos pos,
 		Player player) {
 		BlockState material = getMaterial(level, pos);
-		if (AllBlocks.COPYCAT_BASE.has(material) || player != null && player.isSteppingCarefully())
+		if (AllBlocks.COPYCAT_BASE.has(material) || player != null && player.isShiftKeyDown())
 			return new ItemStack(this);
 		return material.getCloneItemStack(target, level, pos, player);
 	}

--- a/src/main/java/com/simibubi/create/content/decoration/girder/GirderBlock.java
+++ b/src/main/java/com/simibubi/create/content/decoration/girder/GirderBlock.java
@@ -121,7 +121,7 @@ public class GirderBlock extends Block implements SimpleWaterloggedBlock, IWrenc
 			return InteractionResult.SUCCESS;
 		}
 
-		if (AllItems.WRENCH.isIn(itemInHand) && !pPlayer.isSteppingCarefully()) {
+		if (AllItems.WRENCH.isIn(itemInHand) && !pPlayer.isShiftKeyDown()) {
 			if (GirderWrenchBehavior.handleClick(pLevel, pPos, pState, pHit))
 				return InteractionResult.sidedSuccess(pLevel.isClientSide);
 			return InteractionResult.FAIL;

--- a/src/main/java/com/simibubi/create/content/decoration/girder/GirderWrenchBehavior.java
+++ b/src/main/java/com/simibubi/create/content/decoration/girder/GirderWrenchBehavior.java
@@ -44,7 +44,7 @@ public class GirderWrenchBehavior {
 		Player player = mc.player;
 		ItemStack heldItem = player.getMainHandItem();
 
-		if (player.isSteppingCarefully())
+		if (player.isShiftKeyDown())
 			return;
 
 		if (!AllBlocks.METAL_GIRDER.has(world.getBlockState(pos)))

--- a/src/main/java/com/simibubi/create/content/decoration/palettes/LayeredBlock.java
+++ b/src/main/java/com/simibubi/create/content/decoration/palettes/LayeredBlock.java
@@ -18,7 +18,7 @@ public class LayeredBlock extends RotatedPillarBlock {
 				.relative(pContext.getClickedFace()
 					.getOpposite()));
 		if (placedOn.getBlock() == this && (pContext.getPlayer() == null || !pContext.getPlayer()
-			.isSteppingCarefully()))
+			.isShiftKeyDown()))
 			stateForPlacement = stateForPlacement.setValue(AXIS, placedOn.getValue(AXIS));
 		return stateForPlacement;
 	}

--- a/src/main/java/com/simibubi/create/content/equipment/clipboard/ClipboardBlock.java
+++ b/src/main/java/com/simibubi/create/content/equipment/clipboard/ClipboardBlock.java
@@ -87,7 +87,7 @@ public class ClipboardBlock extends FaceAttachedHorizontalDirectionalBlock
 	@Override
 	public InteractionResult use(BlockState pState, Level pLevel, BlockPos pPos, Player pPlayer, InteractionHand pHand,
 		BlockHitResult pHit) {
-		if (pPlayer.isSteppingCarefully()) {
+		if (pPlayer.isShiftKeyDown()) {
 			breakAndCollect(pState, pLevel, pPos, pPlayer);
 			return InteractionResult.SUCCESS;
 		}

--- a/src/main/java/com/simibubi/create/content/equipment/clipboard/ClipboardBlockItem.java
+++ b/src/main/java/com/simibubi/create/content/equipment/clipboard/ClipboardBlockItem.java
@@ -34,7 +34,7 @@ public class ClipboardBlockItem extends BlockItem {
 		Player player = context.getPlayer();
 		if (player == null)
 			return InteractionResult.PASS;
-		if (player.isSteppingCarefully())
+		if (player.isShiftKeyDown())
 			return super.useOn(context);
 		return use(context.getLevel(), player, context.getHand()).getResult();
 	}

--- a/src/main/java/com/simibubi/create/content/equipment/clipboard/ClipboardValueSettingsHandler.java
+++ b/src/main/java/com/simibubi/create/content/equipment/clipboard/ClipboardValueSettingsHandler.java
@@ -141,7 +141,7 @@ public class ClipboardValueSettingsHandler {
 		Player player = event.getPlayer();
 		if (player != null && player.isSpectator())
 			return;
-		if (player.isSteppingCarefully())
+		if (player.isShiftKeyDown())
 			return;
 		if (!(world.getBlockEntity(pos) instanceof SmartBlockEntity smartBE))
 			return;

--- a/src/main/java/com/simibubi/create/content/fluids/pump/PumpBlock.java
+++ b/src/main/java/com/simibubi/create/content/fluids/pump/PumpBlock.java
@@ -132,7 +132,7 @@ public class PumpBlock extends DirectionalKineticBlock
 			return toPlace;
 		if (bestConnectedDirection.getAxis() == targetDirection.getAxis())
 			return toPlace;
-		if (player.isSteppingCarefully() && bestConnectedDirection.getAxis() != targetDirection.getAxis())
+		if (player.isShiftKeyDown() && bestConnectedDirection.getAxis() != targetDirection.getAxis())
 			return toPlace;
 
 		return toPlace.setValue(FACING, bestConnectedDirection);

--- a/src/main/java/com/simibubi/create/content/kinetics/crank/ValveHandleBlock.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/crank/ValveHandleBlock.java
@@ -66,7 +66,7 @@ public class ValveHandleBlock extends HandCrankBlock {
 			return;
 		if (!player.mayBuild())
 			return;
-		if (AllItems.WRENCH.isIn(player.getItemInHand(event.getHand())) && player.isSteppingCarefully())
+		if (AllItems.WRENCH.isIn(player.getItemInHand(event.getHand())) && player.isShiftKeyDown())
 			return;
 
 		if (vhb.clicked(level, pos, blockState, player, event.getHand())) {
@@ -94,7 +94,7 @@ public class ValveHandleBlock extends HandCrankBlock {
 		}
 
 		onBlockEntityUse(level, pos,
-			hcbe -> (hcbe instanceof ValveHandleBlockEntity vhbe) && vhbe.activate(player.isSteppingCarefully())
+			hcbe -> (hcbe instanceof ValveHandleBlockEntity vhbe) && vhbe.activate(player.isShiftKeyDown())
 				? InteractionResult.SUCCESS
 				: InteractionResult.PASS);
 		return true;

--- a/src/main/java/com/simibubi/create/content/logistics/vault/ItemVaultBlock.java
+++ b/src/main/java/com/simibubi/create/content/logistics/vault/ItemVaultBlock.java
@@ -53,7 +53,7 @@ public class ItemVaultBlock extends Block implements IWrenchable, IBE<ItemVaultB
 	@Override
 	public BlockState getStateForPlacement(BlockPlaceContext pContext) {
 		if (pContext.getPlayer() == null || !pContext.getPlayer()
-			.isSteppingCarefully()) {
+			.isShiftKeyDown()) {
 			BlockState placedOn = pContext.getLevel()
 				.getBlockState(pContext.getClickedPos()
 					.relative(pContext.getClickedFace()

--- a/src/main/java/com/simibubi/create/content/logistics/vault/ItemVaultItem.java
+++ b/src/main/java/com/simibubi/create/content/logistics/vault/ItemVaultItem.java
@@ -54,7 +54,7 @@ public class ItemVaultItem extends BlockItem {
 		Player player = ctx.getPlayer();
 		if (player == null)
 			return;
-		if (player.isSteppingCarefully())
+		if (player.isShiftKeyDown())
 			return;
 		Direction face = ctx.getClickedFace();
 		ItemStack stack = ctx.getItemInHand();

--- a/src/main/java/com/simibubi/create/content/materials/ExperienceNuggetItem.java
+++ b/src/main/java/com/simibubi/create/content/materials/ExperienceNuggetItem.java
@@ -35,7 +35,7 @@ public class ExperienceNuggetItem extends Item {
 			return InteractionResultHolder.consume(itemInHand);
 		}
 
-		int amountUsed = pPlayer.isSteppingCarefully() ? 1 : itemInHand.getCount();
+		int amountUsed = pPlayer.isShiftKeyDown() ? 1 : itemInHand.getCount();
 		int total = Mth.ceil(3f * amountUsed);
 		int maxOrbs = amountUsed == 1 ? 1 : 5;
 		int valuePer = Math.max(1, 1 + total / maxOrbs);

--- a/src/main/java/com/simibubi/create/content/redstone/displayLink/DisplayLinkBlock.java
+++ b/src/main/java/com/simibubi/create/content/redstone/displayLink/DisplayLinkBlock.java
@@ -139,7 +139,7 @@ public class DisplayLinkBlock extends WrenchableDirectionalBlock implements IBE<
 		BlockHitResult pHit) {
 		if (pPlayer == null)
 			return InteractionResult.PASS;
-		if (pPlayer.isSteppingCarefully())
+		if (pPlayer.isShiftKeyDown())
 			return InteractionResult.PASS;
 		DistExecutor.unsafeRunWhenOn(Dist.CLIENT,
 			() -> () -> withBlockEntityDo(pLevel, pPos, be -> this.displayScreen(be, pPlayer)));

--- a/src/main/java/com/simibubi/create/content/redstone/displayLink/DisplayLinkBlockItem.java
+++ b/src/main/java/com/simibubi/create/content/redstone/displayLink/DisplayLinkBlockItem.java
@@ -57,7 +57,7 @@ public class DisplayLinkBlockItem extends BlockItem {
 		if (player == null)
 			return InteractionResult.FAIL;
 
-		if (player.isSteppingCarefully() && stack.hasTag()) {
+		if (player.isShiftKeyDown() && stack.hasTag()) {
 			if (level.isClientSide)
 				return InteractionResult.SUCCESS;
 			player.displayClientMessage(Lang.translateDirect("display_link.clear"), true);

--- a/src/main/java/com/simibubi/create/content/redstone/smartObserver/SmartObserverBlock.java
+++ b/src/main/java/com/simibubi/create/content/redstone/smartObserver/SmartObserverBlock.java
@@ -85,7 +85,7 @@ public class SmartObserverBlock extends DirectedDirectionalBlock implements IBE<
 		if (preferredFacing == null) {
 			Direction facing = context.getNearestLookingDirection();
 			preferredFacing = context.getPlayer() != null && context.getPlayer()
-				.isSteppingCarefully() ? facing : facing.getOpposite();
+				.isShiftKeyDown() ? facing : facing.getOpposite();
 		}
 
 		if (preferredFacing.getAxis() == Axis.Y) {

--- a/src/main/java/com/simibubi/create/content/redstone/thresholdSwitch/ThresholdSwitchBlock.java
+++ b/src/main/java/com/simibubi/create/content/redstone/thresholdSwitch/ThresholdSwitchBlock.java
@@ -123,7 +123,7 @@ public class ThresholdSwitchBlock extends DirectedDirectionalBlock implements IB
 		if (preferredFacing == null) {
 			Direction facing = context.getNearestLookingDirection();
 			preferredFacing = context.getPlayer() != null && context.getPlayer()
-				.isSteppingCarefully() ? facing : facing.getOpposite();
+				.isShiftKeyDown() ? facing : facing.getOpposite();
 		}
 
 		if (preferredFacing.getAxis() == Axis.Y) {

--- a/src/main/java/com/simibubi/create/content/trains/entity/TrainRelocator.java
+++ b/src/main/java/com/simibubi/create/content/trains/entity/TrainRelocator.java
@@ -83,7 +83,7 @@ public class TrainRelocator {
 			return;
 
 		if (!player.position()
-			.closerThan(relocatingOrigin, 24) || player.isSteppingCarefully()) {
+			.closerThan(relocatingOrigin, 24) || player.isShiftKeyDown()) {
 			relocatingTrain = null;
 			player.displayClientMessage(Lang.translateDirect("train.relocate.abort")
 				.withStyle(ChatFormatting.RED), true);

--- a/src/main/java/com/simibubi/create/content/trains/station/StationBlock.java
+++ b/src/main/java/com/simibubi/create/content/trains/station/StationBlock.java
@@ -113,7 +113,7 @@ public class StationBlock extends Block implements IBE<StationBlockEntity>, IWre
 	public InteractionResult use(BlockState pState, Level pLevel, BlockPos pPos, Player pPlayer, InteractionHand pHand,
 		BlockHitResult pHit) {
 
-		if (pPlayer == null || pPlayer.isSteppingCarefully())
+		if (pPlayer == null || pPlayer.isShiftKeyDown())
 			return InteractionResult.PASS;
 		ItemStack itemInHand = pPlayer.getItemInHand(pHand);
 		if (AllItems.WRENCH.isIn(itemInHand))

--- a/src/main/java/com/simibubi/create/content/trains/track/CurvedTrackInteraction.java
+++ b/src/main/java/com/simibubi/create/content/trains/track/CurvedTrackInteraction.java
@@ -126,7 +126,7 @@ public class CurvedTrackInteraction {
 				player.swing(InteractionHand.MAIN_HAND);
 				return true;
 			}
-			if (AllItems.WRENCH.isIn(heldItem) && player.isSteppingCarefully()) {
+			if (AllItems.WRENCH.isIn(heldItem) && player.isShiftKeyDown()) {
 				AllPackets.getChannel().sendToServer(new CurvedTrackDestroyPacket(result.blockEntity()
 					.getBlockPos(),
 					result.loc()

--- a/src/main/java/com/simibubi/create/content/trains/track/CurvedTrackSelectionPacket.java
+++ b/src/main/java/com/simibubi/create/content/trains/track/CurvedTrackSelectionPacket.java
@@ -60,7 +60,7 @@ public class CurvedTrackSelectionPacket extends BlockEntityConfigurationPacket<T
 			.getItem(slot);
 		if (!(stack.getItem() instanceof TrackTargetingBlockItem))
 			return;
-		if (player.isSteppingCarefully() && stack.hasTag()) {
+		if (player.isShiftKeyDown() && stack.hasTag()) {
 			player.displayClientMessage(Lang.translateDirect("track_target.clear"), true);
 			stack.setTag(null);
 			AllSoundEvents.CONTROLLER_CLICK.play(player.level, null, pos, 1, .5f);

--- a/src/main/java/com/simibubi/create/content/trains/track/TrackBlockItem.java
+++ b/src/main/java/com/simibubi/create/content/trains/track/TrackBlockItem.java
@@ -80,7 +80,7 @@ public class TrackBlockItem extends BlockItem {
 			}
 			return super.useOn(pContext);
 
-		} else if (player.isSteppingCarefully()) {
+		} else if (player.isShiftKeyDown()) {
 			if (!level.isClientSide) {
 				player.displayClientMessage(Lang.translateDirect("track.selection_cleared"), true);
 				stack.setTag(null);

--- a/src/main/java/com/simibubi/create/content/trains/track/TrackTargetingBlockItem.java
+++ b/src/main/java/com/simibubi/create/content/trains/track/TrackTargetingBlockItem.java
@@ -65,7 +65,7 @@ public class TrackTargetingBlockItem extends BlockItem {
 		if (player == null)
 			return InteractionResult.FAIL;
 
-		if (player.isSteppingCarefully() && stack.hasTag()) {
+		if (player.isShiftKeyDown() && stack.hasTag()) {
 			if (level.isClientSide)
 				return InteractionResult.SUCCESS;
 			player.displayClientMessage(Lang.translateDirect("track_target.clear"), true);


### PR DESCRIPTION
Using the other method causes a conflict with fabrications no_sneak_bypass feature. (possibly others)
Create seams to use the two methods interchangibly the wrench for e.g. uses the appropriate one.

Was told this is a pr apropriate for upstream [fabric-pr](https://github.com/Fabricators-of-Create/Create/pull/1164)