### PR TITLE
Use safer fluidstack comparisons

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/fluid/FluidIngredient.java
+++ b/src/main/java/com/simibubi/create/foundation/fluid/FluidIngredient.java
@@ -152,8 +152,7 @@ public abstract class FluidIngredient implements Predicate<FluidStack> {
 
 		@Override
 		protected boolean testInternal(FluidStack t) {
-			if (!t.getFluid()
-				.isSame(fluid))
+			if (t.getFluid() != fluid)
 				return false;
 			if (tagToMatch.isEmpty())
 				return true;
@@ -206,7 +205,7 @@ public abstract class FluidIngredient implements Predicate<FluidStack> {
 		protected boolean testInternal(FluidStack t) {
 			if (tag == null) {
 				for (FluidStack accepted : getMatchingFluidStacks())
-					if (accepted.isFluidEqual(t))
+					if (accepted.getFluid() != t.getFluid())
 						return true;
 				return false;
 			}

--- a/src/main/java/com/simibubi/create/foundation/fluid/FluidIngredient.java
+++ b/src/main/java/com/simibubi/create/foundation/fluid/FluidIngredient.java
@@ -206,8 +206,7 @@ public abstract class FluidIngredient implements Predicate<FluidStack> {
 		protected boolean testInternal(FluidStack t) {
 			if (tag == null) {
 				for (FluidStack accepted : getMatchingFluidStacks())
-					if (accepted.getFluid()
-						.isSame(t.getFluid()))
+					if (accepted.isFluidEqual(t))
 						return true;
 				return false;
 			}


### PR DESCRIPTION
`isSame` I viewed as more like "isSameForRendering" as vanilla uses it mainly for rendering fluid comparisons.
![image](https://github.com/Creators-of-Create/Create/assets/40846040/21a3bdb6-9ebd-4171-b1b1-7de5d2568d91)

As a result, I have Sugar Water that I wanted to be seen as equivalent to vanilla Water when the two are next to each other and adjusting `isSame` to return true for each other when given the other was the best way to go about that. As shown above, it is much easier to adjust `isSame` than for me to add over 10 mixins all over the place to achieve this result:
<img src="https://github.com/Creators-of-Create/Create/assets/40846040/1806eaef-2dc8-48e3-823c-60c2639ca84d" width="600" />
<img src="https://github.com/Creators-of-Create/Create/assets/40846040/a7b2e8c2-36cd-4bda-b838-c2deeaa36f00" width="600" />

Without the `isSame` adjustment, it would look like this:
<img src="https://github.com/Creators-of-Create/Create/assets/40846040/cd6f2e8d-5b07-4f87-a3ec-9bc5a8bbe053" width="600" />
<img src="https://github.com/Creators-of-Create/Create/assets/40846040/913a18c1-4c57-4c3d-8b5e-48b71ab55b91" width="600" />

I also do the same for my Honey Fluid and Royal Jelly Fluid so my two honey fluids see each other the same for rendering purposes like above (it doesn't see other mod's honey fluids as equivalent).

So coming back to Create, using `isSame` for recipe fluidstack comparisons is not a safe assumption as it is very easy to make fluids see different fluids as `isSame` true and may have very good reasons for it.

Instead, on Forge/NeoForge, you should use FluidStack$isFluidEqual or FluidStack$getFluid with equality check. isFluidEqual will compare the fluidstack nbt tags too to make sure they match. To keep the PR close to old behavior without the nbt check, I opted for the getFluid with equality check. This should prevent the recipe from confusing different fluids as valid if modders makes `isSame` return true for different fluids for rendering purposes.