### PR TITLE
Added silk touch only breakable tiled glass and framed glass blocks

### DIFF
--- a/src/generated/resources/data/create/loot_tables/blocks/framed_glass_trapdoor.json
+++ b/src/generated/resources/data/create/loot_tables/blocks/framed_glass_trapdoor.json
@@ -12,7 +12,17 @@
       ],
       "conditions": [
         {
-          "condition": "minecraft:survives_explosion"
+          "condition": "minecraft:match_tool",
+          "predicate": {
+            "enchantments": [
+              {
+                "enchantment": "minecraft:silk_touch",
+                "levels": {
+                  "min": 1
+                }
+              }
+            ]
+          }
         }
       ]
     }

--- a/src/generated/resources/data/create/loot_tables/blocks/tiled_glass.json
+++ b/src/generated/resources/data/create/loot_tables/blocks/tiled_glass.json
@@ -12,7 +12,17 @@
       ],
       "conditions": [
         {
-          "condition": "minecraft:survives_explosion"
+          "condition": "minecraft:match_tool",
+          "predicate": {
+            "enchantments": [
+              {
+                "enchantment": "minecraft:silk_touch",
+                "levels": {
+                  "min": 1
+                }
+              }
+            ]
+          }
         }
       ]
     }

--- a/src/main/java/com/simibubi/create/AllBlocks.java
+++ b/src/main/java/com/simibubi/create/AllBlocks.java
@@ -2152,6 +2152,7 @@ public class AllBlocks {
 			.properties(p -> p.color(MaterialColor.NONE)
 				.sound(SoundType.GLASS)
 				.noOcclusion())
+			.loot((t, g) -> t.dropWhenSilkTouch(g))
 			.register();
 
 	public static final BlockEntry<TrainTrapdoorBlock> FRAMED_GLASS_TRAPDOOR =
@@ -2161,6 +2162,7 @@ public class AllBlocks {
 			.properties(p -> p.color(MaterialColor.NONE)
 				.sound(SoundType.GLASS)
 				.noOcclusion())
+			.loot((t, g) -> t.dropWhenSilkTouch(g))
 			.onRegister(connectedTextures(TrapdoorCTBehaviour::new))
 			.addLayer(() -> RenderType::cutoutMipped)
 			.register();

--- a/src/main/java/com/simibubi/create/content/decoration/palettes/AllPaletteBlocks.java
+++ b/src/main/java/com/simibubi/create/content/decoration/palettes/AllPaletteBlocks.java
@@ -39,6 +39,7 @@ public class AllPaletteBlocks {
 	public static final BlockEntry<GlassBlock> TILED_GLASS = REGISTRATE.block("tiled_glass", GlassBlock::new)
 		.initialProperties(() -> Blocks.GLASS)
 		.addLayer(() -> RenderType::cutout)
+		.loot((t, g) -> t.dropWhenSilkTouch(g))
 		.recipe((c, p) -> p.stonecutting(DataIngredient.tag(Tags.Items.GLASS_COLORLESS), c::get))
 		.blockstate((c, p) -> BlockStateGen.cubeAll(c, p, "palettes/"))
 		.tag(Tags.Blocks.GLASS_COLORLESS, BlockTags.IMPERMEABLE)


### PR DESCRIPTION
As a follow up of #6739, I adjusted the loot table of framed glass door, trapdoor, and tiled glass. to make them shatter if broken without silk touch following @VoidLeech comment.