### PR TITLE
Added station blockstate check

### DIFF
--- a/src/main/java/com/simibubi/create/content/trains/station/StationBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/trains/station/StationBlockEntity.java
@@ -288,7 +288,7 @@ public class StationBlockEntity extends SmartBlockEntity implements ITransformab
 		BlockPos up = new BlockPos(track.getUpNormal(level, pos, state));
 		BlockPos down = new BlockPos(track.getUpNormal(level, pos, state).scale(-1));
 		int bogeyOffset = pos.distManhattan(edgePoint.getGlobalPosition()) - 1;
-		
+
 		if (!isValidBogeyOffset(bogeyOffset)) {
 			for (boolean upsideDown : Iterate.falseAndTrue) {
 				for (int i = -1; i <= 1; i++) {
@@ -363,6 +363,10 @@ public class StationBlockEntity extends SmartBlockEntity implements ITransformab
 		tryDisassembleTrain(sender);
 		if (!tryEnterAssemblyMode())
 			return false;
+
+		//Check the station wasn't destroyed
+		if (!(level.getBlockState(worldPosition).getBlock() instanceof StationBlock))
+			return true;
 
 		BlockState newState = getBlockState().setValue(StationBlock.ASSEMBLING, true);
 		level.setBlock(getBlockPos(), newState, 3);


### PR DESCRIPTION
When a station and a train clips like so:
![image](https://github.com/Creators-of-Create/Create/assets/65340665/4e471938-84ea-4ee6-8356-38c880c4e5c0)

Deconstructing the train will break the station but the station gets replaced,
This adds an extra check to make sure this wont happen!