### PR TITLE
Preserving BakedModel and switching to ItemRenderer.render instead of ItemRenderer.renderStatic

### DIFF
--- a/src/main/java/com/simibubi/create/content/decoration/placard/PlacardRenderer.java
+++ b/src/main/java/com/simibubi/create/content/decoration/placard/PlacardRenderer.java
@@ -10,6 +10,7 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.block.model.ItemTransforms.TransformType;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.client.renderer.entity.ItemRenderer;
+import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.core.Direction;
 import net.minecraft.util.Mth;
 import net.minecraft.world.item.ItemStack;
@@ -33,8 +34,8 @@ public class PlacardRenderer extends SafeBlockEntityRenderer<PlacardBlockEntity>
 
 		ItemRenderer itemRenderer = Minecraft.getInstance()
 			.getItemRenderer();
-		boolean blockItem = itemRenderer.getModel(heldItem, null, null, 0)
-			.isGui3d();
+		BakedModel bakedModel = itemRenderer.getModel(heldItem, null, null, 0);
+		boolean blockItem = bakedModel.isGui3d();
 
 		ms.pushPose();
 		TransformStack.cast(ms)
@@ -46,7 +47,7 @@ public class PlacardRenderer extends SafeBlockEntityRenderer<PlacardBlockEntity>
 			.translate(0, 0, 4.5 / 16f)
 			.scale(blockItem ? .5f : .375f);
 
-		itemRenderer.renderStatic(heldItem, TransformType.FIXED, light, overlay, ms, buffer, 0);
+		itemRenderer.render(heldItem, TransformType.FIXED, false, ms, buffer, light, overlay, bakedModel);
 		ms.popPose();
 	}
 

--- a/src/main/java/com/simibubi/create/content/fluids/drain/ItemDrainRenderer.java
+++ b/src/main/java/com/simibubi/create/content/fluids/drain/ItemDrainRenderer.java
@@ -19,6 +19,7 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.block.model.ItemTransforms.TransformType;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.client.renderer.entity.ItemRenderer;
+import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Direction.Axis;
 import net.minecraft.util.Mth;
@@ -78,8 +79,8 @@ public class ItemDrainRenderer extends SmartBlockEntityRenderer<ItemDrainBlockEn
 			.getItemRenderer();
 		int count = (int) (Mth.log2((int) (itemStack.getCount()))) / 2;
 		boolean renderUpright = BeltHelper.isItemUpright(itemStack);
-		boolean blockItem = itemRenderer.getModel(itemStack, null, null, 0)
-			.isGui3d();
+		BakedModel bakedModel = itemRenderer.getModel(itemStack, null, null, 0);
+		boolean blockItem = bakedModel.isGui3d();
 
 		if (renderUpright)
 			ms.translate(0, 3 / 32d, 0);
@@ -117,7 +118,7 @@ public class ItemDrainRenderer extends SmartBlockEntityRenderer<ItemDrainBlockEn
 			ms.scale(.5f, .5f, .5f);
 			if (!blockItem && !renderUpright)
 				msr.rotateX(90);
-			itemRenderer.renderStatic(itemStack, TransformType.FIXED, light, overlay, ms, buffer, 0);
+			itemRenderer.render(itemStack, TransformType.FIXED, false, ms, buffer, light, overlay, bakedModel);
 			ms.popPose();
 
 			if (!renderUpright) {

--- a/src/main/java/com/simibubi/create/content/kinetics/belt/BeltRenderer.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/BeltRenderer.java
@@ -30,6 +30,7 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.block.model.ItemTransforms.TransformType;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.client.renderer.entity.ItemRenderer;
+import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Direction.Axis;
 import net.minecraft.core.Direction.AxisDirection;
@@ -194,6 +195,7 @@ public class BeltRenderer extends SafeBlockEntityRenderer<BeltBlockEntity> {
 		boolean slopeAlongX = beltFacing
 								.getAxis() == Axis.X;
 
+		ItemRenderer itemRenderer = Minecraft.getInstance().getItemRenderer();
 		boolean onContraption = be.getLevel() instanceof WrappedWorld;
 
 		for (TransportedItemStack transported : be.getInventory()
@@ -238,11 +240,10 @@ public class BeltRenderer extends SafeBlockEntityRenderer<BeltBlockEntity> {
 			ms.translate(alongX ? sideOffset : 0, 0, alongX ? 0 : sideOffset);
 
 			int stackLight = onContraption ? light : getPackedLight(be, offset);
-			ItemRenderer itemRenderer = Minecraft.getInstance()
-				.getItemRenderer();
+
 			boolean renderUpright = BeltHelper.isItemUpright(transported.stack);
-			boolean blockItem = itemRenderer.getModel(transported.stack, be.getLevel(), null, 0)
-				.isGui3d();
+			BakedModel bakedModel = itemRenderer.getModel(transported.stack, be.getLevel(), null, 0);
+			boolean blockItem = bakedModel.isGui3d();
 			int count = (int) (Mth.log2((int) (transported.stack.getCount()))) / 2;
 			Random r = new Random(transported.angle);
 
@@ -289,7 +290,7 @@ public class BeltRenderer extends SafeBlockEntityRenderer<BeltBlockEntity> {
 				}
 
 				ms.scale(.5f, .5f, .5f);
-				itemRenderer.renderStatic(null, transported.stack, TransformType.FIXED, false, ms, buffer, be.getLevel(), stackLight, overlay, 0);
+				itemRenderer.render(transported.stack, TransformType.FIXED, false, ms, buffer, stackLight, overlay, bakedModel);
 				ms.popPose();
 
 				if (!renderUpright) {

--- a/src/main/java/com/simibubi/create/content/kinetics/deployer/DeployerRenderer.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/deployer/DeployerRenderer.java
@@ -34,6 +34,7 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.block.model.ItemTransforms.TransformType;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.client.renderer.entity.ItemRenderer;
+import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Direction.Axis;
@@ -89,9 +90,8 @@ public class DeployerRenderer extends SafeBlockEntityRenderer<DeployerBlockEntit
 			.getItemRenderer();
 
 		TransformType transform = TransformType.NONE;
-		boolean isBlockItem = (be.heldItem.getItem() instanceof BlockItem)
-			&& itemRenderer.getModel(be.heldItem, be.getLevel(), null, 0)
-				.isGui3d();
+		BakedModel bakedModel = itemRenderer.getModel(be.heldItem, be.getLevel(), null, 0);
+		boolean isBlockItem = (be.heldItem.getItem() instanceof BlockItem) && bakedModel.isGui3d();
 
 		if (displayMode) {
 			float scale = isBlockItem ? 1.25f : 1;
@@ -106,7 +106,7 @@ public class DeployerRenderer extends SafeBlockEntityRenderer<DeployerBlockEntit
 			transform = punching ? TransformType.THIRD_PERSON_RIGHT_HAND : TransformType.FIXED;
 		}
 
-		itemRenderer.renderStatic(be.heldItem, transform, light, overlay, ms, buffer, 0);
+		itemRenderer.render(be.heldItem, transform, false, ms, buffer, light, overlay, bakedModel);
 		ms.popPose();
 	}
 

--- a/src/main/java/com/simibubi/create/content/kinetics/mechanicalArm/ArmRenderer.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/mechanicalArm/ArmRenderer.java
@@ -19,6 +19,7 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.block.model.ItemTransforms.TransformType;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.client.renderer.entity.ItemRenderer;
+import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.util.Mth;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemStack;
@@ -45,9 +46,8 @@ public class ArmRenderer extends KineticBlockEntityRenderer<ArmBlockEntity> {
 		ItemRenderer itemRenderer = Minecraft.getInstance()
 			.getItemRenderer();
 
-		boolean isBlockItem =
-			hasItem && (item.getItem() instanceof BlockItem) && itemRenderer.getModel(item, be.getLevel(), null, 0)
-				.isGui3d();
+		BakedModel bakedModel = itemRenderer.getModel(item, be.getLevel(), null, 0);
+		boolean isBlockItem = hasItem && (item.getItem() instanceof BlockItem) && bakedModel.isGui3d();
 
 		VertexConsumer builder = buffer.getBuffer(be.goggles ? RenderType.cutout() : RenderType.solid());
 		BlockState blockState = be.getBlockState();
@@ -102,7 +102,7 @@ public class ArmRenderer extends KineticBlockEntityRenderer<ArmBlockEntity> {
 				.multiply(msLocal.last()
 					.pose());
 
-			itemRenderer.renderStatic(item, TransformType.FIXED, light, overlay, ms, buffer, 0);
+			itemRenderer.render(item, TransformType.FIXED, false, ms, buffer, light, overlay, bakedModel);
 			ms.popPose();
 		}
 
@@ -141,13 +141,13 @@ public class ArmRenderer extends KineticBlockEntityRenderer<ArmBlockEntity> {
 			.renderInto(ms, builder);
 
 		transformHead(msr, headAngle);
-		
+
 		if (inverted)
 			msr.rotateZ(180);
-			
+
 		claw.transform(msLocal)
 			.renderInto(ms, builder);
-		
+
 		if (inverted)
 			msr.rotateZ(180);
 

--- a/src/main/java/com/simibubi/create/content/kinetics/saw/SawRenderer.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/saw/SawRenderer.java
@@ -134,7 +134,7 @@ public class SawRenderer extends SafeBlockEntityRenderer<SawBlockEntity> {
 				if (alongZ)
 					ms.mulPose(Vector3f.YP.rotationDegrees(90));
 				ms.mulPose(Vector3f.XP.rotationDegrees(90));
-				itemRenderer.renderStatic(stack, ItemTransforms.TransformType.FIXED, light, overlay, ms, buffer, 0);
+				itemRenderer.render(stack, ItemTransforms.TransformType.FIXED, false, ms, buffer, light, overlay, modelWithOverrides);
 				break;
 			}
 

--- a/src/main/java/com/simibubi/create/content/logistics/depot/DepotRenderer.java
+++ b/src/main/java/com/simibubi/create/content/logistics/depot/DepotRenderer.java
@@ -16,6 +16,7 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.block.model.ItemTransforms.TransformType;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.client.renderer.entity.ItemRenderer;
+import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.core.Direction.Axis;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
@@ -104,8 +105,8 @@ public class DepotRenderer extends SafeBlockEntityRenderer<DepotBlockEntity> {
 		TransformStack msr = TransformStack.cast(ms);
 		int count = (int) (Mth.log2((int) (itemStack.getCount()))) / 2;
 		boolean renderUpright = BeltHelper.isItemUpright(itemStack);
-		boolean blockItem = itemRenderer.getModel(itemStack, null, null, 0)
-			.isGui3d();
+		BakedModel bakedModel = itemRenderer.getModel(itemStack, null, null, 0);
+		boolean blockItem = bakedModel.isGui3d();
 
 		ms.pushPose();
 		msr.rotateY(angle);
@@ -131,7 +132,7 @@ public class DepotRenderer extends SafeBlockEntityRenderer<DepotBlockEntity> {
 				ms.translate(0, -3 / 16f, 0);
 				msr.rotateX(90);
 			}
-			itemRenderer.renderStatic(itemStack, TransformType.FIXED, light, overlay, ms, buffer, 0);
+			itemRenderer.render(itemStack, TransformType.FIXED, false, ms, buffer, light, overlay, bakedModel);
 			ms.popPose();
 
 			if (!renderUpright) {


### PR DESCRIPTION
The current implementation of renderItems calls get the BakedModel to check for isGui3d() then call renderStatic multiple times for the stack. ItemRenderer.renderStatic fetch the BakedModel and call ItemRenderer.render. Saving the BakedModel when used, allows us to call ItemRenderer.render() directly without fetching the baked model up to 4 times and saves CPU usage.
On a big factory with a lot of items, this allowed me to go from ~25fps to ~35fps