### PR TITLE
Fix concurrency issue in Creative Tabs System

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/data/CreateRegistrate.java
+++ b/src/main/java/com/simibubi/create/foundation/data/CreateRegistrate.java
@@ -2,6 +2,7 @@ package com.simibubi.create.foundation.data;
 
 import static com.simibubi.create.foundation.data.TagGen.pickaxeOnly;
 
+import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
@@ -52,7 +53,7 @@ import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.registries.RegistryObject;
 
 public class CreateRegistrate extends AbstractRegistrate<CreateRegistrate> {
-	private static final Map<RegistryEntry<?>, RegistryObject<CreativeModeTab>> TAB_LOOKUP = new IdentityHashMap<>();
+	private static final Map<RegistryEntry<?>, RegistryObject<CreativeModeTab>> TAB_LOOKUP = Collections.synchronizedMap(new IdentityHashMap<>());
 
 	@Nullable
 	protected Function<Item, TooltipModifier> currentTooltipModifierFactory;

--- a/src/main/java/com/simibubi/create/foundation/data/CreateRegistrate.java
+++ b/src/main/java/com/simibubi/create/foundation/data/CreateRegistrate.java
@@ -2,9 +2,8 @@ package com.simibubi.create.foundation.data;
 
 import static com.simibubi.create.foundation.data.TagGen.pickaxeOnly;
 
-import java.util.Collections;
-import java.util.IdentityHashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -53,7 +52,7 @@ import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.registries.RegistryObject;
 
 public class CreateRegistrate extends AbstractRegistrate<CreateRegistrate> {
-	private static final Map<RegistryEntry<?>, RegistryObject<CreativeModeTab>> TAB_LOOKUP = Collections.synchronizedMap(new IdentityHashMap<>());
+	private static final Map<RegistryEntry<?>, RegistryObject<CreativeModeTab>> TAB_LOOKUP = new ConcurrentHashMap<>();
 
 	@Nullable
 	protected Function<Item, TooltipModifier> currentTooltipModifierFactory;


### PR DESCRIPTION
Fixes #6222

Forge's parallel/concurrent mod loading causes multiple mods to insert into this hashmap at the same time, switching to a synchronized map will make this thread safe.