### PR TITLE
fix deployers placing blocks when they shouldn't

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/deployer/DeployerHandler.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/deployer/DeployerHandler.java
@@ -109,8 +109,11 @@ public class DeployerHandler {
 	}
 
 	static boolean shouldActivate(ItemStack held, Level world, BlockPos targetPos, @Nullable Direction facing) {
-		if (held.getItem() instanceof BlockItem && !(world.getBlockState(targetPos).getBlock() instanceof AirBlock))
-			return false;
+		if (held.getItem() instanceof BlockItem) {
+			if (!(world.getBlockState(targetPos).getBlock() instanceof AirBlock) && !(world.getBlockState(targetPos).getMaterial().isLiquid())) {
+				return false;
+			}
+		}
 
 		if (held.getItem() instanceof BucketItem) {
 			BucketItem bucketItem = (BucketItem) held.getItem();

--- a/src/main/java/com/simibubi/create/content/kinetics/deployer/DeployerHandler.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/deployer/DeployerHandler.java
@@ -9,6 +9,8 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
+import net.minecraft.world.level.block.AirBlock;
+
 import org.apache.commons.lang3.tuple.Pair;
 
 import com.google.common.collect.Multimap;
@@ -107,10 +109,8 @@ public class DeployerHandler {
 	}
 
 	static boolean shouldActivate(ItemStack held, Level world, BlockPos targetPos, @Nullable Direction facing) {
-		if (held.getItem() instanceof BlockItem)
-			if (world.getBlockState(targetPos)
-				.getBlock() == ((BlockItem) held.getItem()).getBlock())
-				return false;
+		if (held.getItem() instanceof BlockItem && !(world.getBlockState(targetPos).getBlock() instanceof AirBlock))
+			return false;
 
 		if (held.getItem() instanceof BucketItem) {
 			BucketItem bucketItem = (BucketItem) held.getItem();


### PR DESCRIPTION
This should fix #5674. I don't know if this is the correct way to do things, but before this fix, the deployer could right click blocks and therefore place them directly in front of itself. 