### PR TITLE
Fix duplicated extraction issue (#5781)

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/belt/BeltBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/BeltBlockEntity.java
@@ -30,6 +30,7 @@ import com.simibubi.create.content.kinetics.belt.transport.ItemHandlerBeltSegmen
 import com.simibubi.create.content.kinetics.belt.transport.TransportedItemStack;
 import com.simibubi.create.content.logistics.tunnel.BrassTunnelBlockEntity;
 import com.simibubi.create.foundation.blockEntity.behaviour.BlockEntityBehaviour;
+import com.simibubi.create.foundation.utility.LogisticsExtractionManager;
 import com.simibubi.create.foundation.utility.NBTHelper;
 
 import net.minecraft.client.renderer.LightTexture;
@@ -512,6 +513,12 @@ public class BeltBlockEntity extends KineticBlockEntity {
 		if (isOccupied(side))
 			return inserted;
 		if (simulate)
+			return empty;
+
+		// to prevent items be extracted by chute at the same tick be transported to the nextBeltFunnel
+		// try lock the blockPos before try insert it into the nextBeltFunnel
+		BlockPos inputPos = worldPosition.relative(getBeltFacing().getOpposite()).above();
+		if (!LogisticsExtractionManager.tryLock(inputPos))
 			return empty;
 
 		transportedStack = transportedStack.copy();

--- a/src/main/java/com/simibubi/create/content/logistics/chute/ChuteBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/chute/ChuteBlockEntity.java
@@ -251,7 +251,7 @@ public class ChuteBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 				if (!canAcceptItem(ts.stack)) return TransportedResult.doNothing();
 				// only try lock when this chute is empty (can accept item)
 				// to prevent items be extracted by chute at the same tick be transported to the nextFunnel or beltFunnel
-				// try lock the blockPos before try insert it into the nextBeltFunnel
+				// try lock the blockPos below the chute
 				BlockPos beltPos = worldPosition.below();
 				if (LogisticsExtractionManager.tryLock(beltPos)) {
 					setItem(ts.stack.copy(), -beltBelowOffset);

--- a/src/main/java/com/simibubi/create/content/logistics/chute/ChuteBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/chute/ChuteBlockEntity.java
@@ -28,6 +28,7 @@ import com.simibubi.create.foundation.utility.BlockHelper;
 import com.simibubi.create.foundation.utility.Components;
 import com.simibubi.create.foundation.utility.Iterate;
 import com.simibubi.create.foundation.utility.Lang;
+import com.simibubi.create.foundation.utility.LogisticsExtractionManager;
 import com.simibubi.create.foundation.utility.VecHelper;
 import com.simibubi.create.foundation.utility.animation.LerpedFloat;
 import com.simibubi.create.infrastructure.config.AllConfigs;
@@ -244,6 +245,11 @@ public class ChuteBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 	private void extractFromBelt(float itemSpeed) {
 		if (itemSpeed <= 0 || level == null || level.isClientSide)
 			return;
+
+		BlockPos beltPos = worldPosition.below();
+		if (!LogisticsExtractionManager.tryLock(beltPos))
+			return;
+
 		if (getItem().isEmpty() && beltBelow != null) {
 			beltBelow.handleCenteredProcessingOnAllItems(.5f, ts -> {
 				if (canAcceptItem(ts.stack)) {

--- a/src/main/java/com/simibubi/create/content/logistics/funnel/FunnelBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/funnel/FunnelBlockEntity.java
@@ -3,6 +3,8 @@ package com.simibubi.create.content.logistics.funnel;
 import java.lang.ref.WeakReference;
 import java.util.List;
 
+import com.simibubi.create.foundation.utility.LogisticsExtractionManager;
+
 import org.apache.commons.lang3.mutable.MutableBoolean;
 
 import com.jozufozu.flywheel.backend.instancing.InstancedRenderDispatcher;
@@ -122,6 +124,11 @@ public class FunnelBlockEntity extends SmartBlockEntity implements IHaveHovering
 		Direction facing = AbstractFunnelBlock.getFunnelFacing(blockState);
 
 		if (facing == null)
+			return;
+
+		// Determine the position to lock based on the facing direction
+		BlockPos extractPos = worldPosition.relative(facing.getOpposite());
+		if (!LogisticsExtractionManager.tryLock(extractPos))
 			return;
 
 		boolean trackingEntityPresent = true;

--- a/src/main/java/com/simibubi/create/foundation/utility/LogisticsExtractionManager.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/LogisticsExtractionManager.java
@@ -10,23 +10,9 @@ import net.minecraftforge.fml.common.Mod;
 
 /**
  * A manager to handle extraction reservations for specific block positions.
- * This ensures that only one entity can extract items from a specific block position at a time per tick.
+ * This ensures that only one blockEntity can extract items from a specific block position at a time per tick.
  *
- * <p>The `LogisticsExtractionManager` class is responsible for managing and coordinating
- * extraction operations in the game, preventing multiple entities from extracting
- * items from the same block position simultaneously within a single tick. It achieves
- * this by maintaining a set of reserved block positions and providing methods to
- * reserve and release these positions.</p>
- *
- * <p>Key responsibilities of this class include:</p>
- * <ul>
- *   <li>Reserving block positions for extraction to ensure that only one entity can perform an extraction operation on a specific position per tick.</li>
- *   <li>Releasing reservations for block positions once the extraction operation is complete.</li>
- *   <li>Clearing all reserved positions at the start of each tick to reset the state and prepare for the next round of extraction operations.</li>
- * </ul>
- *
- * <p>This class is essential for preventing issues such as duplicated item extraction,
- * ensuring the game's logistics and extraction mechanisms function smoothly and correctly.</p>
+ * This is done via a simple locking system, calling tryLock will return false if the block is already locked or true if it manages to successfully lock the block, at the start of every server tick the current locks are cleared
  */
 @Mod.EventBusSubscriber
 public class LogisticsExtractionManager {

--- a/src/main/java/com/simibubi/create/foundation/utility/LogisticsExtractionManager.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/LogisticsExtractionManager.java
@@ -1,0 +1,67 @@
+package com.simibubi.create.foundation.utility;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import net.minecraft.core.BlockPos;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+/**
+ * A manager to handle extraction reservations for specific block positions.
+ * This ensures that only one entity can extract items from a specific block position at a time per tick.
+ *
+ * <p>The `LogisticsExtractionManager` class is responsible for managing and coordinating
+ * extraction operations in the game, preventing multiple entities from extracting
+ * items from the same block position simultaneously within a single tick. It achieves
+ * this by maintaining a set of reserved block positions and providing methods to
+ * reserve and release these positions.</p>
+ *
+ * <p>Key responsibilities of this class include:</p>
+ * <ul>
+ *   <li>Reserving block positions for extraction to ensure that only one entity can perform an extraction operation on a specific position per tick.</li>
+ *   <li>Releasing reservations for block positions once the extraction operation is complete.</li>
+ *   <li>Clearing all reserved positions at the start of each tick to reset the state and prepare for the next round of extraction operations.</li>
+ * </ul>
+ *
+ * <p>This class is essential for preventing issues such as duplicated item extraction,
+ * ensuring the game's logistics and extraction mechanisms function smoothly and correctly.</p>
+ */
+@Mod.EventBusSubscriber
+public class LogisticsExtractionManager {
+
+	/**
+	 * A set to store reserved block positions while tick processing
+	 */
+	private static final Set<BlockPos> lockedPositions = new HashSet<>();
+
+	/**
+	 * Tries to lock the specified block position.
+	 * If the position is already locked, the method returns false.
+	 *
+	 * @param pos The block position to lock.
+	 * @return True if the position was successfully locked, false otherwise.
+	 */
+	public static boolean tryLock(BlockPos pos) {
+		if (lockedPositions.contains(pos)) {
+			return false;
+		} else {
+			lockedPositions.add(pos);
+			return true;
+		}
+	}
+
+	/**
+	 * Clears all locked positions at the start of each tick.
+	 *
+	 * @param event The server tick event.
+	 */
+	@SubscribeEvent
+	public static void onServerTick(TickEvent.ServerTickEvent event) {
+		if (event.phase == TickEvent.Phase.START) {
+			lockedPositions.clear();
+		}
+	}
+
+}


### PR DESCRIPTION
The issue was that `ChuteBlockEntity` and `FunnelBlockEntity` could extract items from the same (belt) block position simultaneously within a single `tick`, leading to duplicated items generated (#5781). Many thanks to @Mirage-Tank that he helped and located this issue together, we added a `LogisticsExtractionManager` class, which ensures that only one tileEntity can perform an extraction operation on a specific block position per tick.

If the position is already reserved within a tick, the extraction would be skipped for other extractors on that tick.
After completing the extraction, the position will be released automatically at the start phase of the next tick.

Please check the code and see if there are any possible enhancements or better solutions. Thanks!
