### PR TITLE
fix some incorrect limit checks

### DIFF
--- a/src/main/java/com/simibubi/create/content/trains/entity/TrainRelocationPacket.java
+++ b/src/main/java/com/simibubi/create/content/trains/entity/TrainRelocationPacket.java
@@ -9,7 +9,6 @@ import com.simibubi.create.content.trains.track.BezierTrackPointLocation;
 import com.simibubi.create.foundation.networking.SimplePacketBase;
 import com.simibubi.create.foundation.utility.Lang;
 import com.simibubi.create.foundation.utility.VecHelper;
-import com.simibubi.create.infrastructure.config.AllConfigs;
 
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
@@ -82,7 +81,7 @@ public class TrainRelocationPacket extends SimplePacketBase {
 			if (!train.id.equals(cce.trainId))
 				return;
 
-			int verifyDistance = AllConfigs.server().trains.maxTrackPlacementLength.get() * 2;
+			int verifyDistance = 24;
 			if (!sender.position()
 				.closerThan(Vec3.atCenterOf(pos), verifyDistance)) {
 				Create.LOGGER.warn(messagePrefix + train.name.getString() + ": player too far from clicked pos");

--- a/src/main/java/com/simibubi/create/content/trains/track/TrackTargetingBlockItem.java
+++ b/src/main/java/com/simibubi/create/content/trains/track/TrackTargetingBlockItem.java
@@ -119,7 +119,7 @@ public class TrackTargetingBlockItem extends BlockItem {
 
 		boolean bezier = tag.contains("Bezier");
 
-		if (!selectedPos.closerThan(placedPos, bezier ? 64 + 16 : 16)) {
+		if (!selectedPos.closerThan(placedPos, 16)) {
 			player.displayClientMessage(Lang.translateDirect("track_target.too_far")
 				.withStyle(ChatFormatting.RED), true);
 			return InteractionResult.FAIL;
@@ -140,10 +140,10 @@ public class TrackTargetingBlockItem extends BlockItem {
 			itemInHand.setTag(null);
 		player.displayClientMessage(Lang.translateDirect("track_target.success")
 			.withStyle(ChatFormatting.GREEN), true);
-		
+
 		if (type == EdgePointType.SIGNAL)
 			AllAdvancements.SIGNAL.awardTo(player);
-		
+
 		return useOn;
 	}
 

--- a/src/main/java/com/simibubi/create/content/trains/track/TrackTargetingBlockItem.java
+++ b/src/main/java/com/simibubi/create/content/trains/track/TrackTargetingBlockItem.java
@@ -117,15 +117,13 @@ public class TrackTargetingBlockItem extends BlockItem {
 		BlockPos placedPos = pos.relative(pContext.getClickedFace(), state.getMaterial()
 			.isReplaceable() ? 0 : 1);
 
-		boolean bezier = tag.contains("Bezier");
-
 		if (!selectedPos.closerThan(placedPos, 16)) {
 			player.displayClientMessage(Lang.translateDirect("track_target.too_far")
 				.withStyle(ChatFormatting.RED), true);
 			return InteractionResult.FAIL;
 		}
 
-		if (bezier)
+		if (tag.contains("Bezier"))
 			teTag.put("Bezier", tag.getCompound("Bezier"));
 
 		teTag.put("TargetTrack", NbtUtils.writeBlockPos(selectedPos.subtract(placedPos)));


### PR DESCRIPTION
- on clients, the maximum distance that you can relocate a train is 24 blocks, but on the server, it is two times the maximum track placement distance (which by default is 32). I've standarized it so both are 24 now.
- For some reason, the game checks when you place a [`TrackTargetingBlockItem`](https://github.com/Creators-of-Create/Create/blob/mc1.18/dev/src/main/java/com/simibubi/create/content/trains/track/TrackTargetingBlockItem.java) if the targeted track is a curve or not, and allows you to place the block up to 80 blocks away if it is on a curve (compared to 16 when on a straight). I've also corrected this so both are 16.