### PR TITLE
Compatibility recipes for The Aether, Haunted Harvest, Regions Unexplored and Vampirism

### DIFF
--- a/src/main/resources/data/create/recipes/compat/aether/crushing/ambrosium_ore.json
+++ b/src/main/resources/data/create/recipes/compat/aether/crushing/ambrosium_ore.json
@@ -1,0 +1,32 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "aether"
+    }
+  ],
+  "type": "create:crushing",
+  "ingredients": [
+    {
+      "item": "aether:ambrosium_ore"
+    }
+  ],
+  "processingTime": 150,
+  "results": [
+    {
+      "item": "aether:ambrosium_shard"
+    },
+    {
+      "chance": 0.75,
+      "item": "aether:ambrosium_shard"
+    },
+    {
+      "chance": 0.75,
+      "item": "create:experience_nugget"
+    },
+    {
+      "chance": 0.125,
+      "item": "aether:holystone"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/aether/crushing/zanite_ore.json
+++ b/src/main/resources/data/create/recipes/compat/aether/crushing/zanite_ore.json
@@ -1,0 +1,32 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "aether"
+    }
+  ],
+  "type": "create:crushing",
+  "ingredients": [
+    {
+      "item": "aether:zanite_ore"
+    }
+  ],
+  "processingTime": 350,
+  "results": [
+    {
+      "item": "aether:zanite_gemstone"
+    },
+    {
+      "chance": 0.75,
+      "item": "aether:zanite_gemstone"
+    },
+    {
+      "chance": 0.75,
+      "item": "create:experience_nugget"
+    },
+    {
+      "chance": 0.125,
+      "item": "aether:holystone"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/aether/filling/aether_grass_block.json
+++ b/src/main/resources/data/create/recipes/compat/aether/filling/aether_grass_block.json
@@ -1,0 +1,24 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "aether"
+    }
+  ],
+  "type": "create:filling",
+  "ingredients": [
+    {
+      "item": "aether:aether_dirt"
+    },
+    {
+      "amount": 500,
+      "fluid": "minecraft:water",
+      "nbt": {}
+    }
+  ],
+  "results": [
+    {
+      "item": "aether:aether_grass_block"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/aether/pressing/aether_dirt_path.json
+++ b/src/main/resources/data/create/recipes/compat/aether/pressing/aether_dirt_path.json
@@ -1,0 +1,24 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "aether"
+    }
+  ],
+  "type": "create:pressing",
+  "ingredients": [
+    [
+      {
+        "item": "aether:aether_dirt"
+      },
+      {
+        "item": "aether:aether_grass_block"
+      }
+    ]
+  ],
+  "results": [
+    {
+      "item": "aether:aether_dirt_path"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/hauntedharvest/haunting/rotten_apple.json
+++ b/src/main/resources/data/create/recipes/compat/hauntedharvest/haunting/rotten_apple.json
@@ -1,0 +1,19 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "hauntedharvest"
+    }
+  ],
+  "type": "create:haunting",
+  "ingredients": [
+    {
+      "item": "minecraft:apple"
+    }
+  ],
+  "results": [
+    {
+      "item": "hauntedharvest:rotten_apple"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/filling/peat_grass_block.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/filling/peat_grass_block.json
@@ -1,0 +1,24 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:filling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:peat_dirt"
+    },
+    {
+      "amount": 500,
+      "fluid": "minecraft:water",
+      "nbt": {}
+    }
+  ],
+  "results": [
+    {
+      "item": "regions_unexplored:peat_grass_block"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/filling/silt_grass_block.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/filling/silt_grass_block.json
@@ -1,0 +1,24 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:filling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:silt_dirt"
+    },
+    {
+      "amount": 500,
+      "fluid": "minecraft:water",
+      "nbt": {}
+    }
+  ],
+  "results": [
+    {
+      "item": "regions_unexplored:silt_grass_block"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/alpha_dandelion.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/alpha_dandelion.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:alpha_dandelion"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:yellow_dye"
+    },
+    {
+      "chance": 0.05,
+      "item": "minecraft:yellow_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/alpha_rose.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/alpha_rose.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:alpha_rose"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:red_dye"
+    },
+    {
+      "chance": 0.05,
+      "item": "minecraft:green_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/aster.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/aster.json
@@ -1,0 +1,29 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:aster"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:light_blue_dye"
+    },
+    {
+      "chance": 0.2,
+      "item": "minecraft:white_dye"
+    },
+    {
+      "chance": 0.05,
+      "item": "minecraft:light_gray_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/black_snowbelle.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/black_snowbelle.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:black_snowbelle"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:black_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/bleeding_heart.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/bleeding_heart.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:bleeding_heart"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:magenta_dye"
+    },
+    {
+      "chance": 0.1,
+      "item": "minecraft:pink_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/blue_lupine.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/blue_lupine.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:blue_lupine"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:blue_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/blue_snowbelle.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/blue_snowbelle.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:blue_snowbelle"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:blue_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/brown_snowbelle.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/brown_snowbelle.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:brown_snowbelle"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:brown_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/cactus_flower.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/cactus_flower.json
@@ -1,0 +1,29 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:cactus_flower"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:magenta_dye"
+    },
+    {
+      "chance": 0.2,
+      "item": "minecraft:purple_dye"
+    },
+    {
+      "chance": 0.1,
+      "item": "minecraft:green_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/cyan_snowbelle.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/cyan_snowbelle.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:cyan_snowbelle"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:cyan_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/daisy.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/daisy.json
@@ -1,0 +1,29 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:daisy"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:light_gray_dye"
+    },
+    {
+      "chance": 0.2,
+      "item": "minecraft:white_dye"
+    },
+    {
+      "chance": 0.05,
+      "item": "minecraft:yellow_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/day_lily.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/day_lily.json
@@ -1,0 +1,29 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:day_lily"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:orange_dye"
+    },
+    {
+      "chance": 0.1,
+      "item": "minecraft:lime_dye"
+    },
+    {
+      "chance": 0.1,
+      "item": "minecraft:red_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/dorcel.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/dorcel.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:dorcel"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:black_dye"
+    },
+    {
+      "chance": 0.1,
+      "item": "minecraft:brown_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/felicia_daisy.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/felicia_daisy.json
@@ -1,0 +1,29 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:felicia_daisy"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:light_blue_dye"
+    },
+    {
+      "chance": 0.2,
+      "item": "minecraft:blue_dye"
+    },
+    {
+      "chance": 0.05,
+      "item": "minecraft:white_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/fireweed.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/fireweed.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:fireweed"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:magenta_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/glistering_bloom.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/glistering_bloom.json
@@ -1,0 +1,29 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:glistering_bloom"
+    }
+  ],
+  "processingTime": 100,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:pink_dye"
+    },
+    {
+      "chance": 0.25,
+      "item": "minecraft:magenta_dye"
+    },
+    {
+      "chance": 0.25,
+      "item": "minecraft:light_blue_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/gray_snowbelle.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/gray_snowbelle.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:gray_snowbelle"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:gray_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/green_snowbelle.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/green_snowbelle.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:green_snowbelle"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:green_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/hibiscus.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/hibiscus.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:hibiscus"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:yellow_dye"
+    },
+    {
+      "chance": 0.2,
+      "item": "minecraft:red_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/hyssop.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/hyssop.json
@@ -1,0 +1,29 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:hyssop"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:purple_dye"
+    },
+    {
+      "chance": 0.1,
+      "item": "minecraft:magenta_dye"
+    },
+    {
+      "chance": 0.1,
+      "item": "minecraft:green_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/light_blue_snowbelle.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/light_blue_snowbelle.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:light_blue_snowbelle"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:light_blue_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/light_gray_snowbelle.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/light_gray_snowbelle.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:light_gray_snowbelle"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:light_gray_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/lime_snowbelle.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/lime_snowbelle.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:lime_snowbelle"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:lime_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/magenta_snowbelle.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/magenta_snowbelle.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:magenta_snowbelle"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:magenta_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/mallow.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/mallow.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:mallow"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:orange_dye"
+    },
+    {
+      "chance": 0.1,
+      "item": "minecraft:lime_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/orange_coneflower.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/orange_coneflower.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:orange_coneflower"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:orange_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/orange_snowbelle.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/orange_snowbelle.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:orange_snowbelle"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:orange_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/pink_lupine.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/pink_lupine.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:pink_lupine"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:pink_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/pink_snowbelle.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/pink_snowbelle.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:pink_snowbelle"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:pink_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/poppy_bush.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/poppy_bush.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:poppy_bush"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:red_dye"
+    },
+    {
+      "chance": 0.1,
+      "item": "minecraft:green_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/purple_coneflower.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/purple_coneflower.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:purple_coneflower"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:purple_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/purple_lupine.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/purple_lupine.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:purple_lupine"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:purple_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/purple_snowbelle.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/purple_snowbelle.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:purple_snowbelle"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:purple_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/red_lupine.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/red_lupine.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:red_lupine"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:red_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/red_snowbelle.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/red_snowbelle.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:red_snowbelle"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:red_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/salmon_poppy_bush.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/salmon_poppy_bush.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:salmon_poppy_bush"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:pink_dye"
+    },
+    {
+      "chance": 0.1,
+      "item": "minecraft:green_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/tassel.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/tassel.json
@@ -1,0 +1,29 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:tassel"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:light_gray_dye"
+    },
+    {
+      "chance": 0.2,
+      "item": "minecraft:white_dye"
+    },
+    {
+      "chance": 0.05,
+      "item": "minecraft:yellow_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/tsubaki.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/tsubaki.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:tsubaki"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:red_dye"
+    },
+    {
+      "chance": 0.1,
+      "item": "minecraft:green_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/waratah.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/waratah.json
@@ -1,0 +1,29 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:waratah"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:red_dye"
+    },
+    {
+      "chance": 0.2,
+      "item": "minecraft:red_dye"
+    },
+    {
+      "chance": 0.1,
+      "item": "minecraft:green_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/white_snowbelle.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/white_snowbelle.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:white_snowbelle"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:white_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/white_trillium.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/white_trillium.json
@@ -1,0 +1,29 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:white_trillium"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:light_gray_dye"
+    },
+    {
+      "chance": 0.2,
+      "item": "minecraft:white_dye"
+    },
+    {
+      "chance": 0.05,
+      "item": "minecraft:yellow_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/wilting_trillium.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/wilting_trillium.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:wilting_trillium"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:brown_dye"
+    },
+    {
+      "chance": 0.1,
+      "item": "minecraft:light_gray_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/yellow_lupine.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/yellow_lupine.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:yellow_lupine"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:yellow_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/yellow_snowbelle.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/milling/yellow_snowbelle.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:yellow_snowbelle"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 2,
+      "item": "minecraft:yellow_dye"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/mixing/peat_mud_by_mixing.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/mixing/peat_mud_by_mixing.json
@@ -1,0 +1,24 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:mixing",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:peat_dirt"
+    },
+    {
+      "amount": 250,
+      "fluid": "minecraft:water",
+      "nbt": {}
+    }
+  ],
+  "results": [
+    {
+      "item": "regions_unexplored:peat_mud"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/mixing/silt_mud_by_mixing.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/mixing/silt_mud_by_mixing.json
@@ -1,0 +1,24 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:mixing",
+  "ingredients": [
+    {
+      "item": "regions_unexplored:silt_dirt"
+    },
+    {
+      "amount": 250,
+      "fluid": "minecraft:water",
+      "nbt": {}
+    }
+  ],
+  "results": [
+    {
+      "item": "regions_unexplored:silt_mud"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/pressing/peat_dirt_path.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/pressing/peat_dirt_path.json
@@ -1,0 +1,24 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:pressing",
+  "ingredients": [
+    [
+      {
+        "item": "regions_unexplored:peat_dirt"
+      },
+      {
+        "item": "regions_unexplored:peat_grass_block"
+      }
+    ]
+  ],
+  "results": [
+    {
+      "item": "regions_unexplored:peat_dirt_path"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/regions_unexplored/pressing/silt_dirt_path.json
+++ b/src/main/resources/data/create/recipes/compat/regions_unexplored/pressing/silt_dirt_path.json
@@ -1,0 +1,24 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "regions_unexplored"
+    }
+  ],
+  "type": "create:pressing",
+  "ingredients": [
+    [
+      {
+        "item": "regions_unexplored:silt_dirt"
+      },
+      {
+        "item": "regions_unexplored:silt_grass_block"
+      }
+    ]
+  ],
+  "results": [
+    {
+      "item": "regions_unexplored:silt_dirt_path"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/vampirism/filling/cursed_grass.json
+++ b/src/main/resources/data/create/recipes/compat/vampirism/filling/cursed_grass.json
@@ -1,0 +1,24 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "vampirism"
+    }
+  ],
+  "type": "create:filling",
+  "ingredients": [
+    {
+      "item": "vampirism:cursed_earth"
+    },
+    {
+      "amount": 500,
+      "fluid": "minecraft:water",
+      "nbt": {}
+    }
+  ],
+  "results": [
+    {
+      "item": "vampirism:cursed_grass"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/compat/vampirism/pressing/cursed_earth_path.json
+++ b/src/main/resources/data/create/recipes/compat/vampirism/pressing/cursed_earth_path.json
@@ -1,0 +1,24 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "vampirism"
+    }
+  ],
+  "type": "create:pressing",
+  "ingredients": [
+    [
+      {
+        "item": "vampirism:cursed_earth"
+      },
+      {
+        "item": "vampirism:cursed_grass"
+      }
+    ]
+  ],
+  "results": [
+    {
+      "item": "vampirism:cursed_earth_path"
+    }
+  ]
+}


### PR DESCRIPTION
Some extra recipes for better compatibility with mods:  

The Aether
- Filling recipe for Aether Dirt to Aether Grass
- Pressing recipe for Aether Dirt/Grass to Aether Dirt Path
- Crushing recipes for Zanite and Ambrosium Ore

Haunted Harvest
- Haunt Apples into Rotten Apples
Note: this feature was suggested to Haunted Harvest and is still pending: https://github.com/MehVahdJukaar/TrickOrTreatMod/issues/37  
I am happy to remove this change if so desired, please let me know.

Regions Unexplored
- Filling recipes for Peat Dirt and Silt Dirt into Peat/Silt Grass
- Pressing recipes for Peat and Silt Dirt/Grass into their respective path blocks
- Mixing recipes for Peat Dirt and Silt Dirt into Peat/Silt Mud
- Milling recipes for most of the mod's flowers

Vampirism
- Filling recipe for Cursed Dirt into Cursed Grass
- Pressing recipe for Cursed Dirt/Grass into Cursed Earth Path