### PR TITLE
Make hardcoded basin checks use tags (1.19.2)

### DIFF
--- a/src/generated/resources/.cache/8e794e243511ea3d808ffb90a97ef5ee71d8d5f9
+++ b/src/generated/resources/.cache/8e794e243511ea3d808ffb90a97ef5ee71d8d5f9
@@ -1,4 +1,4 @@
-// 1.19.2	2023-11-02T11:38:33.5419266	Registrate Provider for create [Recipes, Advancements, Loot tables, Tags (blocks), Tags (items), Tags (fluids), Tags (entity_types), Blockstates, Item models, Lang (en_us/en_ud)]
+// 1.19.2	2024-04-27T13:48:48.3457557	Registrate Provider for create [Recipes, Advancements, Loot tables, Tags (blocks), Tags (items), Tags (fluids), Tags (entity_types), Blockstates, Item models, Lang (en_us/en_ud)]
 60bbdf92d2ac9824ea6144955c74043a6005f79d assets/create/blockstates/acacia_window.json
 6a67703c2697d81b7dc83e9d72a66f9c9ff08383 assets/create/blockstates/acacia_window_pane.json
 c3ae87b62e81d8e9476eccd793bb1548d74c66a1 assets/create/blockstates/adjustable_chain_gearshift.json
@@ -4166,6 +4166,7 @@ d17cb8ef2ef82e1c264fb2c8d5314c3b42cf2e28 data/create/recipes/warped_window_pane.
 93c61ebeda451ebeb37c3047459f95f14fa9f1f9 data/create/recipes/weathered_copper_tile_slab_from_weathered_copper_tiles_stonecutting.json
 fd2aaa5ab155c675e7ef4c143106428f181056af data/create/recipes/weathered_copper_tile_stairs.json
 f1a03ac86925e26cbec6aeeada2eafb40008fc8e data/create/recipes/weathered_copper_tile_stairs_from_weathered_copper_tiles_stonecutting.json
+95c7102fb3c0ecb6d4c60a3ea9abaea8ce44ace9 data/create/tags/blocks/basin.json
 8b98a671e80724e815a3af0c3764d760e4170e02 data/create/tags/blocks/brittle.json
 8b6c0b444b15f7fb2d55b9cbcb68537c1269f877 data/create/tags/blocks/casing.json
 35133e95f1c8fdd7a1c21afcc231fc0bffefb9a8 data/create/tags/blocks/contraption_inventory_deny.json

--- a/src/generated/resources/data/create/tags/blocks/basin.json
+++ b/src/generated/resources/data/create/tags/blocks/basin.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "create:basin"
+  ]
+}

--- a/src/main/java/com/simibubi/create/AllBlocks.java
+++ b/src/main/java/com/simibubi/create/AllBlocks.java
@@ -692,6 +692,7 @@ public class AllBlocks {
 		.transform(pickaxeOnly())
 		.blockstate(new BasinGenerator()::generate)
 		.addLayer(() -> RenderType::cutoutMipped)
+		.tag(AllBlockTags.BASIN.tag)
 		.onRegister(movementBehaviour(new BasinMovementBehaviour()))
 		.item()
 		.transform(customItemModel("_", "block"))

--- a/src/main/java/com/simibubi/create/AllTags.java
+++ b/src/main/java/com/simibubi/create/AllTags.java
@@ -52,7 +52,7 @@ public class AllTags {
 	}
 
 	public enum NameSpace {
-		
+
 		MOD(Create.ID, false, true),
 		FORGE("forge"),
 		TIC("tconstruct"),
@@ -76,7 +76,7 @@ public class AllTags {
 	}
 
 	public enum AllBlockTags {
-		
+
 		BRITTLE,
 		CASING,
 		CONTRAPTION_INVENTORY_DENY,
@@ -100,6 +100,7 @@ public class AllTags {
 		VALVE_HANDLES,
 		WINDMILL_SAILS,
 		WRENCH_PICKUP,
+		BASIN,
 
 		RELOCATION_NOT_SUPPORTED(FORGE),
 		WG_STONE(FORGE),
@@ -153,11 +154,11 @@ public class AllTags {
 		}
 
 		private static void init() {}
-		
+
 	}
 
 	public enum AllItemTags {
-		
+
 		BLAZE_BURNER_FUEL_REGULAR(MOD, "blaze_burner_fuel/regular"),
 		BLAZE_BURNER_FUEL_SPECIAL(MOD, "blaze_burner_fuel/special"),
 		CASING,
@@ -224,11 +225,11 @@ public class AllTags {
 		}
 
 		private static void init() {}
-		
+
 	}
 
 	public enum AllFluidTags {
-		
+
 		BOTTOMLESS_ALLOW(MOD, "bottomless/allow"),
 		BOTTOMLESS_DENY(MOD, "bottomless/deny"),
 		FAN_PROCESSING_CATALYSTS_BLASTING(MOD, "fan_processing_catalysts/blasting"),
@@ -279,9 +280,9 @@ public class AllTags {
 		}
 
 		private static void init() {}
-		
+
 	}
-	
+
 	public enum AllEntityTags {
 
 		BLAZE_BURNER_CAPTURABLE,
@@ -327,9 +328,9 @@ public class AllTags {
 		}
 
 		private static void init() {}
-		
+
 	}
-	
+
 	public enum AllRecipeSerializerTags {
 
 		AUTOMATION_IGNORE,

--- a/src/main/java/com/simibubi/create/content/fluids/particle/BasinFluidParticle.java
+++ b/src/main/java/com/simibubi/create/content/fluids/particle/BasinFluidParticle.java
@@ -2,7 +2,7 @@ package com.simibubi.create.content.fluids.particle;
 
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import com.mojang.math.Quaternion;
-import com.simibubi.create.AllBlocks;
+import com.simibubi.create.AllTags;
 import com.simibubi.create.content.processing.basin.BasinBlockEntity;
 import com.simibubi.create.foundation.utility.VecHelper;
 
@@ -56,7 +56,7 @@ public class BasinFluidParticle extends FluidStackParticle {
 			: 1 / 8f * (1 - ((Math.abs(age - (lifetime / 2)) / (1f * lifetime))));
 
 		if (age % 2 == 0) {
-			if (!AllBlocks.BASIN.has(level.getBlockState(basinPos))) {
+			if (!AllTags.AllBlockTags.BASIN.matches(level.getBlockState(basinPos))) {
 				remove();
 				return;
 			}

--- a/src/main/java/com/simibubi/create/content/kinetics/mechanicalArm/AllArmInteractionPointTypes.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/mechanicalArm/AllArmInteractionPointTypes.java
@@ -8,6 +8,7 @@ import javax.annotation.Nullable;
 import org.apache.commons.lang3.mutable.MutableBoolean;
 
 import com.simibubi.create.AllBlocks;
+import com.simibubi.create.AllTags;
 import com.simibubi.create.Create;
 import com.simibubi.create.content.kinetics.base.KineticBlockEntity;
 import com.simibubi.create.content.kinetics.belt.BeltBlockEntity;
@@ -96,7 +97,7 @@ public class AllArmInteractionPointTypes {
 
 		@Override
 		public boolean canCreatePoint(Level level, BlockPos pos, BlockState state) {
-			return AllBlocks.BASIN.has(state);
+			return AllTags.AllBlockTags.BASIN.matches(state);
 		}
 
 		@Override

--- a/src/main/java/com/simibubi/create/content/kinetics/mixer/MechanicalMixerBlock.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/mixer/MechanicalMixerBlock.java
@@ -1,8 +1,8 @@
 package com.simibubi.create.content.kinetics.mixer;
 
 import com.simibubi.create.AllBlockEntityTypes;
-import com.simibubi.create.AllBlocks;
 import com.simibubi.create.AllShapes;
+import com.simibubi.create.AllTags;
 import com.simibubi.create.content.kinetics.base.KineticBlock;
 import com.simibubi.create.content.kinetics.simpleRelays.ICogWheel;
 import com.simibubi.create.foundation.block.IBE;
@@ -28,7 +28,7 @@ public class MechanicalMixerBlock extends KineticBlock implements IBE<Mechanical
 
 	@Override
 	public boolean canSurvive(BlockState state, LevelReader worldIn, BlockPos pos) {
-		return !AllBlocks.BASIN.has(worldIn.getBlockState(pos.below()));
+		return !AllTags.AllBlockTags.BASIN.matches(worldIn.getBlockState(pos.below()));
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/kinetics/press/MechanicalPressBlock.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/press/MechanicalPressBlock.java
@@ -3,6 +3,7 @@ package com.simibubi.create.content.kinetics.press;
 import com.simibubi.create.AllBlockEntityTypes;
 import com.simibubi.create.AllBlocks;
 import com.simibubi.create.AllShapes;
+import com.simibubi.create.AllTags;
 import com.simibubi.create.content.kinetics.base.HorizontalKineticBlock;
 import com.simibubi.create.foundation.block.IBE;
 
@@ -37,7 +38,7 @@ public class MechanicalPressBlock extends HorizontalKineticBlock implements IBE<
 
 	@Override
 	public boolean canSurvive(BlockState state, LevelReader worldIn, BlockPos pos) {
-		return !AllBlocks.BASIN.has(worldIn.getBlockState(pos.below()));
+		return !AllTags.AllBlockTags.BASIN.matches(worldIn.getBlockState(pos.below()));
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/kinetics/press/PressingBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/press/PressingBehaviour.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import com.simibubi.create.AllBlocks;
 import com.simibubi.create.AllSoundEvents;
+import com.simibubi.create.AllTags;
 import com.simibubi.create.content.kinetics.belt.behaviour.BeltProcessingBehaviour;
 import com.simibubi.create.content.kinetics.belt.behaviour.TransportedItemStackHandlerBehaviour;
 import com.simibubi.create.content.kinetics.belt.transport.TransportedItemStack;
@@ -144,7 +145,7 @@ public class PressingBehaviour extends BeltProcessingBehaviour {
 					if (BlockEntityBehaviour.get(level, worldPosition.below(2),
 						TransportedItemStackHandlerBehaviour.TYPE) != null)
 						return;
-					if (AllBlocks.BASIN.has(level.getBlockState(worldPosition.below(2))))
+					if (AllTags.AllBlockTags.BASIN.matches(level.getBlockState(worldPosition.below(2))))
 						return;
 
 					for (ItemEntity itemEntity : level.getEntitiesOfClass(ItemEntity.class,

--- a/src/main/java/com/simibubi/create/content/processing/AssemblyOperatorBlockItem.java
+++ b/src/main/java/com/simibubi/create/content/processing/AssemblyOperatorBlockItem.java
@@ -1,6 +1,7 @@
 package com.simibubi.create.content.processing;
 
 import com.simibubi.create.AllBlocks;
+import com.simibubi.create.AllTags;
 import com.simibubi.create.content.kinetics.belt.BeltBlock;
 import com.simibubi.create.content.kinetics.belt.BeltSlope;
 
@@ -48,7 +49,7 @@ public class AssemblyOperatorBlockItem extends BlockItem {
 	protected boolean operatesOn(BlockState placedOnState) {
 		if (AllBlocks.BELT.has(placedOnState))
 			return placedOnState.getValue(BeltBlock.SLOPE) == BeltSlope.HORIZONTAL;
-		return AllBlocks.BASIN.has(placedOnState) || AllBlocks.DEPOT.has(placedOnState) || AllBlocks.WEIGHTED_EJECTOR.has(placedOnState);
+		return AllTags.AllBlockTags.BASIN.matches(placedOnState) || AllBlocks.DEPOT.has(placedOnState) || AllBlocks.WEIGHTED_EJECTOR.has(placedOnState);
 	}
 
 }

--- a/src/main/java/com/simibubi/create/content/processing/basin/BasinBlock.java
+++ b/src/main/java/com/simibubi/create/content/processing/basin/BasinBlock.java
@@ -3,6 +3,7 @@ package com.simibubi.create.content.processing.basin;
 import com.simibubi.create.AllBlockEntityTypes;
 import com.simibubi.create.AllBlocks;
 import com.simibubi.create.AllShapes;
+import com.simibubi.create.AllTags;
 import com.simibubi.create.Create;
 import com.simibubi.create.content.equipment.wrench.IWrenchable;
 import com.simibubi.create.content.fluids.transfer.GenericItemEmptying;
@@ -127,7 +128,7 @@ public class BasinBlock extends Block implements IBE<BasinBlockEntity>, IWrencha
 	@Override
 	public void updateEntityAfterFallOn(BlockGetter worldIn, Entity entityIn) {
 		super.updateEntityAfterFallOn(worldIn, entityIn);
-		if (!AllBlocks.BASIN.has(worldIn.getBlockState(entityIn.blockPosition())))
+		if (!AllTags.AllBlockTags.BASIN.matches(worldIn.getBlockState(entityIn.blockPosition())))
 			return;
 		if (!(entityIn instanceof ItemEntity))
 			return;

--- a/src/main/java/com/simibubi/create/content/processing/burner/BlazeBurnerBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/processing/burner/BlazeBurnerBlockEntity.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.simibubi.create.AllBlocks;
 import com.simibubi.create.AllItems;
+import com.simibubi.create.AllTags;
 import com.simibubi.create.AllTags.AllItemTags;
 import com.simibubi.create.content.fluids.tank.FluidTankBlock;
 import com.simibubi.create.content.processing.burner.BlazeBurnerBlock.HeatLevel;
@@ -269,7 +270,7 @@ public class BlazeBurnerBlockEntity extends SmartBlockEntity {
 		if (isVirtual())
 			return false;
 		BlockState blockState = level.getBlockState(worldPosition.above());
-		return AllBlocks.BASIN.has(blockState) || blockState.getBlock() instanceof FluidTankBlock;
+		return AllTags.AllBlockTags.BASIN.matches(blockState) || blockState.getBlock() instanceof FluidTankBlock;
 	}
 
 	protected void playSound() {
@@ -305,14 +306,14 @@ public class BlazeBurnerBlockEntity extends SmartBlockEntity {
 		Vec3 c = VecHelper.getCenterOf(worldPosition);
 		Vec3 v = c.add(VecHelper.offsetRandomly(Vec3.ZERO, r, .125f)
 			.multiply(1, 0, 1));
-		
+
 		if (r.nextInt(4) != 0)
 			return;
 
 		boolean empty = level.getBlockState(worldPosition.above())
 			.getCollisionShape(level, worldPosition.above())
 			.isEmpty();
-		
+
 		if (empty || r.nextInt(8) == 0)
 			level.addParticle(ParticleTypes.LARGE_SMOKE, v.x, v.y, v.z, 0, 0, 0);
 


### PR DESCRIPTION
Currently, some checks for basins check for AllBlocks.BASIN, which means that all basins added by addons wouldn't be accounted for. This PR simply makes this check use a tag instead, so new basins can simply be added to the tag and would be able to have all the functionality of the normal basin.

This PR is just a 1.19.2 port of #6172.