### PR TITLE
Extra Build Info in jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,8 @@ plugins {
     id 'org.parchmentmc.librarian.forgegradle' version "${librarian_version}"
     id 'org.spongepowered.mixin' version "${mixingradle_version}"
     id 'com.matthewprenger.cursegradle' version "${cursegradle_version}"
+    id("net.kyori.blossom") version "2.1.0" // https://github.com/KyoriPowered/blossom
+    id("org.jetbrains.gradle.plugin.idea-ext") version "1.1.8" // https://github.com/JetBrains/gradle-idea-ext-plugin
 }
 
 jarJar.enable()
@@ -17,6 +19,7 @@ ext.buildNumber = System.getenv('BUILD_NUMBER')
 group = 'com.simibubi.create'
 archivesBaseName = "create-${artifact_minecraft_version}"
 version = mod_version + (dev && buildNumber != null ? "-${buildNumber}" : '')
+String gitHash = "\"${calculateGitHash() + (hasUnstaged() ? "-modified" : "")}\""
 
 java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 
@@ -217,15 +220,20 @@ dependencies {
     }
 }
 
-sourceSets.main.java {
-	if (!cc_tweaked_enable.toBoolean()) {
-        exclude 'com/simibubi/create/compat/computercraft/implementation/**'
-	}
-}
-
-sourceSets.main.resources {
-    srcDir 'src/generated/resources'
-    exclude '.cache/'
+sourceSets.main {
+    java {
+        if (!cc_tweaked_enable.toBoolean()) {
+            exclude 'com/simibubi/create/compat/computercraft/implementation/**'
+        }
+    }
+    resources {
+        srcDir 'src/generated/resources'
+        exclude '.cache/'
+    }
+    blossom.javaSources {
+        property("version", build_info_mod_version)
+        property("gitCommit", gitHash.toString())
+    }
 }
 
 // Workaround for SpongePowered/MixinGradle#38
@@ -242,6 +250,11 @@ compileJava {
     options.compilerArgs = ['-Xdiags:verbose']
 }
 
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
+
 jar {
     archiveClassifier = 'slim'
     manifest {
@@ -253,8 +266,15 @@ jar {
             'Implementation-Version': project.jar.archiveVersion,
             'Implementation-Vendor': 'simibubi',
             'Implementation-Timestamp': new Date().format("yyyy-MM-dd'T'HH:mm:ssZ"),
-            'MixinConfigs': 'create.mixins.json'
+            'MixinConfigs': 'create.mixins.json',
+            'Git-Hash': gitHash
         ])
+    }
+}
+
+tasks.named("sourcesJar") {
+    manifest {
+        attributes(Map.of("Git-Hash", gitHash))
     }
 }
 
@@ -266,11 +286,6 @@ task jarJarRelease {
         }
     }
     finalizedBy tasks.jarJar
-}
-
-java {
-    withSourcesJar()
-    withJavadocJar()
 }
 
 void addLicense(jarTask) {
@@ -303,55 +318,31 @@ publishing {
     }
 }
 
-String getChangelogText() {
-    def changelogFile = file('changelog.txt')
-    String str = ''
-    int lineCount = 0
-    boolean done = false
-    changelogFile.eachLine {
-        if (done || it == null) {
-            return
+String calculateGitHash() {
+    try {
+        ByteArrayOutputStream stdout = new ByteArrayOutputStream()
+        exec {
+            commandLine("git", "rev-parse", "HEAD")
+            standardOutput = stdout
         }
-        if (it.size() > 1) {
-            def temp = it
-            if (lineCount == 0) {
-                temp = "Create ${version}"
-                temp = "<span style=\"font-size: 18px; color: #333399;\">Create v${mod_version}</span>&nbsp;&nbsp;<em>for Minecraft ${minecraft_version}</em><br/>"
-            } else if (it.startsWith('-')) {
-                temp = "&nbsp;&nbsp;&nbsp;$temp<br/>"
-                temp = temp.replaceAll("(\\S+\\/\\S+)#([0-9]+)\\b", "<a href=\"https://github.com/\$1/issues/\$2\">\$0</a>");
-                temp = temp.replaceAll("#([0-9]+)\\b(?!<\\/a>)", "<a href=\"https://github.com/$github_project/issues/\$1\">\$0</a>");
-            } else {
-                temp = "<h4>$temp</h4>"
-            }
-            str += temp
-            lineCount++
-        } else {
-            str += "<p>Please submit any Issues you come across on the&nbsp;<a href=\"https://github.com/${github_project}/issues\" rel=\"nofollow\">Issue Tracker</a>.</p>"
-            done = true
-        }
+        return stdout.toString().trim()
+    } catch(Throwable ignored) {
+        return "unknown"
     }
-    return str
 }
 
-// changelog debugging
-// new File("changelog.html").write getChangelogText()
-// tasks.curseforge.enabled = !dev && project.hasProperty('simi_curseforge_key')
-// curseforge {
-//     if (project.hasProperty('simi_curseforge_key')) {
-//         apiKey = project.simi_curseforge_key
-//     }
-//
-//     project {
-//         id = project.projectId
-//         changelog = System.getenv('CHANGELOG') == null || System.getenv('CHANGELOG').equals('none') ? getChangelogText() : System.getenv('CHANGELOG')
-//         changelogType = 'html'
-//         releaseType = project.curse_type
-//         mainArtifact(shadowJar) {
-//             displayName = "Create - ${version}"
-//         }
-//         relations {
-//             optionalDependency 'jei'
-//         }
-//     }
-// }
+boolean hasUnstaged() {
+    try {
+        ByteArrayOutputStream stdout = new ByteArrayOutputStream()
+        exec {
+            commandLine("git", "status", "--porcelain")
+            standardOutput = stdout
+        }
+        String result = stdout.toString().replace("/M gradlew(\\.bat)?/", "").trim()
+        if (!result.isEmpty())
+            println("Found stageable results:\n${result}\n")
+        return !result.isEmpty()
+    }  catch(Throwable ignored) {
+        return false
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,9 @@ org.gradle.jvmargs = -Xmx3G
 org.gradle.daemon = false
 
 # mod version info
+# build_info_mod_version is the version that gets filled into BuildParameters.java
 mod_version = 0.5.2
+build_info_mod_version = 0.5.2-experimental
 artifact_minecraft_version = 1.20.1
 
 minecraft_version = 1.20.1

--- a/src/main/java-templates/com/simibubi/create/CreateBuildInfo.java.peb
+++ b/src/main/java-templates/com/simibubi/create/CreateBuildInfo.java.peb
@@ -1,0 +1,6 @@
+package com.simibubi.create;
+
+public class CreateBuildInfo {
+    public static String VERSION = "{{ version }}";
+    public static String GIT_COMMIT = {{ gitCommit }};
+}

--- a/src/main/java/com/simibubi/create/Create.java
+++ b/src/main/java/com/simibubi/create/Create.java
@@ -57,10 +57,8 @@ import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 
 @Mod(Create.ID)
 public class Create {
-
 	public static final String ID = "create";
 	public static final String NAME = "Create";
-	public static final String VERSION = "0.5.2-experimental";
 
 	public static final Logger LOGGER = LogUtils.getLogger();
 
@@ -97,6 +95,8 @@ public class Create {
 	}
 
 	public static void onCtor() {
+		LOGGER.info("{} {} initializing! Commit hash: {}", NAME, CreateBuildInfo.VERSION, CreateBuildInfo.GIT_COMMIT);
+
 		ModLoadingContext modLoadingContext = ModLoadingContext.get();
 
 		IEventBus modEventBus = FMLJavaModLoadingContext.get()
@@ -174,5 +174,4 @@ public class Create {
 	public static ResourceLocation asResource(String path) {
 		return new ResourceLocation(ID, path);
 	}
-
 }

--- a/src/main/java/com/simibubi/create/infrastructure/debugInfo/DebugInformation.java
+++ b/src/main/java/com/simibubi/create/infrastructure/debugInfo/DebugInformation.java
@@ -11,6 +11,7 @@ import javax.annotation.Nullable;
 import com.google.common.collect.ImmutableMap;
 import com.mojang.blaze3d.platform.GlUtil;
 import com.simibubi.create.Create;
+import com.simibubi.create.CreateBuildInfo;
 import com.simibubi.create.foundation.mixin.accessor.SystemReportAccessor;
 import com.simibubi.create.infrastructure.debugInfo.element.DebugInfoSection;
 import com.simibubi.create.infrastructure.debugInfo.element.InfoElement;
@@ -68,7 +69,7 @@ public class DebugInformation {
 
 	static {
 		DebugInfoSection.builder(Create.NAME)
-				.put("Mod Version", Create.VERSION)
+				.put("Mod Version", CreateBuildInfo.VERSION)
 				.put("Forge Version", getVersionOfMod("forge"))
 				.put("Minecraft Version", SharedConstants.getCurrentVersion().getName())
 				.buildTo(DebugInformation::registerBothInfo);

--- a/src/main/java/com/simibubi/create/infrastructure/gui/CreateMainMenuScreen.java
+++ b/src/main/java/com/simibubi/create/infrastructure/gui/CreateMainMenuScreen.java
@@ -5,6 +5,7 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.simibubi.create.AllBlocks;
 import com.simibubi.create.Create;
+import com.simibubi.create.CreateBuildInfo;
 import com.simibubi.create.foundation.config.ui.BaseConfigScreen;
 import com.simibubi.create.foundation.gui.AbstractSimiScreen;
 import com.simibubi.create.foundation.gui.AllGuiTextures;
@@ -110,7 +111,7 @@ public class CreateMainMenuScreen extends AbstractSimiScreen {
 				.render(graphics);
 			ms.popPose();
 		}
-		
+
 	    RenderSystem.enableBlend();
 
 		ms.pushPose();
@@ -130,7 +131,7 @@ public class CreateMainMenuScreen extends AbstractSimiScreen {
 		ms.translate(0, 0, 200);
 		graphics.drawCenteredString(font, Components.literal(Create.NAME).withStyle(ChatFormatting.BOLD)
 			.append(
-				Components.literal(" v" + Create.VERSION).withStyle(ChatFormatting.BOLD, ChatFormatting.WHITE)),
+				Components.literal(" v" + CreateBuildInfo.VERSION).withStyle(ChatFormatting.BOLD, ChatFormatting.WHITE)),
 			width / 2, 89, 0xFF_E4BB67);
 		ms.popPose();
 


### PR DESCRIPTION
- Adds commit sha to jar manifest
- Also logs the commit sha to console upon the mod initalizing, this is helpful when binary searching or needing to findout what commit a version was built from quickly

Fixes #5779