### PR TITLE
Fix #5998, Configs with the same key

### DIFF
--- a/src/main/java/com/simibubi/create/infrastructure/config/CSchematics.java
+++ b/src/main/java/com/simibubi/create/infrastructure/config/CSchematics.java
@@ -6,7 +6,7 @@ public class CSchematics extends ConfigBase {
 
 	public final ConfigBool creativePrintIncludesAir = b(false, "creativePrintIncludesAir", Comments.creativePrintIncludesAir);
 	public final ConfigInt maxSchematics = i(10, 1, "maxSchematics", Comments.maxSchematics);
-	public final ConfigInt maxTotalSchematicSize = i(256, 16, "maxSchematics", Comments.kb, Comments.maxSize);
+	public final ConfigInt maxTotalSchematicSize = i(256, 16, "maxTotalSchematicSize", Comments.kb, Comments.maxSize);
 	public final ConfigInt maxSchematicPacketSize =
 		i(1024, 256, 32767, "maxSchematicPacketSize", Comments.b, Comments.maxPacketSize);
 	public final ConfigInt schematicIdleTimeout = i(600, 100, "schematicIdleTimeout", Comments.idleTimeout);


### PR DESCRIPTION
The schematic configs had 2 configs with the same key, small fix for that (#5998)