### PR TITLE
Removed BOP Cherry Compat

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/data/recipe/CuttingRecipeGen.java
+++ b/src/main/java/com/simibubi/create/foundation/data/recipe/CuttingRecipeGen.java
@@ -103,7 +103,7 @@ public class CuttingRecipeGen extends ProcessingRecipeGen {
 		ECO_3 = stripAndMakePlanks(Mods.ECO, "flowering_azalea_wood", "stripped_azalea_wood", null),
 
 		// Biomes O' Plenty
-		BOP = cuttingCompat(Mods.BOP, "fir", "redwood", "cherry", "mahogany", "jacaranda", "palm", "willow", "dead",
+		BOP = cuttingCompat(Mods.BOP, "fir", "redwood", "mahogany", "jacaranda", "palm", "willow", "dead",
 			"magic", "umbran", "hellbark"),
 
 		// Blue Skies (crystallized does not have stripped variants)


### PR DESCRIPTION
BOP doesn't have cherry trees anymore size Minecraft 1.20 introduced Cherry trees.

Fixes error message: "Parsing error loading recipe create:cutting/compat/biomesoplenty/stripped_cherry_log
com.google.gson.JsonSyntaxException: Unknown item 'biomesoplenty:stripped_cherry_log'"