### PR TITLE
Fix wrong slot limit reading on threshold switches

### DIFF
--- a/src/main/java/com/simibubi/create/content/redstone/thresholdSwitch/ThresholdSwitchBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/redstone/thresholdSwitch/ThresholdSwitchBlockEntity.java
@@ -109,22 +109,23 @@ public class ThresholdSwitchBlockEntity extends SmartBlockEntity {
 
 		} else if (observedInventory.hasInventory() || observedTank.hasInventory()) {
 			if (observedInventory.hasInventory()) {
-				
+
 				// Item inventory
 				IItemHandler inv = observedInventory.getInventory();
 				if (invVersionTracker.stillWaiting(inv)) {
 					occupied = prevLevel;
 					totalSpace = 1f;
-					
+
 				} else {
 					invVersionTracker.awaitNewVersion(inv);
+					final int VANILLA_SLOT_LIMIT = 64;
 					for (int slot = 0; slot < inv.getSlots(); slot++) {
 						ItemStack stackInSlot = inv.getStackInSlot(slot);
-						int space = Math.min(stackInSlot.getMaxStackSize(), inv.getSlotLimit(slot));
+						int space = inv.getSlotLimit(slot) / (VANILLA_SLOT_LIMIT / stackInSlot.getMaxStackSize());
 						int count = stackInSlot.getCount();
 						if (space == 0)
 							continue;
-						
+
 						totalSpace += 1;
 						if (filtering.test(stackInSlot))
 							occupied += count * (1f / space);
@@ -209,7 +210,7 @@ public class ThresholdSwitchBlockEntity extends SmartBlockEntity {
 				this.updateCurrentLevel();
 				invVersionTracker.reset();
 			}));
-		
+
 		behaviours.add(invVersionTracker = new VersionedInventoryTrackerBehaviour(this));
 
 		InterfaceProvider towardBlockFacing =


### PR DESCRIPTION
Adds compatibility with sophisticated storage entities (chests, barrels, limited barrels) by fixing the threshold switch capacity limit reading.

# Images
## Setup
![image](https://github.com/Creators-of-Create/Create/assets/90877801/86104471-b045-480e-9a9b-c04efa7be112)
## Sophisticated Storage Chest Inventory with 2x Upgrade
### Pre-Fix
![image](https://github.com/Creators-of-Create/Create/assets/90877801/b0629b45-f479-486a-97ec-aff9808375c8)
### Post-Fix
![image](https://github.com/Creators-of-Create/Create/assets/90877801/c02e5db5-3665-4e4f-ade1-f6233dd89fac)

# Explanation
The line below is bad because it doesn't account for having space for multiple stacks in one slot from other mods such as  sophisticated storage
`int space = Math.min(stackInSlot.getMaxStackSize(), inv.getSlotLimit(slot));`
i.e. take the minimum of [ (1,16, or 64), 64 or greater]. When written like this, its clear that the item stack size is always chosen regardless of what the slot limit is.

From my understanding of the code:
`stackInSlot.getMaxStackSize()` -> current item max stack size (typically 64, 16, or 1)
 `inv.getSlotLimit(slot)` -> inventory slot max number of items (typically 64, can be increased by mods)
Added in: `VANILLA_SLOT_LIMIT` -> always 64
### Replacement code
`int space = inv.getSlotLimit(slot) / (VANILLA_SLOT_LIMIT / stackInSlot.getMaxStackSize());`

`(VANILLA_SLOT_LIMIT / stackInSlot.getMaxStackSize())` -> Conversion factor for changing the slot limit into the correct item stack amount
## Math
ASSUMPTIONS:
`stackInSlot.getMaxStackSize()` is never 0 as that item should never exist in inventories because you can't have > 0 of it (could result in division by 0 error)


###  Vanilla
Unstackable (1 item stack) = 64 / (64/1) -> 1 item limit
Snowballs (16 item stack) = 64 / (64/16) -> 16 item limit
Regular (64) = 64 / (64/64) -> 64 item limit
### Bigger Slot Limits
Unstackable = 128 / (64/1) -> 2 item limit
Snowballs = 128  / (64/16) -> 32 item limit 
Regular = 128 / (64/64) -> 128 item limit