### PR TITLE
Train navigation optimization

### DIFF
--- a/src/main/java/com/simibubi/create/content/trains/entity/CarriageContraptionEntity.java
+++ b/src/main/java/com/simibubi/create/content/trains/entity/CarriageContraptionEntity.java
@@ -1,7 +1,6 @@
 package com.simibubi.create.content.trains.entity;
 
 import java.lang.ref.WeakReference;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -54,8 +53,6 @@ import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.network.PacketDistributor;
-
-import org.openjdk.nashorn.internal.objects.Global;
 
 public class CarriageContraptionEntity extends OrientedContraptionEntity {
 

--- a/src/main/java/com/simibubi/create/content/trains/entity/CarriageContraptionEntity.java
+++ b/src/main/java/com/simibubi/create/content/trains/entity/CarriageContraptionEntity.java
@@ -640,7 +640,7 @@ public class CarriageContraptionEntity extends OrientedContraptionEntity {
 			if (lookAhead != null) {
 				if (spaceDown) {
 					carriage.train.manualTick = true;
-					nav.startNavigation(lookAhead, -1, false);
+					nav.startNavigation(nav.findPathTo(lookAhead, -1));
 					carriage.train.manualTick = false;
 					navDistanceTotal = nav.distanceToDestination;
 					return true;

--- a/src/main/java/com/simibubi/create/content/trains/entity/CarriageContraptionEntity.java
+++ b/src/main/java/com/simibubi/create/content/trains/entity/CarriageContraptionEntity.java
@@ -1,6 +1,7 @@
 package com.simibubi.create.content.trains.entity;
 
 import java.lang.ref.WeakReference;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -53,6 +54,8 @@ import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.network.PacketDistributor;
+
+import org.openjdk.nashorn.internal.objects.Global;
 
 public class CarriageContraptionEntity extends OrientedContraptionEntity {
 

--- a/src/main/java/com/simibubi/create/content/trains/entity/Navigation.java
+++ b/src/main/java/com/simibubi/create/content/trains/entity/Navigation.java
@@ -605,7 +605,7 @@ public class Navigation {
 
 		frontier.add(new FrontierEntry(distanceToNode2, 0, initialNode1, initialNode2, initialEdge));
 		int signalWeight = Mth.clamp(ticksWaitingForSignal * 2, Train.Penalties.RED_SIGNAL, 200);
-		int total = 0;
+
 		Search: while (!frontier.isEmpty()) {
 			FrontierEntry entry = frontier.poll();
 			if (!visited.add(entry.edge))
@@ -616,7 +616,7 @@ public class Navigation {
 
 			if (distance > maxDistance)
 				continue;
-			total++;
+
 			TrackEdge edge = entry.edge;
 			TrackNode node1 = entry.node1;
 			TrackNode node2 = entry.node2;

--- a/src/main/java/com/simibubi/create/content/trains/entity/Navigation.java
+++ b/src/main/java/com/simibubi/create/content/trains/entity/Navigation.java
@@ -601,7 +601,7 @@ public class Navigation {
 
 		double distanceToNode2 = forward ? initialEdge.getLength() - startingPoint.position : startingPoint.position;
 
-		frontier.add(new FrontierEntry(distanceToNode2, 0, 0, initialNode1, initialNode2, initialEdge));
+		frontier.add(new FrontierEntry(distanceToNode2, 0, initialNode1, initialNode2, initialEdge));
 		int signalWeight = Mth.clamp(ticksWaitingForSignal * 2, Train.Penalties.RED_SIGNAL, 200);
 		int total = 0;
 		Search: while (!frontier.isEmpty()) {
@@ -705,6 +705,14 @@ public class Navigation {
 		TrackNode node2;
 		TrackEdge edge;
 
+		public FrontierEntry(double distance, int penalty, TrackNode node1, TrackNode node2, TrackEdge edge) {
+			this.distance = distance;
+			this.penalty = penalty;
+			this.remaining = 0;
+			this.node1 = node1;
+			this.node2 = node2;
+			this.edge = edge;
+		}
 		public FrontierEntry(double distance, int penalty, double remaining, TrackNode node1, TrackNode node2, TrackEdge edge) {
 			this.distance = distance;
 			this.penalty = penalty;

--- a/src/main/java/com/simibubi/create/content/trains/entity/Navigation.java
+++ b/src/main/java/com/simibubi/create/content/trains/entity/Navigation.java
@@ -658,7 +658,7 @@ public class Navigation {
 		if (costRelevant && distanceToNode2 + initialPenalty > maxCost)
 			return;
 
-		frontier.add(new FrontierEntry(distanceToNode2, initialPenalty, false, initialNode1, initialNode2, initialEdge));
+		frontier.add(new FrontierEntry(distanceToNode2, initialPenalty, initialNode1, initialNode2, initialEdge));
 
 		while (!frontier.isEmpty()) {
 			FrontierEntry entry = frontier.poll();
@@ -787,7 +787,7 @@ public class Navigation {
 							dMid = temp;
 						}
 						// Octile distance from newNode to station node
-						double currentRemaining = 0.317837245 * dMin + 0.414213562 * dMid + dMax + destination.position;
+						double currentRemaining = 0.317837245195782 * dMin + 0.414213562373095 * dMid + dMax + destination.position;
 						if (node2.getLocation().equals(destinationNode))
 							currentRemaining -= newEdge.getLength() * 2; // Correct the distance estimator for station edge
 						remainingDist = Math.min(remainingDist, currentRemaining);
@@ -810,11 +810,11 @@ public class Navigation {
 		TrackNode node2;
 		TrackEdge edge;
 
-		public FrontierEntry(double distance, int penalty, boolean hasDestination, TrackNode node1, TrackNode node2, TrackEdge edge) {
+		public FrontierEntry(double distance, int penalty, TrackNode node1, TrackNode node2, TrackEdge edge) {
 			this.distance = distance;
 			this.penalty = penalty;
 			this.remaining = 0;
-			this.hasDestination = hasDestination;
+			this.hasDestination = false;
 			this.node1 = node1;
 			this.node2 = node2;
 			this.edge = edge;

--- a/src/main/java/com/simibubi/create/content/trains/entity/Navigation.java
+++ b/src/main/java/com/simibubi/create/content/trains/entity/Navigation.java
@@ -1,6 +1,7 @@
 package com.simibubi.create.content.trains.entity;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
@@ -685,10 +686,36 @@ public class Navigation {
 				TrackNode newNode = target.getKey();
 				TrackEdge newEdge = target.getValue();
 				double newDistance = newEdge.getLength() + distance;
-				double remainingDist = destination == null ? 0 : newNode.getLocation().getLocation().distanceTo(destinationNodePosition);
+				double remainingDist = 0;
+
+				if (destination != null) {
+					Vec3 newNodePosition = newNode.getLocation().getLocation();
+					double dMin = Math.abs(newNodePosition.x - destinationNodePosition.x);
+					double dMid = Math.abs(newNodePosition.y - destinationNodePosition.y);
+					double dMax = Math.abs(newNodePosition.z - destinationNodePosition.z);
+
+					double temp;
+					if (dMin > dMid) {
+						temp = dMid;
+						dMid = dMin;
+						dMin = temp;
+					}
+					if (dMin > dMax) {
+						temp = dMax;
+						dMax = dMin;
+						dMin = temp;
+					}
+					if (dMid > dMax) {
+						temp = dMax;
+						dMax = dMid;
+						dMid = temp;
+					}
+					// Octile distance from newNode to station node
+					remainingDist = 0.317837245 * dMin + 0.414213562 * dMid + dMax;
+				}
 
 				reachedVia.putIfAbsent(newEdge, Pair.of(validTargets.size() > 1, Couple.create(node1, node2)));
-				if (destination != null && remainingDist == 0.0 && stationTest.test(newDistance, newDistance + penalty, reachedVia,
+				if (destination != null && Math.round(remainingDist) == 0 && stationTest.test(newDistance, newDistance + penalty, reachedVia,
 						Pair.of(Couple.create(node2, newNode), newEdge), destination))
 					return;
 				frontier.add(new FrontierEntry(newDistance, penalty, remainingDist, node2, newNode, newEdge));

--- a/src/main/java/com/simibubi/create/content/trains/entity/Navigation.java
+++ b/src/main/java/com/simibubi/create/content/trains/entity/Navigation.java
@@ -611,6 +611,7 @@ public class Navigation {
 
 		int signalWeight = Mth.clamp(ticksWaitingForSignal * 2, Train.Penalties.RED_SIGNAL, 200);
 
+		// Apply penalties to initial edge
 		int initialPenalty = 0;
 		if (costRelevant)
 			initialPenalty += penalties.getOrDefault(initialEdge, 0);
@@ -712,6 +713,7 @@ public class Navigation {
 				if (costRelevant)
 					newPenalty += penalties.getOrDefault(newEdge, 0);
 
+				// Apply penalty to next connected edge
 				boolean hasDestination = false;
 				EdgeData signalData = newEdge.getEdgeData();
 				if (signalData.hasPoints()) {
@@ -758,7 +760,7 @@ public class Navigation {
 					continue;
 
 				double remainingDist = 0;
-
+				// Calculate remaining distance estimator for next connected edge
 				if (destinations != null && !destinations.isEmpty()) {
 					remainingDist = Double.MAX_VALUE;
 					Vec3 newNodePosition = newNode.getLocation().getLocation();
@@ -884,9 +886,9 @@ public class Navigation {
 			c -> currentPath.add(Couple
 				.deserializeEach(c.getList("Nodes", Tag.TAG_COMPOUND), c2 -> TrackNodeLocation.read(c2, dimensions))
 				.map(graph::locateNode)));
-
+		
 		removeBrokenPathEntries();
-
+		
 		waitingForSignal = tag.contains("BlockingSignal")
 			? Pair.of(tag.getUUID("BlockingSignal"), tag.getBoolean("BlockingSignalSide"))
 			: null;
@@ -901,7 +903,7 @@ public class Navigation {
 		 * Trains might load or save with null entries in their path, this method avoids
 		 * that anomaly from causing NPEs. The underlying issue has not been found.
 		 */
-
+		
 		boolean nullEntriesPresent = false;
 
 		for (Iterator<Couple<TrackNode>> iterator = currentPath.iterator(); iterator.hasNext();) {

--- a/src/main/java/com/simibubi/create/content/trains/entity/Navigation.java
+++ b/src/main/java/com/simibubi/create/content/trains/entity/Navigation.java
@@ -15,7 +15,6 @@ import java.util.UUID;
 
 import javax.annotation.Nullable;
 
-import com.mojang.logging.LogUtils;
 import com.simibubi.create.content.trains.graph.DiscoveredPath;
 
 import org.apache.commons.lang3.mutable.MutableDouble;
@@ -618,7 +617,7 @@ public class Navigation {
 			TrackEdge edge = entry.edge;
 			TrackNode node1 = entry.node1;
 			TrackNode node2 = entry.node2;
-			//LogUtils.getLogger().info("straight: " + entry.straight + " | dist: " + distance + " | old: " + node1.getLocation().getLocation().toString() + " | new: " + node2.getLocation().getLocation().toString() + " | " + (entry.straight + entry.distance));
+
 			if (costRelevant)
 				penalty += penalties.getOrDefault(edge, 0);
 
@@ -687,10 +686,8 @@ public class Navigation {
 
 				reachedVia.putIfAbsent(newEdge, Pair.of(validTargets.size() > 1, Couple.create(node1, node2)));
 				if (destination != null && remainingDist == 0.0 && stationTest.test(newDistance, newDistance + penalty, reachedVia,
-						Pair.of(Couple.create(node2, newNode), newEdge), destination)){
-					LogUtils.getLogger().info("Node term: " + total);
+						Pair.of(Couple.create(node2, newNode), newEdge), destination))
 					return;
-				}
 				frontier.add(new FrontierEntry(newDistance, penalty, remainingDist, node2, newNode, newEdge));
 			}
 		}

--- a/src/main/java/com/simibubi/create/content/trains/entity/Navigation.java
+++ b/src/main/java/com/simibubi/create/content/trains/entity/Navigation.java
@@ -543,6 +543,9 @@ public class Navigation {
 		if (graph == null)
 			return;
 
+		// Cache the position of a node on the station edge if provided
+		Vec3 destinationNodePosition = destination == null ? null : destination.edgeLocation.getSecond().getLocation();
+
 		// Cache the list of track types that the train can travel on
 		Set<TrackMaterial.TrackType> validTypes = new HashSet<>();
 		for (int i = 0; i < train.carriages.size(); i++) {
@@ -682,7 +685,7 @@ public class Navigation {
 				TrackNode newNode = target.getKey();
 				TrackEdge newEdge = target.getValue();
 				double newDistance = newEdge.getLength() + distance;
-				double remainingDist = destination == null ? 0 : newNode.getLocation().getLocation().distanceTo(destination.edgeLocation.getSecond().getLocation());
+				double remainingDist = destination == null ? 0 : newNode.getLocation().getLocation().distanceTo(destinationNodePosition);
 
 				reachedVia.putIfAbsent(newEdge, Pair.of(validTargets.size() > 1, Couple.create(node1, node2)));
 				if (destination != null && remainingDist == 0.0 && stationTest.test(newDistance, newDistance + penalty, reachedVia,

--- a/src/main/java/com/simibubi/create/content/trains/entity/Navigation.java
+++ b/src/main/java/com/simibubi/create/content/trains/entity/Navigation.java
@@ -443,7 +443,7 @@ public class Navigation {
 		TrackGraph graph = train.graph;
 		if (graph == null)
 			return null;
-		LogUtils.getLogger().info("finding path");
+
 		Couple<DiscoveredPath> results = Couple.create(null, null);
 		for (boolean forward : Iterate.trueAndFalse) {
 

--- a/src/main/java/com/simibubi/create/content/trains/entity/Navigation.java
+++ b/src/main/java/com/simibubi/create/content/trains/entity/Navigation.java
@@ -1,7 +1,6 @@
 package com.simibubi.create.content.trains.entity;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
@@ -693,7 +692,7 @@ public class Navigation {
 					double dMin = Math.abs(newNodePosition.x - destinationNodePosition.x);
 					double dMid = Math.abs(newNodePosition.y - destinationNodePosition.y);
 					double dMax = Math.abs(newNodePosition.z - destinationNodePosition.z);
-
+					// Sort distance vector in ascending order
 					double temp;
 					if (dMin > dMid) {
 						temp = dMid;
@@ -714,10 +713,10 @@ public class Navigation {
 					remainingDist = 0.317837245 * dMin + 0.414213562 * dMid + dMax;
 				}
 
+				if (destination != null && Math.round(remainingDist) == 0)
+					remainingDist = -999999; // Ensure edges containing the station node get checked first
+
 				reachedVia.putIfAbsent(newEdge, Pair.of(validTargets.size() > 1, Couple.create(node1, node2)));
-				if (destination != null && Math.round(remainingDist) == 0 && stationTest.test(newDistance, newDistance + penalty, reachedVia,
-						Pair.of(Couple.create(node2, newNode), newEdge), destination))
-					return;
 				frontier.add(new FrontierEntry(newDistance, penalty, remainingDist, node2, newNode, newEdge));
 			}
 		}

--- a/src/main/java/com/simibubi/create/content/trains/entity/Train.java
+++ b/src/main/java/com/simibubi/create/content/trains/entity/Train.java
@@ -17,6 +17,8 @@ import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
 
+import com.simibubi.create.content.trains.graph.DiscoveredPath;
+
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.commons.lang3.mutable.MutableObject;
 
@@ -541,12 +543,12 @@ public class Train {
 
 		GlobalStation destination = navigation.destination;
 		if (!navigatingManually && fullRefresh) {
-			GlobalStation preferredDestination = runtime.startCurrentInstruction();
-			if (preferredDestination != null)
-				destination = preferredDestination;
+			DiscoveredPath preferredPath = runtime.startCurrentInstruction();
+			if (preferredPath != null)
+				destination = preferredPath.destination;
 		}
 
-		navigation.startNavigation(destination, navigatingManually ? -1 : Double.MAX_VALUE, false);
+		navigation.startNavigation(navigation.findPathTo(destination, navigatingManually ? -1 : Double.MAX_VALUE));
 	}
 
 	private void tickDerailedSlowdown() {

--- a/src/main/java/com/simibubi/create/content/trains/entity/Train.java
+++ b/src/main/java/com/simibubi/create/content/trains/entity/Train.java
@@ -1040,7 +1040,7 @@ public class Train {
 	}
 
 	public static class Penalties {
-		static final int STATION = 200, STATION_WITH_TRAIN = 300;
+		static final int STATION = 50, STATION_WITH_TRAIN = 300;
 		static final int MANUAL_TRAIN = 200, IDLE_TRAIN = 700, ARRIVING_TRAIN = 50, WAITING_TRAIN = 50, ANY_TRAIN = 25,
 			RED_SIGNAL = 25, REDSTONE_RED_SIGNAL = 400;
 	}

--- a/src/main/java/com/simibubi/create/content/trains/entity/Train.java
+++ b/src/main/java/com/simibubi/create/content/trains/entity/Train.java
@@ -541,14 +541,12 @@ public class Train {
 		if (!reservedSignalBlocks.isEmpty())
 			return;
 
-		GlobalStation destination = navigation.destination;
 		if (!navigatingManually && fullRefresh) {
 			DiscoveredPath preferredPath = runtime.startCurrentInstruction();
-			if (preferredPath != null)
-				destination = preferredPath.destination;
+			if (preferredPath != null){
+				navigation.startNavigation(preferredPath);
+			}
 		}
-
-		navigation.startNavigation(navigation.findPathTo(destination, navigatingManually ? -1 : Double.MAX_VALUE));
 	}
 
 	private void tickDerailedSlowdown() {

--- a/src/main/java/com/simibubi/create/content/trains/graph/DiscoveredPath.java
+++ b/src/main/java/com/simibubi/create/content/trains/graph/DiscoveredPath.java
@@ -3,8 +3,6 @@ package com.simibubi.create.content.trains.graph;
 import com.simibubi.create.content.trains.station.GlobalStation;
 import com.simibubi.create.foundation.utility.Couple;
 
-import org.openjdk.nashorn.internal.objects.Global;
-
 import java.util.List;
 
 public class DiscoveredPath {

--- a/src/main/java/com/simibubi/create/content/trains/graph/DiscoveredPath.java
+++ b/src/main/java/com/simibubi/create/content/trains/graph/DiscoveredPath.java
@@ -1,0 +1,22 @@
+package com.simibubi.create.content.trains.graph;
+
+import com.simibubi.create.content.trains.station.GlobalStation;
+import com.simibubi.create.foundation.utility.Couple;
+
+import org.openjdk.nashorn.internal.objects.Global;
+
+import java.util.List;
+
+public class DiscoveredPath {
+	public List<Couple<TrackNode>> path;
+	public GlobalStation destination;
+	public double distance;
+	public double cost;
+
+	public DiscoveredPath(double distance, double cost, List<Couple<TrackNode>> path, GlobalStation destination) {
+		this.distance = distance;
+		this.cost = cost;
+		this.path = path;
+		this.destination = destination;
+	}
+}

--- a/src/main/java/com/simibubi/create/content/trains/schedule/ScheduleRuntime.java
+++ b/src/main/java/com/simibubi/create/content/trains/schedule/ScheduleRuntime.java
@@ -326,9 +326,9 @@ public class ScheduleRuntime {
 			return accumulatedTime;
 		if (predictionTicks.size() <= currentEntry)
 			return accumulatedTime;
-
+		
 		int departureTime = estimateStayDuration(index);
-
+		
 		if (accumulatedTime < 0) {
 			predictions.add(createPrediction(index, filter.getFilter(), currentTitle, accumulatedTime));
 			return Math.min(accumulatedTime, departureTime);
@@ -344,10 +344,10 @@ public class ScheduleRuntime {
 
 		if (accumulatedTime != TBD)
 			accumulatedTime += departureTime;
-
+		
 		if (departureTime == INVALID)
 			accumulatedTime = INVALID;
-
+		
 		return accumulatedTime;
 	}
 
@@ -375,7 +375,7 @@ public class ScheduleRuntime {
 	private TrainDeparturePrediction createPrediction(int index, String destination, String currentTitle, int time) {
 		if (time == INVALID)
 			return null;
-
+		
 		int size = schedule.entries.size();
 		if (index >= size) {
 			if (!schedule.cyclic)

--- a/src/main/java/com/simibubi/create/content/trains/schedule/ScheduleRuntime.java
+++ b/src/main/java/com/simibubi/create/content/trains/schedule/ScheduleRuntime.java
@@ -175,9 +175,8 @@ public class ScheduleRuntime {
 
 		if (instruction instanceof DestinationInstruction destination) {
 			String regex = destination.getFilterForRegex();
-			DiscoveredPath best = null;
-			double bestCost = Double.MAX_VALUE;
 			boolean anyMatch = false;
+			ArrayList<GlobalStation> validStations = new ArrayList<>();
 
 			if (!train.hasForwardConductor() && !train.hasBackwardConductor()) {
 				train.status.missingConductor();
@@ -189,23 +188,9 @@ public class ScheduleRuntime {
 				if (!globalStation.name.matches(regex))
 					continue;
 				anyMatch = true;
-				boolean matchesCurrent = train.currentStation != null && train.currentStation.equals(globalStation.id);
-				double cost;
-				DiscoveredPath path = train.navigation.findPathTo(globalStation, bestCost);
-				if (matchesCurrent) {
-					cost = 0;
-				} else {
-					cost = path == null ? -1 : path.cost;
-				}
-
-				if (cost < 0)
-					continue;
-				if (cost > bestCost)
-					continue;
-				best = path;
-				bestCost = cost;
+				validStations.add(globalStation);
 			}
-
+			DiscoveredPath best = train.navigation.findPathTo(validStations, Double.MAX_VALUE);
 			if (best == null) {
 				if (anyMatch)
 					train.status.failedNavigation();

--- a/src/main/java/com/simibubi/create/content/trains/schedule/ScheduleRuntime.java
+++ b/src/main/java/com/simibubi/create/content/trains/schedule/ScheduleRuntime.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.regex.PatternSyntaxException;
 
 import com.simibubi.create.AllItems;
 import com.simibubi.create.content.trains.display.GlobalTrainDisplayData.TrainDeparturePrediction;
@@ -183,13 +184,16 @@ public class ScheduleRuntime {
 				cooldown = INTERVAL;
 				return null;
 			}
-
-			for (GlobalStation globalStation : train.graph.getPoints(EdgePointType.STATION)) {
-				if (!globalStation.name.matches(regex))
-					continue;
-				anyMatch = true;
-				validStations.add(globalStation);
-			}
+			
+			try {
+				for (GlobalStation globalStation : train.graph.getPoints(EdgePointType.STATION)) {
+					if (!globalStation.name.matches(regex))
+						continue;
+					anyMatch = true;
+					validStations.add(globalStation);
+				}
+			} catch (PatternSyntaxException ignored) {}
+			
 			DiscoveredPath best = train.navigation.findPathTo(validStations, Double.MAX_VALUE);
 			if (best == null) {
 				if (anyMatch)

--- a/src/main/java/com/simibubi/create/content/trains/station/StationBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/trains/station/StationBlockEntity.java
@@ -13,6 +13,8 @@ import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
 
+import com.simibubi.create.content.trains.graph.DiscoveredPath;
+
 import org.jetbrains.annotations.NotNull;
 
 import com.simibubi.create.AllBlocks;
@@ -286,7 +288,7 @@ public class StationBlockEntity extends SmartBlockEntity implements ITransformab
 		BlockPos up = new BlockPos(track.getUpNormal(level, pos, state));
 		BlockPos down = new BlockPos(track.getUpNormal(level, pos, state).scale(-1));
 		int bogeyOffset = pos.distManhattan(edgePoint.getGlobalPosition()) - 1;
-		
+
 		if (!isValidBogeyOffset(bogeyOffset)) {
 			for (boolean upsideDown : Iterate.falseAndTrue) {
 				for (int i = -1; i <= 1; i++) {
@@ -374,8 +376,8 @@ public class StationBlockEntity extends SmartBlockEntity implements ITransformab
 				if (train.navigation.destination != station)
 					continue;
 
-				GlobalStation preferredDestination = train.runtime.startCurrentInstruction();
-				train.navigation.startNavigation(preferredDestination != null ? preferredDestination : station, Double.MAX_VALUE, false);
+				DiscoveredPath preferredPath = train.runtime.startCurrentInstruction();
+				train.navigation.startNavigation(preferredPath != null ? preferredPath : train.navigation.findPathTo(station, Double.MAX_VALUE));
 			}
 		}
 

--- a/src/main/java/com/simibubi/create/content/trains/station/StationBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/trains/station/StationBlockEntity.java
@@ -288,7 +288,7 @@ public class StationBlockEntity extends SmartBlockEntity implements ITransformab
 		BlockPos up = new BlockPos(track.getUpNormal(level, pos, state));
 		BlockPos down = new BlockPos(track.getUpNormal(level, pos, state).scale(-1));
 		int bogeyOffset = pos.distManhattan(edgePoint.getGlobalPosition()) - 1;
-
+		
 		if (!isValidBogeyOffset(bogeyOffset)) {
 			for (boolean upsideDown : Iterate.falseAndTrue) {
 				for (int i = -1; i <= 1; i++) {


### PR DESCRIPTION
The current implementation of scheduled train navigation can cause significant lag on very large networks, so I've made some changes that make the performance scale better with larger graphs.
1. When a destination has n possible stations, the search algorithm is run n times to find the closest station, and another time to get the path again. I've changed startCurrentInstruction() to return a DiscoveredPath instead of a GlobalStation, so the search algorithm only has to be called n times. 
2. To speed up the search algorithm, each FrontierEntry has an additional value, which is the straignt-line remaining distance to the station. This adaptation causes the PriorityQueue to check edges that go in the direction of the station first. The implementation is very similar to the [A* algorithm](https://en.wikipedia.org/wiki/A*_search_algorithm), and greatly reduces the number of edges that need to be considered in a search call.

Any reviews, feedback or suggestions are appreciated, thank you :)