### PR TITLE
Culling Items on belts

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/belt/BeltRenderer.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/BeltRenderer.java
@@ -198,10 +198,6 @@ public class BeltRenderer extends SafeBlockEntityRenderer<BeltBlockEntity> {
 
 		for (TransportedItemStack transported : be.getInventory()
 			.getTransportedItems()) {
-			ms.pushPose();
-            TransformStack.cast(ms)
-				.nudge(transported.angle);
-
 			float offset;
 			float sideOffset;
 			float verticalMovement;
@@ -228,6 +224,18 @@ public class BeltRenderer extends SafeBlockEntityRenderer<BeltBlockEntity> {
 																														.getAxis() == Axis.Z);
 			float slopeAngle = onSlope ? tiltForward ? -45 : 45 : 0;
 
+			Vec3 itemPos = beltStartOffset.add(
+					be.getBlockPos().getX(),
+					be.getBlockPos().getY(),
+					be.getBlockPos().getZ())
+				.add(offsetVec);
+
+			if (this.shouldCullItem(itemPos)) {
+				continue;
+			}
+
+			ms.pushPose();
+			TransformStack.cast(ms).nudge(transported.angle);
 			ms.translate(offsetVec.x, offsetVec.y, offsetVec.z);
 
 			boolean alongX = beltFacing
@@ -243,7 +251,13 @@ public class BeltRenderer extends SafeBlockEntityRenderer<BeltBlockEntity> {
 			boolean renderUpright = BeltHelper.isItemUpright(transported.stack);
 			boolean blockItem = itemRenderer.getModel(transported.stack, be.getLevel(), null, 0)
 				.isGui3d();
-			int count = (int) (Mth.log2((int) (transported.stack.getCount()))) / 2;
+
+
+			int count = 0;
+			if (Minecraft.getInstance().player.getEyePosition(1.0F).distanceTo(itemPos) < 16) {
+				count = (int) (Mth.log2((int) (transported.stack.getCount()))) / 2;
+			}
+
 			Random r = new Random(transported.angle);
 
 			boolean slopeShadowOnly = renderUpright && onSlope;

--- a/src/main/java/com/simibubi/create/foundation/blockEntity/renderer/SafeBlockEntityRenderer.java
+++ b/src/main/java/com/simibubi/create/foundation/blockEntity/renderer/SafeBlockEntityRenderer.java
@@ -2,10 +2,14 @@ package com.simibubi.create.foundation.blockEntity.renderer;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
+import net.minecraft.client.renderer.culling.Frustum;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
 
 public abstract class SafeBlockEntityRenderer<T extends BlockEntity> implements BlockEntityRenderer<T> {
 	@Override
@@ -22,5 +26,22 @@ public abstract class SafeBlockEntityRenderer<T extends BlockEntity> implements 
 	public boolean isInvalid(T be) {
 		return !be.hasLevel() || be.getBlockState()
 			.getBlock() == Blocks.AIR;
+	}
+
+	public boolean shouldCullItem(Vec3 itemPos) {
+		Frustum frustum = Minecraft.getInstance().levelRenderer.capturedFrustum != null ?
+				Minecraft.getInstance().levelRenderer.capturedFrustum :
+				Minecraft.getInstance().levelRenderer.cullingFrustum;
+
+		AABB itemBB = new AABB(
+				itemPos.x - 0.25,
+				itemPos.y - 0.25,
+				itemPos.z - 0.25,
+				itemPos.x + 0.25,
+				itemPos.y + 0.25,
+				itemPos.z + 0.25
+		);
+
+		return !frustum.isVisible(itemBB);
 	}
 }

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -42,3 +42,6 @@ public net.minecraft.client.model.AgeableListModel f_102012_ # bodyYOffset
 
 public net.minecraft.client.gui.components.CommandSuggestions f_93866_ # suggestions
 public net.minecraft.client.gui.components.CommandSuggestions$SuggestionsList <init>(Lnet/minecraft/client/gui/components/CommandSuggestions;IIILjava/util/List;Z)V # <init>
+
+public net.minecraft.client.renderer.LevelRenderer f_172938_ # cullingFrustum
+public net.minecraft.client.renderer.LevelRenderer f_109442_ # capturedFrustum


### PR DESCRIPTION
Implementation of LevelRenderer Frustrum culling per ItemStack on belts this saves a lot of ItemRenderer calls.
Implementation of a basic "LoD" system, if an item on a belt is stacked, will only render one item on the belt if the item is further than 16 blocks.

With the BakedModel optimization of #6674 I went from 25FPS inside my factory to 55-60 and CPU spent on BeltRenderer.renderItems from ~12% to 2%.

I hardcoded the AABB of an item, maybe this could cause some problems.