### PR TITLE
Fix to issue #6784, with schematic renderers not deactivating

### DIFF
--- a/src/main/java/com/simibubi/create/content/schematics/client/SchematicHandler.java
+++ b/src/main/java/com/simibubi/create/content/schematics/client/SchematicHandler.java
@@ -112,8 +112,10 @@ public class SchematicHandler {
 
 		if (!active || !stack.getTag()
 			.getString("File")
-			.equals(displayedSchematic))
+			.equals(displayedSchematic)) {
+			renderers.forEach(r -> r.setActive(false));
 			init(player, stack);
+		}
 		if (!active)
 			return;
 
@@ -160,7 +162,7 @@ public class SchematicHandler {
 		BlockPos pos;
 
 		pos = BlockPos.ZERO;
-		
+
 		try {
 			schematic.placeInWorld(w, pos, pos, placementSettings, w.getRandom(), Block.UPDATE_CLIENTS);
 		} catch (Exception e) {


### PR DESCRIPTION
Added render deactivation before initialising the new one, then, in the event that the schematic isn't deployed, and the renderers don't get reset, the existing structure wont stay