### PR TITLE
Prevent shaped recipes with 1 ingredient from being used in autoShaped

### DIFF
--- a/src/main/java/com/simibubi/create/AllRecipeTypes.java
+++ b/src/main/java/com/simibubi/create/AllRecipeTypes.java
@@ -138,9 +138,7 @@ public enum AllRecipeTypes implements IRecipeTypeInfo {
 		RecipeSerializer<?> serializer = recipe.getSerializer();
 		if (serializer != null && AllTags.AllRecipeSerializerTags.AUTOMATION_IGNORE.matches(serializer))
 			return true;
-		return recipe.getId()
-			.getPath()
-			.endsWith("_manual_only");
+		return recipe.getId().getPath().endsWith("_manual_only") || recipe.getIngredients().size() == 1;
 	}
 
 	private static class Registers {


### PR DESCRIPTION
fixes Creators-of-Create#6368
fixes TheCBProject/EnderStorage#222
fixes mezz/JustEnoughItems#3276