### PR TITLE
Fix for #6758: Added check for portal blocks when trying to fill.

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/actors/roller/RollerMovementBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/actors/roller/RollerMovementBehaviour.java
@@ -469,9 +469,10 @@ public class RollerMovementBehaviour extends BlockBreakingMovementBehaviour {
 		if (existing.is(toPlace.getBlock()))
 			return PaveResult.PASS;
 		if (!existing.is(BlockTags.LEAVES) && !existing.getMaterial()
-			.isReplaceable()
-			&& !existing.getCollisionShape(level, targetPos)
-				.isEmpty())
+				.isReplaceable()
+				&& (!existing.getCollisionShape(level, targetPos)
+					.isEmpty()
+					|| existing.is(BlockTags.PORTALS)))
 			return PaveResult.FAIL;
 
 		FilterItemStack filter = context.getFilterFromBE();


### PR DESCRIPTION
The root of the problem wasn't in the block breaking code (it does properly filter out portal blocks when deciding what to break), but rather in the block filling code in "tryFill". One of the types of blocks it tries to fill is those with empty collision shapes, a condition end portal blocks satisfy.

Fixed by adding an additional nested "or" to the collision shape check to check if the existing block is a portal. Could also be split out into its own separate if statement if desired but I thought this way seemed cleanest.