### PR TITLE
Disallow item extraction from crushing wheels with mech arms

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/mechanicalArm/AllArmInteractionPointTypes.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/mechanicalArm/AllArmInteractionPointTypes.java
@@ -182,7 +182,7 @@ public class AllArmInteractionPointTypes {
 
 		@Override
 		public ArmInteractionPoint createPoint(Level level, BlockPos pos, BlockState state) {
-			return new TopFaceArmInteractionPoint(this, level, pos, state);
+			return new CrushingWheelPoint(this, level, pos, state);
 		}
 	}
 
@@ -712,4 +712,15 @@ public class AllArmInteractionPointTypes {
 		}
 	}
 
+	public static class CrushingWheelPoint extends DepositOnlyArmInteractionPoint {
+		public CrushingWheelPoint(ArmInteractionPointType type, Level level, BlockPos pos, BlockState state) {
+			super(type, level, pos, state);
+		}
+
+		@Override
+		protected Vec3 getInteractionPositionVector() {
+			return Vec3.atLowerCornerOf(pos)
+					.add(.5f, 1, .5f);
+		}
+	}
 }


### PR DESCRIPTION
Mechanical Arms can't actually extract from crushing wheels, and hence they should not even show the option of being able to do so