### PR TITLE
Allow Redstone Power to be transmitted through Encased Shafts

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/base/AbstractEncasedShaftBlock.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/base/AbstractEncasedShaftBlock.java
@@ -24,11 +24,6 @@ public abstract class AbstractEncasedShaftBlock extends RotatedPillarKineticBloc
     }
 
     @Override
-    public boolean shouldCheckWeakPower(BlockState state, LevelReader world, BlockPos pos, Direction side) {
-        return false;
-    }
-
-    @Override
     public PushReaction getPistonPushReaction(@Nullable BlockState state) {
         return PushReaction.NORMAL;
     }


### PR DESCRIPTION
Fixes #6365 

dev note: This exception did appear to be intentionally added so if there is any reason this should not be fixed, feel free to close this pr. The bug was, however, labeled as 'confirmed', so I felt that this would be a good change to implement