### PR TITLE
Fix Graphics Mode Debug Information

### DIFF
--- a/src/main/java/com/simibubi/create/infrastructure/debugInfo/DebugInformation.java
+++ b/src/main/java/com/simibubi/create/infrastructure/debugInfo/DebugInformation.java
@@ -78,7 +78,7 @@ public class DebugInformation {
 					.put("Flywheel Backend", () -> Backend.getBackendType().toString())
 					.put("OpenGL Renderer", GlUtil::getRenderer)
 					.put("OpenGL Version", GlUtil::getOpenGLVersion)
-					.put("Graphics Mode", () -> Minecraft.getInstance().options.graphicsMode().toString())
+					.put("Graphics Mode", () -> Minecraft.getInstance().options.graphicsMode().get().toString())
 					.buildTo(DebugInformation::registerClientInfo);
 		});
 


### PR DESCRIPTION
Just a simple fix to output the correct graphics mode in the debug information. Actually toString the value of the option, not the name of the option