### PR TITLE
Fix Filters not Respecting 'Respect Data' option

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/filter/FilterItemStack.java
+++ b/src/main/java/com/simibubi/create/content/logistics/filter/FilterItemStack.java
@@ -128,7 +128,7 @@ public class FilterItemStack {
 					containedItems.add(FilterItemStack.of(stackInSlot));
 			}
 
-			shouldRespectNBT = !defaults ? false
+			shouldRespectNBT = defaults ? false
 				: filter.getTag()
 					.getBoolean("RespectNBT");
 			isBlacklist = defaults ? false


### PR DESCRIPTION
Fixes #5780
This PR applies the same fix as #5971 which I've closed due to an accidentally introduced merge commit that'd clutter the git history. This PR further only edits the relevant line and doesn't randomly change some tabs for empty lines, which snuck in via Intellij.

### Cause
The assignment for shouldRespectNBT has a negation applied to whether the defaults should be used, ensuring this is always set to false

### Fix
Removed the negation