### PR TITLE
fix: unbounded acceleration when approaching station

### DIFF
--- a/src/main/java/com/simibubi/create/content/trains/entity/Navigation.java
+++ b/src/main/java/com/simibubi/create/content/trains/entity/Navigation.java
@@ -266,7 +266,7 @@ public class Navigation {
 		if (targetDistance < 10) {
 			double target = topSpeed * ((targetDistance) / 10);
 			if (target < Math.abs(train.speed)) {
-				train.speed += (target - Math.abs(train.speed)) * .5f * speedMod;
+				train.speed += (target - Math.abs(train.speed)) * .5f * Math.signum(train.speed);
 				return;
 			}
 		}


### PR DESCRIPTION
If the `trainTopSpeed` config was set very low (about 1.4 or so), and you backed out of a station, and, while the train was still going backwards, tapped forward and held in space to approach the station, the train would accelerate backwards at an increasing rate. This is because the acceleration introduced to counter a speed above the target did not take into account the direction the train was actually moving, but rather the direction of the station.