### PR TITLE
"Fix" NullPointerException when bounds is null

### DIFF
--- a/src/main/java/com/simibubi/create/content/schematics/client/SchematicTransformation.java
+++ b/src/main/java/com/simibubi/create/content/schematics/client/SchematicTransformation.java
@@ -44,6 +44,8 @@ public class SchematicTransformation {
 			.startWithValue(frontBack);
 		getScaleLR().chase(0, 0.45f, Chaser.EXP)
 			.startWithValue(leftRight);
+		if (bounds == null)
+			bounds = new AABB(BlockPos.ZERO, BlockPos.ZERO);
 		xOrigin = bounds.getXsize() / 2f;
 		zOrigin = bounds.getZsize() / 2f;
 


### PR DESCRIPTION
Fixes this exception:
```
java.lang.NullPointerException: Cannot invoke "net.minecraft.world.phys.AABB.m_82362_()" because "bounds" is null
	at com.simibubi.create.content.schematics.client.SchematicTransformation.init(SchematicTransformation.java:47) ~[create-1.18.2-0.5.1.f.jar%2361!/:0.5.1.f] {re:classloading}
	at com.simibubi.create.content.schematics.client.SchematicEditScreen.m_7861_(SchematicEditScreen.java:193) ~[create-1.18.2-0.5.1.f.jar%2361!/:0.5.1.f] {re:classloading}
```
I tried to figure out why `bounds` was null but I couldn't figure it out, so I added a check that makes sure that it doesn't crash when `bounds` is null