### PR TITLE
Performance improvements in several tick methods

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/minecart/CouplingHandler.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/minecart/CouplingHandler.java
@@ -45,14 +45,15 @@ public class CouplingHandler {
 			event.setResult(Result.DENY);
 		}
 	}
-	
+
 	public static void forEachLoadedCoupling(Level world, Consumer<Couple<MinecartController>> consumer) {
 		if (world == null)
 			return;
 		Set<UUID> cartsWithCoupling = CapabilityMinecartController.loadedMinecartsWithCoupling.get(world);
 		if (cartsWithCoupling == null)
 			return;
-		cartsWithCoupling.forEach(id -> {
+
+		for (UUID id : cartsWithCoupling) {
 			MinecartController controller = CapabilityMinecartController.getIfPresent(world, id);
 			if (controller == null)
 				return;
@@ -63,7 +64,7 @@ public class CouplingHandler {
 			if (coupledController == null)
 				return;
 			consumer.accept(Couple.create(controller, coupledController));
-		});
+		};
 	}
 
 	public static boolean tryToCoupleCarts(@Nullable Player player, Level world, int cartId1, int cartId2) {
@@ -83,13 +84,13 @@ public class CouplingHandler {
 		int distanceTo = (int) entity1.position()
 			.distanceTo(entity2.position());
 		boolean contraptionCoupling = player == null;
-		
+
 		if (distanceTo < 2) {
 			if (contraptionCoupling)
 				return false; // dont allow train contraptions with <2 distance
 			distanceTo = 2;
 		}
-		
+
 		if (distanceTo > AllConfigs.server().kinetics.maxCartCouplingLength.get()) {
 			status(player, tooFar);
 			return false;

--- a/src/main/java/com/simibubi/create/content/contraptions/minecart/capability/CapabilityMinecartController.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/minecart/capability/CapabilityMinecartController.java
@@ -1,6 +1,5 @@
 package com.simibubi.create.content.contraptions.minecart.capability;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -86,15 +85,16 @@ public class CapabilityMinecartController implements ICapabilitySerializable<Com
 	}
 
 	public static void tick(Level world) {
-		List<UUID> toRemove = new ArrayList<>();
 		Map<UUID, MinecartController> carts = loadedMinecartsByUUID.get(world);
 		List<AbstractMinecart> queued = queuedAdditions.get(world);
 		List<UUID> queuedRemovals = queuedUnloads.get(world);
 		Set<UUID> cartsWithCoupling = loadedMinecartsWithCoupling.get(world);
 		Set<UUID> keySet = carts.keySet();
 
-		keySet.removeAll(queuedRemovals);
-		cartsWithCoupling.removeAll(queuedRemovals);
+		for (UUID removal : queuedRemovals) {
+			keySet.remove(removal);
+			cartsWithCoupling.remove(removal);
+		}
 
 		for (AbstractMinecart cart : queued) {
 			UUID uniqueID = cart.getUUID();
@@ -115,10 +115,12 @@ public class CapabilityMinecartController implements ICapabilitySerializable<Com
 			capability.addListener(new MinecartRemovalListener(world, cart));
 			carts.put(uniqueID, controller);
 
-			capability.ifPresent(mc -> {
-				if (mc.isLeadingCoupling())
+			if (capability.isPresent()) {
+				MinecartController mc = capability.orElse(null);
+				if (mc.isLeadingCoupling()) {
 					cartsWithCoupling.add(uniqueID);
-			});
+				}
+			}
 			if (!world.isClientSide && controller != null)
 				controller.sendData();
 		}
@@ -134,11 +136,9 @@ public class CapabilityMinecartController implements ICapabilitySerializable<Com
 					continue;
 				}
 			}
-			toRemove.add(entry.getKey());
+			cartsWithCoupling.remove(entry.getKey());
+			keySet.remove(entry.getKey());
 		}
-
-		cartsWithCoupling.removeAll(toRemove);
-		keySet.removeAll(toRemove);
 	}
 
 	public static void onChunkUnloaded(ChunkEvent.Unload event) {

--- a/src/main/java/com/simibubi/create/content/schematics/ServerSchematicLoader.java
+++ b/src/main/java/com/simibubi/create/content/schematics/ServerSchematicLoader.java
@@ -11,7 +11,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import com.simibubi.create.AllBlocks;
@@ -25,6 +24,7 @@ import com.simibubi.create.foundation.utility.Lang;
 import com.simibubi.create.infrastructure.config.AllConfigs;
 import com.simibubi.create.infrastructure.config.CSchematics;
 
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.ChatFormatting;
 import net.minecraft.Util;
 import net.minecraft.core.BlockPos;
@@ -64,6 +64,8 @@ public class ServerSchematicLoader {
 		return "schematics/uploaded";
 	}
 
+	private final ObjectArrayList<String> deadEntries = ObjectArrayList.of();
+
 	public void tick() {
 		// Detect Timed out Uploads
 		int timeout = getConfig().schematicIdleTimeout.get();
@@ -72,9 +74,17 @@ public class ServerSchematicLoader {
 
 			if (entry.idleTime++ > timeout) {
 				Create.LOGGER.warn("Schematic Upload timed out: " + upload);
-				this.cancelUpload(upload);
+				deadEntries.add(upload);
 			}
 		}
+
+		// Remove Timed out Uploads
+		var iterator = deadEntries.iterator();
+		while (iterator.hasNext()) {
+			String toRemove = iterator.next();
+			this.cancelUpload(toRemove);
+		}
+		deadEntries.clear();
 	}
 
 	public void shutdown() {

--- a/src/main/java/com/simibubi/create/content/schematics/ServerSchematicLoader.java
+++ b/src/main/java/com/simibubi/create/content/schematics/ServerSchematicLoader.java
@@ -79,9 +79,7 @@ public class ServerSchematicLoader {
 		}
 
 		// Remove Timed out Uploads
-		var iterator = deadEntries.iterator();
-		while (iterator.hasNext()) {
-			String toRemove = iterator.next();
+		for (String toRemove : deadEntries) {
 			this.cancelUpload(toRemove);
 		}
 		deadEntries.clear();

--- a/src/main/java/com/simibubi/create/content/schematics/ServerSchematicLoader.java
+++ b/src/main/java/com/simibubi/create/content/schematics/ServerSchematicLoader.java
@@ -66,19 +66,15 @@ public class ServerSchematicLoader {
 
 	public void tick() {
 		// Detect Timed out Uploads
-		Set<String> deadEntries = new HashSet<>();
+		int timeout = getConfig().schematicIdleTimeout.get();
 		for (String upload : activeUploads.keySet()) {
 			SchematicUploadEntry entry = activeUploads.get(upload);
 
-			if (entry.idleTime++ > getConfig().schematicIdleTimeout.get()) {
+			if (entry.idleTime++ > timeout) {
 				Create.LOGGER.warn("Schematic Upload timed out: " + upload);
-				deadEntries.add(upload);
+				this.cancelUpload(upload);
 			}
-
 		}
-
-		// Remove Timed out Uploads
-		deadEntries.forEach(this::cancelUpload);
 	}
 
 	public void shutdown() {


### PR DESCRIPTION
This PR is #6696 but targeting `mc1.18/dev` instead of `mc1.20.1/dev`.
Profiles shown are from `mc1.20.1/dev` based on commit a41053b8966e.

Avoids capturing lambdas (not cached by (most?) JVMs), streams, and Set#removeAll ([reason](https://www.jetbrains.com/help/inspectopedia/SlowAbstractSetRemoveAll.html)).
Also removes some auxiliary "removal sets" as they do not save resources over just removing the elements since hashing will be needed either way and auxiliary maps would just add unnecessary allocation(s).
Not very comprehensive, just some low hanging fruit for now mainly targetting tick methods.

I was focused more on reducing allocations so here's some spark profiles to prove that it worked:
[Before](https://spark.lucko.me/qmUl37vhmG)
![Before](https://github.com/user-attachments/assets/6f360463-8990-4fb5-bd5a-04f52c6d8af7)

[After](https://spark.lucko.me/AQ3XCI6uS0)
![After](https://github.com/user-attachments/assets/f7837a1f-3132-4480-9d1c-3e2b3af9a23d)

(Build after changes based off commit a41053b8966e under assumptions that it is the commit of the build available on Curseforge)

Only places changed by this PR are expanded in the images, feel free to explore the profile yourself.