### PR TITLE
Big Outlines API

### DIFF
--- a/src/main/java/com/simibubi/create/content/decoration/slidingDoor/SlidingDoorBlock.java
+++ b/src/main/java/com/simibubi/create/content/decoration/slidingDoor/SlidingDoorBlock.java
@@ -7,6 +7,8 @@ import com.simibubi.create.content.contraptions.ContraptionWorld;
 import com.simibubi.create.content.equipment.wrench.IWrenchable;
 import com.simibubi.create.foundation.block.IBE;
 
+import com.simibubi.create.foundation.block.IHasBigOutline;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.InteractionHand;
@@ -36,7 +38,7 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.eventbus.api.Event.Result;
 
-public class SlidingDoorBlock extends DoorBlock implements IWrenchable, IBE<SlidingDoorBlockEntity> {
+public class SlidingDoorBlock extends DoorBlock implements IWrenchable, IBE<SlidingDoorBlockEntity>, IHasBigOutline {
 
 	public static final BooleanProperty VISIBLE = BooleanProperty.create("visible");
 	private boolean folds;

--- a/src/main/java/com/simibubi/create/content/decoration/slidingDoor/SlidingDoorBlock.java
+++ b/src/main/java/com/simibubi/create/content/decoration/slidingDoor/SlidingDoorBlock.java
@@ -7,7 +7,7 @@ import com.simibubi.create.content.contraptions.ContraptionWorld;
 import com.simibubi.create.content.equipment.wrench.IWrenchable;
 import com.simibubi.create.foundation.block.IBE;
 
-import com.simibubi.create.foundation.block.IHasBigOutline;
+import com.simibubi.create.foundation.block.IHaveBigOutline;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -38,7 +38,7 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.eventbus.api.Event.Result;
 
-public class SlidingDoorBlock extends DoorBlock implements IWrenchable, IBE<SlidingDoorBlockEntity>, IHasBigOutline {
+public class SlidingDoorBlock extends DoorBlock implements IWrenchable, IBE<SlidingDoorBlockEntity>, IHaveBigOutline {
 
 	public static final BooleanProperty VISIBLE = BooleanProperty.create("visible");
 	private boolean folds;

--- a/src/main/java/com/simibubi/create/content/trains/track/TrackBlock.java
+++ b/src/main/java/com/simibubi/create/content/trains/track/TrackBlock.java
@@ -19,6 +19,8 @@ import java.util.Random;
 import java.util.Set;
 import java.util.function.Consumer;
 
+import com.simibubi.create.foundation.block.IHasBigOutline;
+
 import org.jetbrains.annotations.Nullable;
 
 import com.google.common.base.Predicates;
@@ -108,7 +110,7 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.IBlockRenderProperties;
 
 public class TrackBlock extends Block
-	implements IBE<TrackBlockEntity>, IWrenchable, ITrackBlock, ISpecialBlockItemRequirement, ProperWaterloggedBlock {
+	implements IBE<TrackBlockEntity>, IWrenchable, ITrackBlock, ISpecialBlockItemRequirement, ProperWaterloggedBlock, IHasBigOutline {
 
 	public static final EnumProperty<TrackShape> SHAPE = EnumProperty.create("shape", TrackShape.class);
 	public static final BooleanProperty HAS_BE = BooleanProperty.create("turn");

--- a/src/main/java/com/simibubi/create/content/trains/track/TrackBlock.java
+++ b/src/main/java/com/simibubi/create/content/trains/track/TrackBlock.java
@@ -19,7 +19,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.function.Consumer;
 
-import com.simibubi.create.foundation.block.IHasBigOutline;
+import com.simibubi.create.foundation.block.IHaveBigOutline;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -110,7 +110,7 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.IBlockRenderProperties;
 
 public class TrackBlock extends Block
-	implements IBE<TrackBlockEntity>, IWrenchable, ITrackBlock, ISpecialBlockItemRequirement, ProperWaterloggedBlock, IHasBigOutline {
+	implements IBE<TrackBlockEntity>, IWrenchable, ITrackBlock, ISpecialBlockItemRequirement, ProperWaterloggedBlock, IHaveBigOutline {
 
 	public static final EnumProperty<TrackShape> SHAPE = EnumProperty.create("shape", TrackShape.class);
 	public static final BooleanProperty HAS_BE = BooleanProperty.create("turn");

--- a/src/main/java/com/simibubi/create/foundation/block/BigOutlines.java
+++ b/src/main/java/com/simibubi/create/foundation/block/BigOutlines.java
@@ -1,7 +1,5 @@
 package com.simibubi.create.foundation.block;
 
-import com.simibubi.create.content.decoration.slidingDoor.SlidingDoorBlock;
-import com.simibubi.create.content.trains.track.TrackBlock;
 import com.simibubi.create.foundation.utility.AnimationTickHolder;
 import com.simibubi.create.foundation.utility.RaycastHelper;
 import com.simibubi.create.foundation.utility.VecHelper;
@@ -47,9 +45,7 @@ public class BigOutlines {
 					p.set(pos.getX() + x, pos.getY(), pos.getZ() + z);
 					BlockState blockState = mc.level.getBlockState(p);
 
-					// Could be a dedicated interface for big blocks
-					if (!(blockState.getBlock() instanceof TrackBlock)
-						&& !(blockState.getBlock() instanceof SlidingDoorBlock))
+					if (!(blockState.getBlock() instanceof IHasBigOutline))
 						continue;
 
 					BlockHitResult hit = blockState.getInteractionShape(mc.level, p)

--- a/src/main/java/com/simibubi/create/foundation/block/BigOutlines.java
+++ b/src/main/java/com/simibubi/create/foundation/block/BigOutlines.java
@@ -17,7 +17,7 @@ import net.minecraftforge.common.ForgeMod;
 
 
 /**
- * For mods wanting to use this take a look at {@link IHasBigOutline}
+ * For mods wanting to use this take a look at {@link IHaveBigOutline}
  */
 public class BigOutlines {
 
@@ -49,7 +49,7 @@ public class BigOutlines {
 					p.set(pos.getX() + x, pos.getY(), pos.getZ() + z);
 					BlockState blockState = mc.level.getBlockState(p);
 
-					if (!(blockState.getBlock() instanceof IHasBigOutline))
+					if (!(blockState.getBlock() instanceof IHaveBigOutline))
 						continue;
 
 					BlockHitResult hit = blockState.getInteractionShape(mc.level, p)

--- a/src/main/java/com/simibubi/create/foundation/block/BigOutlines.java
+++ b/src/main/java/com/simibubi/create/foundation/block/BigOutlines.java
@@ -15,6 +15,10 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.common.ForgeMod;
 
+
+/**
+ * For mods wanting to use this take a look at {@link IHasBigOutline}
+ */
 public class BigOutlines {
 
 	static BlockHitResult result = null;

--- a/src/main/java/com/simibubi/create/foundation/block/IHasBigOutline.java
+++ b/src/main/java/com/simibubi/create/foundation/block/IHasBigOutline.java
@@ -1,0 +1,15 @@
+package com.simibubi.create.foundation.block;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import com.simibubi.create.content.trains.track.TrackBlock;
+import com.simibubi.create.content.decoration.slidingDoor.SlidingDoorBlock;
+
+/**
+ * Implementing this interface will allow you to have bigger outlines when overriding {@link BlockBehaviour#getInteractionShape(BlockState, BlockGetter, BlockPos)}
+ * <p>
+ * For examples look at {@link TrackBlock} and {@link SlidingDoorBlock}
+ */
+public interface IHasBigOutline { }

--- a/src/main/java/com/simibubi/create/foundation/block/IHaveBigOutline.java
+++ b/src/main/java/com/simibubi/create/foundation/block/IHaveBigOutline.java
@@ -12,4 +12,4 @@ import com.simibubi.create.content.decoration.slidingDoor.SlidingDoorBlock;
  * <p>
  * For examples look at {@link TrackBlock} and {@link SlidingDoorBlock}
  */
-public interface IHasBigOutline { }
+public interface IHaveBigOutline { }


### PR DESCRIPTION
Currently BigOutlines is hard coded to only work for TrackBlock and SlidingDoorBlock, this makes it hard for addons to cleanly use BigBlocks, small change allowing people to implement IHasBigOutline which will let their block's bigger outline work