### PR TITLE
Fix Automated Brewing of Modded Potions

### DIFF
--- a/src/main/java/com/simibubi/create/content/fluids/potion/PotionMixingRecipes.java
+++ b/src/main/java/com/simibubi/create/content/fluids/potion/PotionMixingRecipes.java
@@ -97,7 +97,11 @@ public class PotionMixingRecipes {
 				FluidStack outputFluid = null;
 				for (ItemStack stack : supportedContainerStacks) {
 					if (input.test(stack)) {
-						FluidStack inputFluid = PotionFluidHandler.getFluidFromPotionItem(stack);
+						ItemStack[] stacks = input.getItems();
+						if (stacks.length == 0){
+							continue;
+						}
+						FluidStack inputFluid = PotionFluidHandler.getFluidFromPotionItem(stacks[0]);
 						if (outputFluid == null) {
 							outputFluid = PotionFluidHandler.getFluidFromPotionItem(output);
 						}

--- a/src/main/java/com/simibubi/create/content/fluids/potion/PotionMixingRecipes.java
+++ b/src/main/java/com/simibubi/create/content/fluids/potion/PotionMixingRecipes.java
@@ -102,9 +102,11 @@ public class PotionMixingRecipes {
 							continue;
 						}
 						FluidStack inputFluid = PotionFluidHandler.getFluidFromPotionItem(stacks[0]);
+						inputFluid.setAmount(1000);
 						if (outputFluid == null) {
 							outputFluid = PotionFluidHandler.getFluidFromPotionItem(output);
 						}
+						outputFluid.setAmount(1000);
 						mixingRecipes.add(createRecipe("potion_mixing_modded_" + recipeIndex++, ingredient, inputFluid, outputFluid));
 					}
 				}


### PR DESCRIPTION
Fixes #5171
Fixes #3852
Fixes #4104

### Cause
During the registration for automated brewing recipes of modded potions, getFluidFromPotionItem(ItemStack stack) is only ever called with item stacks representing potion.empty, splash_potion.empty or lingering_potion.empty, without actually consulting the recipe for the proper base potion. 

### Effect
This results in the uncraftable potion being displayed in recipes (if viewed in JEI). In practice, that meant that if any potion is given the ingredient for the modded potion, that modded potion is brewed, even if the base potion was not the correct one.

### Fixes
This PR fixes this by retrieving an ItemStack from the Ingredient input and passing this to getFluidFromPotionItem(...).
Additionally, this PR sets these recipes to use 1000 mB of the potion fluid (and resulting in 1000 mB), as this is the amount that automated brewing for vanilla recipes uses.

### Further ideas
Specifically with regard to Alex's Mobs, this mod has brewing recipes that have a non-potion as either input or output. (Lava->Lava Vision, Poison->Poisonous Essence, Poisonous Essence->Poison Resistance, Komodo Spit->Poison Resistance) An argument can be made to add compatibilty mixing recipes for these, but I've left these out of the PR for now.

#3852 is NOT fixed by this for 1.18. This fixes Ars Nouveau mixes resulting in vanilla potion outputs, but all new Ars Nouveau potions are still missing in their entirety. These mixes are fixed with this fix applied in 1.19 and 1.20.1, so the 1.18 mixes are likely on Ars Nouveau's end.