### PR TITLE
Create netherrack.json

### DIFF
--- a/src/generated/resources/data/create/recipes/haunting/netherrack.json
+++ b/src/generated/resources/data/create/recipes/haunting/netherrack.json
@@ -1,0 +1,13 @@
+{
+  "type": "create:haunting",
+  "ingredients": [
+    {
+      "tag": "minecraft:andesite"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:netherrack"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes inability for netherrack to be automated, since netherrack is required for certain late-game recipes. 
An alternative would be to use diorite, giving it a use since andesite is a core component of create, however diorite currently requires calcite to be automated, which is not possible at this time. 

If this was an intended feature to limit the power of blaze cakes and other items then feel free to block this PR, just let me know! 