### PR TITLE
Fix an NPE during processing MergeableBE

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/utility/BlockHelper.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/BlockHelper.java
@@ -298,10 +298,12 @@ public class BlockHelper {
 		if (data != null) {
 			if (existingBlockEntity instanceof IMergeableBE mergeable) {
 				BlockEntity loaded = BlockEntity.loadStatic(target, state, data);
-				if (existingBlockEntity.getType()
-					.equals(loaded.getType())) {
-					mergeable.accept(loaded);
-					return;
+				if (loaded != null) {
+					if (existingBlockEntity.getType()
+							.equals(loaded.getType())) {
+						mergeable.accept(loaded);
+						return;
+					}
 				}
 			}
 			BlockEntity blockEntity = world.getBlockEntity(target);


### PR DESCRIPTION
## Issue description

when putting "large_water_wheel" into the container of a schemanticannon
and let it throw it out based on the blueprint, 
it may have a chance to trigger an NPE like the one below:

```java
java.lang.NullPointerException: Cannot invoke "net.minecraft.world.level.block.entity.BlockEntity.m_58903_()" because "loaded" is null
	at com.simibubi.create.foundation.utility.BlockHelper.placeSchematicBlock(BlockHelper.java:302) ~[create-1.18.2-0.5.1.f-all.jar%2378!/:0.5.1.f] {re:classloading}
	at com.simibubi.create.content.schematics.cannon.LaunchedItem$ForBlockState.place(LaunchedItem.java:126) ~[create-1.18.2-0.5.1.f-all.jar%2378!/:0.5.1.f] {re:classloading}
	at com.simibubi.create.content.schematics.cannon.LaunchedItem.update(LaunchedItem.java:60) ~[create-1.18.2-0.5.1.f-all.jar%2378!/:0.5.1.f] {re:classloading}
	at com.simibubi.create.content.schematics.cannon.SchematicannonBlockEntity.tickFlyingBlocks(SchematicannonBlockEntity.java:641) ~[create-1.18.2-0.5.1.f-all.jar%2378!/:0.5.1.f] {re:classloading,pl:runtimedistcleaner:A}
	at com.simibubi.create.content.schematics.cannon.SchematicannonBlockEntity.tick(SchematicannonBlockEntity.java:272) ~[create-1.18.2-0.5.1.f-all.jar%2378!/:0.5.1.f] {re:classloading,pl:runtimedistcleaner:A}
	at com.simibubi.create.foundation.blockEntity.SmartBlockEntityTicker.m_155252_(SmartBlockEntityTicker.java:15) ~[create-1.18.2-0.5.1.f-all.jar%2378!/:0.5.1.f] {re:classloading}
	at net.minecraft.world.level.chunk.LevelChunk$BoundTickingBlockEntity.m_142224_(LevelChunk.java:757) ~[server-1.18.2-20220404.173914-srg.jar%23137!/:?] {re:classloading}
	at net.minecraft.world.level.chunk.LevelChunk$RebindableTickingBlockEntityWrapper.m_142224_(LevelChunk.java:855) ~[server-1.18.2-20220404.173914-srg.jar%23137!/:?] {re:classloading}
	at net.minecraft.world.level.Level.redirect$znb000$redirectTick(Level.java:1398) ~[server-1.18.2-20220404.173914-srg.jar%23137!/:?] {re:mixin,pl:accesstransformer:B,xf:fml:beefix:Level,re:classloading,pl:accesstransformer:B,xf:fml:beefix:Level,pl:mixin:APP:observable.common.json:LevelMixin,pl:mixin:A}
	at net.minecraft.world.level.Level.m_46463_(Level.java:734) ~[server-1.18.2-20220404.173914-srg.jar%23137!/:?] {re:mixin,pl:accesstransformer:B,xf:fml:beefix:Level,re:classloading,pl:accesstransformer:B,xf:fml:beefix:Level,pl:mixin:APP:observable.common.json:LevelMixin,pl:mixin:A}
	at net.minecraft.server.level.ServerLevel.m_8793_(ServerLevel.java:449) ~[server-1.18.2-20220404.173914-srg.jar%23137!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:blueprint.mixins.json:ServerLevelMixin,pl:mixin:APP:observable.common.json:ServerLevelMixin,pl:mixin:APP:create.mixins.json:accessor.ServerLevelAccessor,pl:mixin:A}
	at net.minecraft.server.MinecraftServer.m_5703_(MinecraftServer.java:1229) ~[server-1.18.2-20220404.173914-srg.jar%23137!/:?] {re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:balm.mixins.json:MinecraftServerMixin,pl:mixin:A}
	at net.minecraft.server.dedicated.DedicatedServer.m_5703_(DedicatedServer.java:397) ~[server-1.18.2-20220404.173914-srg.jar%23137!/:?] {re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:blueprint.mixins.json:DedicatedServerMixin,pl:mixin:A}
	at net.minecraft.server.MinecraftServer.m_5705_(MinecraftServer.java:1144) ~[server-1.18.2-20220404.173914-srg.jar%23137!/:?] {re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:balm.mixins.json:MinecraftServerMixin,pl:mixin:A}
	at net.minecraft.server.MinecraftServer.m_130011_(MinecraftServer.java:984) ~[server-1.18.2-20220404.173914-srg.jar%23137!/:?] {re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:balm.mixins.json:MinecraftServerMixin,pl:mixin:A}
	at net.minecraft.server.MinecraftServer.m_177918_(MinecraftServer.java:344) ~[server-1.18.2-20220404.173914-srg.jar%23137!/:?] {re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:balm.mixins.json:MinecraftServerMixin,pl:mixin:A}
	at java.lang.Thread.run(Thread.java:833) [?:?] {re:mixin}
```

and this will crash the server when each time to load the chunk with this schematicannon
so there is a fix below for letting schematicannon able to continue and process with the mergeable water wheel
and tested successfully without further crashes, the related blueprint can continue to proceed
