### PR TITLE
Fix memory leak in CapManipulationBehaviourBase for 1.20.1

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/blockEntity/behaviour/inventory/CapManipulationBehaviourBase.java
+++ b/src/main/java/com/simibubi/create/foundation/blockEntity/behaviour/inventory/CapManipulationBehaviourBase.java
@@ -7,6 +7,7 @@ import com.simibubi.create.foundation.blockEntity.behaviour.BlockEntityBehaviour
 import com.simibubi.create.foundation.blockEntity.behaviour.filtering.FilteringBehaviour;
 import com.simibubi.create.foundation.item.ItemHelper.ExtractionCountMode;
 import com.simibubi.create.foundation.utility.BlockFace;
+import com.simibubi.create.foundation.utility.HashableNonNullConsumer;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
@@ -102,7 +103,7 @@ public abstract class CapManipulationBehaviourBase<T, S extends CapManipulationB
 			amount = filter.getAmount();
 		return amount;
 	}
-	
+
 	public ExtractionCountMode getModeFromFilter() {
 		ExtractionCountMode mode = ExtractionCountMode.UPTO;
 		FilteringBehaviour filter = blockEntity.getBehaviour(FilteringBehaviour.TYPE);
@@ -128,7 +129,7 @@ public abstract class CapManipulationBehaviourBase<T, S extends CapManipulationB
 		targetCapability =
 			bypassSided ? invBE.getCapability(capability) : invBE.getCapability(capability, targetBlockFace.getFace());
 		if (targetCapability.isPresent())
-			targetCapability.addListener(this::onHandlerInvalidated);
+			targetCapability.addListener(new HashableNonNullConsumer<>(this::onHandlerInvalidated, this));
 	}
 
 	@FunctionalInterface

--- a/src/main/java/com/simibubi/create/foundation/utility/HashableNonNullConsumer.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/HashableNonNullConsumer.java
@@ -1,0 +1,35 @@
+package com.simibubi.create.foundation.utility;
+
+import java.util.Objects;
+
+import javax.annotation.Nonnull;
+
+import net.minecraftforge.common.util.NonNullConsumer;
+
+public class HashableNonNullConsumer<T, H> implements NonNullConsumer<T> {
+	private final NonNullConsumer<T> consumer;
+	private final H hashKey;
+
+	public HashableNonNullConsumer(NonNullConsumer<T> consumer, H hashKey) {
+		this.consumer = consumer;
+		this.hashKey = hashKey;
+	}
+
+	@Override
+	public void accept(@Nonnull T t) {
+		consumer.accept(t);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		HashableNonNullConsumer<?, ?> that = (HashableNonNullConsumer<?, ?>) o;
+		return Objects.equals(hashKey, that.hashKey);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(hashKey);
+	}
+}


### PR DESCRIPTION
This is a copy of the PR https://github.com/Creators-of-Create/Create/pull/5707 but for 1.20.1 as this memory leak still exists in that version / branch. 