### PR TITLE
Add null-safety check on usage of BlockEntity.loadStatic

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/utility/BlockHelper.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/BlockHelper.java
@@ -298,10 +298,12 @@ public class BlockHelper {
 		if (data != null) {
 			if (existingBlockEntity instanceof IMergeableBE mergeable) {
 				BlockEntity loaded = BlockEntity.loadStatic(target, state, data);
-				if (existingBlockEntity.getType()
-					.equals(loaded.getType())) {
-					mergeable.accept(loaded);
-					return;
+				if (loaded != null) {
+					if (existingBlockEntity.getType()
+						.equals(loaded.getType())) {
+						mergeable.accept(loaded);
+						return;
+					}
 				}
 			}
 			BlockEntity blockEntity = world.getBlockEntity(target);


### PR DESCRIPTION
Originally posted here: https://github.com/Fabricators-of-Create/Create/pull/1348

We identified that `loaded` sometimes comes back as `null`, we I've added a null safety check here.