### PR TITLE
Support custom tooltip component heights.

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/gui/RemovedGuiUtils.java
+++ b/src/main/java/com/simibubi/create/foundation/gui/RemovedGuiUtils.java
@@ -188,7 +188,7 @@ public class RemovedGuiUtils {
 			if (lineNumber + 1 == titleLinesCount)
 				tooltipY += 2;
 
-			tooltipY += 10;
+			tooltipY += line.getHeight();
 		}
 
 		renderType.endBatch();


### PR DESCRIPTION
This simple change will allow mods with custom tooltip components with non-standard heights to display properly with Engineer's Goggles.  See AHilyard/Iceberg#56 and AHilyard/Iceberg#54 for one issue this will fix.