### PR TITLE
Optional creative overlay without goggles, highly requested QoL feature.

### DIFF
--- a/src/main/java/com/simibubi/create/content/equipment/goggles/GoggleOverlayRenderer.java
+++ b/src/main/java/com/simibubi/create/content/equipment/goggles/GoggleOverlayRenderer.java
@@ -82,9 +82,9 @@ public class GoggleOverlayRenderer {
 		lastHovered = pos;
 
 		pos = proxiedOverlayPosition(world, pos);
-		
+
 		BlockEntity be = world.getBlockEntity(pos);
-		boolean wearingGoggles = GogglesItem.isWearingGoggles(mc.player);
+		boolean shouldSeeOverlay = shouldSeeOverlay(mc);
 
 		boolean hasGoggleInformation = be instanceof IHaveGoggleInformation;
 		boolean hasHoveringInformation = be instanceof IHaveHoveringInformation;
@@ -94,7 +94,7 @@ public class GoggleOverlayRenderer {
 
 		List<Component> tooltip = new ArrayList<>();
 
-		if (hasGoggleInformation && wearingGoggles) {
+		if (hasGoggleInformation && shouldSeeOverlay) {
 			IHaveGoggleInformation gte = (IHaveGoggleInformation) be;
 			goggleAddedInformation = gte.addToGoggleTooltip(tooltip, mc.player.isShiftKeyDown());
 		}
@@ -130,7 +130,7 @@ public class GoggleOverlayRenderer {
 
 		// check for piston poles if goggles are worn
 		BlockState state = world.getBlockState(pos);
-		if (wearingGoggles && AllBlocks.PISTON_EXTENSION_POLE.has(state)) {
+		if (shouldSeeOverlay && AllBlocks.PISTON_EXTENSION_POLE.has(state)) {
 			Direction[] directions = Iterate.directionsInAxis(state.getValue(PistonExtensionPoleBlock.FACING)
 				.getAxis());
 			int poles = 1;
@@ -144,7 +144,7 @@ public class GoggleOverlayRenderer {
 			}
 
 			if (!pistonFound) {
-				hoverTicks = 0;				
+				hoverTicks = 0;
 				return;
 			}
 			if (!tooltip.isEmpty())
@@ -156,7 +156,7 @@ public class GoggleOverlayRenderer {
 		}
 
 		if (tooltip.isEmpty()) {
-			hoverTicks = 0;			
+			hoverTicks = 0;
 			return;
 		}
 
@@ -211,12 +211,17 @@ public class GoggleOverlayRenderer {
 			.render(graphics);
 		poseStack.popPose();
 	}
-	
+
 	public static BlockPos proxiedOverlayPosition(Level level, BlockPos pos) {
 		BlockState targetedState = level.getBlockState(pos);
 		if (targetedState.getBlock() instanceof IProxyHoveringInformation proxy)
 			return proxy.getInformationSource(level, pos, targetedState);
 		return pos;
+	}
+
+	private static boolean shouldSeeOverlay(Minecraft mc) {
+		return GogglesItem.isWearingGoggles(mc.player)
+				|| mc.gameMode.getPlayerMode() == GameType.CREATIVE && AllConfigs.client().creativeOverlay.get();
 	}
 
 }

--- a/src/main/java/com/simibubi/create/infrastructure/config/CClient.java
+++ b/src/main/java/com/simibubi/create/infrastructure/config/CClient.java
@@ -56,6 +56,8 @@ public class CClient extends ConfigBase {
 			Comments.overlayBorderColorTop);
 	public final ConfigInt overlayBorderColorBot = i(0x50_28007f, Integer.MIN_VALUE, Integer.MAX_VALUE, "customBorderBotOverlay",
 			Comments.overlayBorderColorBot);
+	public final ConfigBool creativeOverlay = b(false, "creativeOverlay",
+			Comments.creativeOverlay);
 
 	//placement assist group
 	public final ConfigGroup placementAssist = group(1, "placementAssist",
@@ -71,7 +73,7 @@ public class CClient extends ConfigBase {
 	public final ConfigBool comfyReading = b(false, "comfyReading",
 			Comments.comfyReading);
 	public final ConfigBool editingMode = b(false, "editingMode",
-		Comments.editingMode);
+			Comments.editingMode);
 
 	//sound group
 	public final ConfigGroup sound = group(1, "sound",
@@ -140,6 +142,7 @@ public class CClient extends ConfigBase {
 				"The custom bot color of the border gradient to use for the Goggle- and Hover- Overlays, if enabled",
 				"[in Hex: #AaRrGgBb]", ConfigAnnotations.IntDisplay.HEX.asComment()
 		};
+		static String creativeOverlay = "Display goggle's overlay in Creative Mode even if you don't wear them";
 		static String placementAssist = "Settings for the Placement Assist";
 		static String[] placementIndicator = new String[]{
 				"What indicator should be used when showing where the assisted placement ends up relative to your crosshair",


### PR DESCRIPTION
This is an update to the PR #3049 for 1.20.1, previously closed due to "because grabbing goggles in creative mode feels like a non-issue"... until you actually play the game in creative and it is an issue every time you clear your inventory. No wonder this suggestion appears all the time with multiple thumbs up on discord.

This fixes an annoyance that happens all the time when playing in creative mode. It's a really simple QoL change in the code that requires no maintainability and doesn't break the game in any way. Please, consider adding it, just look for "creative overlay" on discord and you will see the demand for it.