### PR TITLE
Allow goggles to function in any curio slot

### DIFF
--- a/src/main/java/com/simibubi/create/compat/curios/Curios.java
+++ b/src/main/java/com/simibubi/create/compat/curios/Curios.java
@@ -43,13 +43,16 @@ public class Curios {
 		modEventBus.addListener(Curios::onClientSetup);
 
 		GogglesItem.addIsWearingPredicate(player -> resolveCuriosMap(player)
-			.map(curiosMap -> curiosMap.get("head"))
-			.map(stacksHandler -> {
-				// Check all the Head slots for Goggles existing
-				int slots = stacksHandler.getSlots();
-				for (int slot = 0; slot < slots; slot++)
-					if (AllItems.GOGGLES.isIn(stacksHandler.getStacks().getStackInSlot(slot)))
-						return true;
+			.map(curiosMap -> {
+				for (ICurioStacksHandler stacksHandler : curiosMap.values()) {
+					// Search all the curio slots for Goggles existing
+					int slots = stacksHandler.getSlots();
+					for (int slot = 0; slot < slots; slot++) {
+						if (AllItems.GOGGLES.isIn(stacksHandler.getStacks().getStackInSlot(slot))) {
+							return true;
+						}
+					}
+				}
 
 				return false;
 			})


### PR DESCRIPTION
Currently, the goggles item is hardcoded to work only in a Curios "head" slot, making it lose functionality when the slot is changed.

As an example, my use case is to change the goggles and other curio-enabled eye wear to a "face" slot so that they can be worn with hat-like curios. This cannot be done without this change.