### PR TITLE
Memory leak in CapManipulationBehaviourBase

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/blockEntity/behaviour/inventory/CapManipulationBehaviourBase.java
+++ b/src/main/java/com/simibubi/create/foundation/blockEntity/behaviour/inventory/CapManipulationBehaviourBase.java
@@ -7,6 +7,7 @@ import com.simibubi.create.foundation.blockEntity.behaviour.BlockEntityBehaviour
 import com.simibubi.create.foundation.blockEntity.behaviour.filtering.FilteringBehaviour;
 import com.simibubi.create.foundation.item.ItemHelper.ExtractionCountMode;
 import com.simibubi.create.foundation.utility.BlockFace;
+import com.simibubi.create.foundation.utility.HashableNonNullConsumer;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
@@ -102,7 +103,7 @@ public abstract class CapManipulationBehaviourBase<T, S extends CapManipulationB
 			amount = filter.getAmount();
 		return amount;
 	}
-	
+
 	public ExtractionCountMode getModeFromFilter() {
 		ExtractionCountMode mode = ExtractionCountMode.UPTO;
 		FilteringBehaviour filter = blockEntity.getBehaviour(FilteringBehaviour.TYPE);
@@ -128,7 +129,7 @@ public abstract class CapManipulationBehaviourBase<T, S extends CapManipulationB
 		targetCapability =
 			bypassSided ? invBE.getCapability(capability) : invBE.getCapability(capability, targetBlockFace.getFace());
 		if (targetCapability.isPresent())
-			targetCapability.addListener(this::onHandlerInvalidated);
+			targetCapability.addListener(new HashableNonNullConsumer<>(this::onHandlerInvalidated, this));
 	}
 
 	@FunctionalInterface

--- a/src/main/java/com/simibubi/create/foundation/utility/HashableNonNullConsumer.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/HashableNonNullConsumer.java
@@ -1,0 +1,35 @@
+package com.simibubi.create.foundation.utility;
+
+import java.util.Objects;
+
+import javax.annotation.Nonnull;
+
+import net.minecraftforge.common.util.NonNullConsumer;
+
+public class HashableNonNullConsumer<T, H> implements NonNullConsumer<T> {
+	private final NonNullConsumer<T> consumer;
+	private final H hashKey;
+
+	public HashableNonNullConsumer(NonNullConsumer<T> consumer, H hashKey) {
+		this.consumer = consumer;
+		this.hashKey = hashKey;
+	}
+
+	@Override
+	public void accept(@Nonnull T t) {
+		consumer.accept(t);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		HashableNonNullConsumer<?, ?> that = (HashableNonNullConsumer<?, ?>) o;
+		return Objects.equals(hashKey, that.hashKey);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(hashKey);
+	}
+}


### PR DESCRIPTION
### The leak

CapManipulationBehaviourBase causes a memory leak in findNewCapablities() by always adding new listener objects to its present target capability, which will never get removed, overwritten, or otherwise garbage collected. 
This happens because a new lambda object is allocated for the method reference every time and this object does not override equals() and hashCode(), so it always gets stored in the underlying HashSet of LazyOptional.

A Threshold Switch calls the method in CapManipulationBehaviourBase every time it gets lazy ticked, so on long running servers this causes problems (see #2949).

### Testing

Here are some spark heap dump summaries from a test world with 900 Threshold Switches to speed up the process:

![world](https://github.com/Creators-of-Create/Create/assets/16989201/21a03a4c-5dcc-4d54-9150-659637a83363)

Reference summary at world load: https://spark.lucko.me/lCidSpmy5A

After 30 minutes:
![image](https://github.com/Creators-of-Create/Create/assets/16989201/347dd0a2-8ad3-45fd-8e72-cce8c4b7b64d)
Full summary: https://spark.lucko.me/hYGHP6plT0

After an hour:
![image](https://github.com/Creators-of-Create/Create/assets/16989201/befd120a-4f72-4351-9613-e04f75322a24)
Full summary: https://spark.lucko.me/JXNTpd2m3Y

### The fix

Implementing equals() and hashCode() for the listener object to use something else as a key (in this case the CapManipulationBehaviourBase object) fixes the issue.

At world load:
![image](https://github.com/Creators-of-Create/Create/assets/16989201/643151da-dcd8-43f4-b84b-edc6aa2a70bc)
Full summary: https://spark.lucko.me/v9itUW2f6T

After 30 minutes:
![image](https://github.com/Creators-of-Create/Create/assets/16989201/dc493577-fdb6-47c5-b874-6b995928b7f5)
Full summary: https://spark.lucko.me/PuamEAgH86

### Affected versions

Judging only by the commit history of CapManipulationBehaviourBase.java and InvManipulationBehaviour.java (created at 3792e06b and 651e06a7 respectively), this bug affects all Create versions since September of 2020.