### PR TITLE
Forced Goggle Overlay API

### DIFF
--- a/src/main/java/com/simibubi/create/content/equipment/goggles/GoggleOverlayRenderer.java
+++ b/src/main/java/com/simibubi/create/content/equipment/goggles/GoggleOverlayRenderer.java
@@ -57,8 +57,7 @@ public class GoggleOverlayRenderer {
 		if (mc.options.hideGui || mc.gameMode.getPlayerMode() == GameType.SPECTATOR)
 			return;
 
-		HitResult objectMouseOver = mc.hitResult;
-		if (!(objectMouseOver instanceof BlockHitResult)) {
+		if (!(mc.hitResult instanceof BlockHitResult result)) {
 			lastHovered = null;
 			hoverTicks = 0;
 			return;
@@ -72,7 +71,6 @@ public class GoggleOverlayRenderer {
 				return;
 		}
 
-		BlockHitResult result = (BlockHitResult) objectMouseOver;
 		ClientLevel world = mc.level;
 		BlockPos pos = result.getBlockPos();
 
@@ -95,12 +93,15 @@ public class GoggleOverlayRenderer {
 
 		List<Component> tooltip = new ArrayList<>();
 
-		if (hasGoggleInformation && wearingGoggles) {
-			boolean isShifting = mc.player.isShiftKeyDown();
-
+		if (hasGoggleInformation) {
 			IHaveGoggleInformation gte = (IHaveGoggleInformation) be;
-			goggleAddedInformation = gte.addToGoggleTooltip(tooltip, isShifting);
-			item = gte.getIcon(isShifting);
+
+			if (wearingGoggles || gte.forcedGoggleOverlay()) {
+				boolean isShifting = mc.player.isShiftKeyDown();
+
+				goggleAddedInformation = gte.addToGoggleTooltip(tooltip, isShifting);
+				item = gte.getIcon(isShifting);
+			}
 		}
 
 		if (hasHoveringInformation) {

--- a/src/main/java/com/simibubi/create/content/equipment/goggles/IHaveGoggleInformation.java
+++ b/src/main/java/com/simibubi/create/content/equipment/goggles/IHaveGoggleInformation.java
@@ -53,6 +53,16 @@ public interface IHaveGoggleInformation {
 		return AllItems.GOGGLES.asStack();
 	}
 
+	/**
+	 * this method will be called when looking at a BlockEntity that implemented this
+	 * interface
+	 * <p>
+	 * return true if the goggle overlay should show up no matter what, even when goggle wearing predicates aren't true.
+	 */
+	default boolean forcedGoggleOverlay() {
+		return false;
+	}
+
 	default boolean containedFluidTooltip(List<Component> tooltip, boolean isPlayerSneaking,
 		LazyOptional<IFluidHandler> handler) {
 		Optional<IFluidHandler> resolve = handler.resolve();


### PR DESCRIPTION
Allows overriding a method to force the goggle overlay to show even when not wearing goggles (or when the goggle predicates aren't true)