### PR TITLE
Fix #6245 : Display links not writing to signs

### DIFF
--- a/src/main/java/com/simibubi/create/content/redstone/displayLink/target/SignDisplayTarget.java
+++ b/src/main/java/com/simibubi/create/content/redstone/displayLink/target/SignDisplayTarget.java
@@ -26,7 +26,7 @@ public class SignDisplayTarget extends DisplayTarget {
 			if (i > 0 && isReserved(i + line, sign, context))
 				break;
 
-			signText.setMessage(i + line, text.get(i));
+			signText = signText.setMessage(i + line, text.get(i));
 			changed = true;
 		}
 


### PR DESCRIPTION
Quick PR for Display Links not being able to write to signs, fixes #6245 


![image](https://github.com/Creators-of-Create/Create/assets/20230450/5bb65b50-e8b2-4cee-9117-561396b42278)
