### PR TITLE
Fix: newly unpowered smart chutes don't ignore vault version tracker

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/chute/ChuteBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/chute/ChuteBlockEntity.java
@@ -74,6 +74,7 @@ public class ChuteBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 	ChuteItemHandler itemHandler;
 	LazyOptional<IItemHandler> lazyHandler;
 	boolean canPickUpItems;
+	boolean previouslyPowered;
 
 	float bottomPullDistance;
 	float beltBelowOffset;
@@ -83,7 +84,7 @@ public class ChuteBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 	int entitySearchCooldown;
 
 	VersionedInventoryTrackerBehaviour invVersionTracker;
-	
+
 	LazyOptional<IItemHandler> capAbove;
 	LazyOptional<IItemHandler> capBelow;
 
@@ -340,8 +341,9 @@ public class ChuteBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 	private void handleInput(IItemHandler inv, float startLocation) {
 		if (inv == null)
 			return;
-		if (invVersionTracker.stillWaiting(inv))
+		if (!previouslyPowered && invVersionTracker.stillWaiting(inv))
 			return;
+		setPreviouslyPowered(false);
 		Predicate<ItemStack> canAccept = this::canAcceptItem;
 		int count = getExtractionAmount();
 		ExtractionCountMode mode = getExtractionMode();
@@ -759,6 +761,15 @@ public class ChuteBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 
 	public ItemStack getItem() {
 		return item;
+	}
+
+	/**
+	 * Sets whether the chute was previously powered, so that we get a tick of skipping invVersionTracker.stillWaiting
+	 * (Only relevant for the smart chute, but the logic that needs it is in here)
+	 * @param previouslyPowered
+	 */
+	public void setPreviouslyPowered(boolean previouslyPowered) {
+		this.previouslyPowered = previouslyPowered;
 	}
 
 	// @Override

--- a/src/main/java/com/simibubi/create/content/logistics/chute/SmartChuteBlock.java
+++ b/src/main/java/com/simibubi/create/content/logistics/chute/SmartChuteBlock.java
@@ -40,8 +40,12 @@ public class SmartChuteBlock extends AbstractChuteBlock {
 	@Override
 	public void tick(BlockState state, ServerLevel worldIn, BlockPos pos, Random r) {
 		boolean previouslyPowered = state.getValue(POWERED);
-		if (previouslyPowered != worldIn.hasNeighborSignal(pos))
+		if (previouslyPowered != worldIn.hasNeighborSignal(pos)) {
 			worldIn.setBlock(pos, state.cycle(POWERED), 2);
+			if (previouslyPowered) {
+				withBlockEntityDo(worldIn, pos, (c) -> c.setPreviouslyPowered(true));
+			}
+		}
 	}
 
 	@Override
@@ -54,7 +58,7 @@ public class SmartChuteBlock extends AbstractChuteBlock {
 	public boolean canSurvive(BlockState state, LevelReader world, BlockPos pos) {
 		return true;
 	}
-	
+
 	@Override
 	public BlockEntityType<? extends ChuteBlockEntity> getBlockEntityType() {
 		return AllBlockEntityTypes.SMART_CHUTE.get();


### PR DESCRIPTION
### Issues Fixed
Fixes #6154
Fixes #5867 

### Implemented Solution
At runtime, save an additional boolean in a ChuteBlockEntity that gets toggled when we toggle the powered state to off (in SmartChuteBlock):
If that's set to true, don't check whether we're still waiting on the versioned inventory tracker, just go through with the transfer attempt, then toggle it back to false so subsequent attempts to check the versioned inventory tracker aren't skipped.

This boolean doesn't need to be saved to disk I don't think, we seem to get a new versioned inventory tracker when the world is loaded that we can't yet be waiting on.
This does introduce some useless logic (a boolean comparison and setting a boolean to false) for normal chutes as the transferring logic is in ChuteBlockEntity, but at least we never toggle it to true for those.