### PR TITLE
fix: items in ponders being culled incorrectly

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/belt/BeltRenderer.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/BeltRenderer.java
@@ -233,7 +233,7 @@ public class BeltRenderer extends SafeBlockEntityRenderer<BeltBlockEntity> {
 					be.getBlockPos().getZ())
 				.add(offsetVec);
 
-			if (this.shouldCullItem(itemPos)) {
+			if (this.shouldCullItem(itemPos, be.getLevel())) {
 				continue;
 			}
 

--- a/src/main/java/com/simibubi/create/foundation/blockEntity/renderer/SafeBlockEntityRenderer.java
+++ b/src/main/java/com/simibubi/create/foundation/blockEntity/renderer/SafeBlockEntityRenderer.java
@@ -2,10 +2,13 @@ package com.simibubi.create.foundation.blockEntity.renderer;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 
+import com.simibubi.create.foundation.ponder.PonderWorld;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.culling.Frustum;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.phys.AABB;
@@ -28,7 +31,10 @@ public abstract class SafeBlockEntityRenderer<T extends BlockEntity> implements 
 			.getBlock() == Blocks.AIR;
 	}
 
-	public boolean shouldCullItem(Vec3 itemPos) {
+	public boolean shouldCullItem(Vec3 itemPos, Level level) {
+		if (level instanceof PonderWorld)
+			return false;
+
 		Frustum frustum = Minecraft.getInstance().levelRenderer.capturedFrustum != null ?
 				Minecraft.getInstance().levelRenderer.capturedFrustum :
 				Minecraft.getInstance().levelRenderer.cullingFrustum;


### PR DESCRIPTION
- Items shouldn't be culled in ponder worlds, the cullingFrustum is wrong and ponders are unpredictable

Fixes: #6896