### PR TITLE
[Fix Loot Table] Added silk touch only breakable tiled glass and framed glass blocks

### DIFF
--- a/src/generated/resources/data/create/loot_tables/blocks/framed_glass_door.json
+++ b/src/generated/resources/data/create/loot_tables/blocks/framed_glass_door.json
@@ -5,7 +5,17 @@
       "bonus_rolls": 0.0,
       "conditions": [
         {
-          "condition": "minecraft:survives_explosion"
+          "condition": "minecraft:match_tool",
+          "predicate": {
+            "enchantments": [
+              {
+                "enchantment": "minecraft:silk_touch",
+                "levels": {
+                  "min": 1
+                }
+              }
+            ]
+          }
         }
       ],
       "entries": [

--- a/src/generated/resources/data/create/loot_tables/blocks/framed_glass_trapdoor.json
+++ b/src/generated/resources/data/create/loot_tables/blocks/framed_glass_trapdoor.json
@@ -5,7 +5,17 @@
       "bonus_rolls": 0.0,
       "conditions": [
         {
-          "condition": "minecraft:survives_explosion"
+          "condition": "minecraft:match_tool",
+          "predicate": {
+            "enchantments": [
+              {
+                "enchantment": "minecraft:silk_touch",
+                "levels": {
+                  "min": 1
+                }
+              }
+            ]
+          }
         }
       ],
       "entries": [

--- a/src/generated/resources/data/create/loot_tables/blocks/tiled_glass.json
+++ b/src/generated/resources/data/create/loot_tables/blocks/tiled_glass.json
@@ -5,7 +5,17 @@
       "bonus_rolls": 0.0,
       "conditions": [
         {
-          "condition": "minecraft:survives_explosion"
+          "condition": "minecraft:match_tool",
+          "predicate": {
+            "enchantments": [
+              {
+                "enchantment": "minecraft:silk_touch",
+                "levels": {
+                  "min": 1
+                }
+              }
+            ]
+          }
         }
       ],
       "entries": [


### PR DESCRIPTION
I adjusted the loot table of 3 glass-based blocks to make them shatter if broken without silk touch.
* Most framed glass blocks already had this feature. I added the missing ones, i.e. trapdoor and door.
* The tiled glass pane already had this feature. I added it to the tiled glass block.