### PR TITLE
Minor ClipboardCloneable outline renderer oversight

### DIFF
--- a/src/main/java/com/simibubi/create/content/equipment/clipboard/ClipboardValueSettingsHandler.java
+++ b/src/main/java/com/simibubi/create/content/equipment/clipboard/ClipboardValueSettingsHandler.java
@@ -58,7 +58,8 @@ public class ClipboardValueSettingsHandler {
 		if (!smartBE.getAllBehaviours()
 			.stream()
 			.anyMatch(b -> b instanceof ClipboardCloneable cc
-				&& cc.writeToClipboard(new CompoundTag(), target.getDirection())))
+				&& cc.writeToClipboard(new CompoundTag(), target.getDirection()))
+				&& !(smartBE instanceof ClipboardCloneable))
 			return;
 
 		VoxelShape shape = blockstate.getShape(mc.level, pos);


### PR DESCRIPTION
Outline renderer only checks the Smart BE's behaviors for implementing ClipboardCloneable, missing any BEs which implement it directly