### PR TITLE
feat: use config options instead of hard coded amounts for transfer r…

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/chute/ChuteBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/chute/ChuteBlockEntity.java
@@ -485,7 +485,7 @@ public class ChuteBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 	}
 
 	protected int getExtractionAmount() {
-		return 16;
+		return AllConfigs.server().kinetics.chuteMaxItemsToTransfer.get();
 	}
 
 	protected ExtractionCountMode getExtractionMode() {

--- a/src/main/java/com/simibubi/create/content/logistics/funnel/FunnelBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/funnel/FunnelBlockEntity.java
@@ -236,10 +236,10 @@ public class FunnelBlockEntity extends SmartBlockEntity implements IHaveHovering
 
 	public int getAmountToExtract() {
 		if (!supportsAmountOnFilter())
-			return 64;
+			return AllConfigs.server().kinetics.filterMaxItemsToTransfer.get();
 		int amountToExtract = invManipulation.getAmountFromFilter();
 		if (!filtering.isActive())
-			amountToExtract = 1;
+			amountToExtract = AllConfigs.server().kinetics.funnelMaxItemsToTransfer.get();
 		return amountToExtract;
 	}
 

--- a/src/main/java/com/simibubi/create/foundation/blockEntity/behaviour/filtering/FilteringBehaviour.java
+++ b/src/main/java/com/simibubi/create/foundation/blockEntity/behaviour/filtering/FilteringBehaviour.java
@@ -23,6 +23,8 @@ import com.simibubi.create.foundation.utility.Iterate;
 import com.simibubi.create.foundation.utility.Lang;
 import com.simibubi.create.foundation.utility.VecHelper;
 
+import com.simibubi.create.infrastructure.config.AllConfigs;
+
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -72,7 +74,7 @@ public class FilteringBehaviour extends BlockEntityBehaviour implements ValueSet
 		};
 		predicate = stack -> true;
 		isActive = () -> true;
-		count = 64;
+		count = AllConfigs.server().kinetics.filterMaxItemsToTransfer.get();
 		showCountPredicate = () -> showCount;
 		recipeFilter = false;
 		fluidFilter = false;
@@ -97,14 +99,14 @@ public class FilteringBehaviour extends BlockEntityBehaviour implements ValueSet
 		filter = FilterItemStack.of(nbt.getCompound("Filter"));
 		count = nbt.getInt("FilterAmount");
 		upTo = nbt.getBoolean("UpTo");
-		
+
 		// Migrate from previous behaviour
 		if (count == 0) {
 			upTo = true;
 			count = filter.item()
 				.getMaxStackSize();
 		}
-		
+
 		super.read(nbt, clientPacket);
 	}
 
@@ -260,7 +262,9 @@ public class FilteringBehaviour extends BlockEntityBehaviour implements ValueSet
 	@Override
 	public ValueSettingsBoard createBoard(Player player, BlockHitResult hitResult) {
 		ItemStack filter = getFilter(hitResult.getDirection());
-		int maxAmount = (filter.getItem() instanceof FilterItem) ? 64 : filter.getMaxStackSize();
+		int maxAmount = (filter.getItem() instanceof FilterItem) ?
+				AllConfigs.server().kinetics.filterMaxItemsToTransfer.get()
+				: filter.getMaxStackSize();
 		return new ValueSettingsBoard(Lang.translateDirect("logistics.filter.extracted_amount"), maxAmount, 16,
 			Lang.translatedOptions("logistics.filter", "up_to", "exactly"),
 			new ValueSettingsFormatter(this::formatValue));

--- a/src/main/java/com/simibubi/create/infrastructure/config/CKinetics.java
+++ b/src/main/java/com/simibubi/create/infrastructure/config/CKinetics.java
@@ -37,6 +37,13 @@ public class CKinetics extends ConfigBase {
 	public final ConfigInt maxCartCouplingLength = i(32, 1, "maxCartCouplingLength", Comments.maxCartCouplingLength);
 	public final ConfigInt rollerFillDepth = i(12, 1, "rollerFillDepth", Comments.rollerFillDepth);
 	public final ConfigBool survivalContraptionPickup = b(true, "survivalContraptionPickup", Comments.survivalContraptionPickup);
+
+	public final ConfigInt funnelMaxItemsToTransfer = i(1, 0, "funnelMaxItemsToTransfer",
+			Comments.funnelMaxItemsToTransfer);
+	public final ConfigInt chuteMaxItemsToTransfer = i(16, 0, "chuteMaxItemsToTransfer",
+			Comments.chuteMaxItemsToTransfer);
+	public final ConfigInt filterMaxItemsToTransfer = i(64, 0, "filterMaxItemsToTransfer",
+			Comments.filterMaxItemsToTransfer);
 	public final ConfigEnum<ContraptionMovementSetting> spawnerMovement =
 		e(ContraptionMovementSetting.NO_PICKUP, "movableSpawners", Comments.spawnerMovement);
 	public final ConfigEnum<ContraptionMovementSetting> amethystMovement =
@@ -116,7 +123,15 @@ public class CKinetics extends ConfigBase {
 		static String amethystMovement = "Configure how Budding Amethyst can be moved by contraptions.";
 		static String obsidianMovement = "Configure how Obsidian blocks can be moved by contraptions.";
 		static String minecartContraptionInContainers = "Whether minecart contraptions can be placed into container items.";
+
+		static String funnelMaxItemsToTransfer = "Maximum amount of items that can be " +
+				"transferred by a single Andesite Funnel per pull";
+		static String chuteMaxItemsToTransfer = "Maximum amount of items that can be " +
+				"transferred by a single Chute per pull";
+		static String filterMaxItemsToTransfer = "Maximum amount of items that can be " +
+				"transferred by a single brass Funnel or smart Chute per pull";
 	}
+
 
 	public enum DeployerAggroSetting {
 		ALL, CREEPERS, NONE


### PR DESCRIPTION
Hi, for my modpack I needed to alter rates of chutes and funnels and didn't manage to do so with reflection through kubejs, so this pr should allow this to be configurable in the server configs instead of hardcoded for me and for anyone that needs to modify those rates.