### PR TITLE
Allow for TrainHatInfoProvider to properly be extended

### DIFF
--- a/src/main/java/com/simibubi/create/api/data/TrainHatInfoProvider.java
+++ b/src/main/java/com/simibubi/create/api/data/TrainHatInfoProvider.java
@@ -61,7 +61,7 @@ public abstract class TrainHatInfoProvider implements DataProvider {
 	}
 
 	@Override
-	public final String getName() {
+	public String getName() {
 		return "Create Train Hat Information";
 	}
 }


### PR DESCRIPTION
If any mod currently wants to extend TrainHatInfoProvider they can't properly set the name, small change to allow overriding the provider name so mod's can set it to their own name