### PR TITLE
Fixed Potato Cannon Shooter Credit

### DIFF
--- a/src/main/java/com/simibubi/create/content/equipment/potatoCannon/PotatoProjectileEntity.java
+++ b/src/main/java/com/simibubi/create/content/equipment/potatoCannon/PotatoProjectileEntity.java
@@ -317,7 +317,7 @@ public class PotatoProjectileEntity extends AbstractHurtingProjectile implements
 	}
 
 	private DamageSource causePotatoDamage() {
-		return CreateDamageSources.potatoCannon(level(), getOwner(), this);
+		return CreateDamageSources.potatoCannon(level(), this, getOwner());
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
Projectile and shooter were the wrong way round in the damage method. 
This resulted in some enchantments not taking effect, no EXP, and no contribution to killed stats.
Fixes: #5699 