### PR TITLE
Update JEI integration and add potion fluids to the ingredient list

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,7 @@ registrate_version = MC1.20-1.3.3
 flywheel_minecraft_version = 1.20.1
 flywheel_version = 1.0.0-beta-113
 jei_minecraft_version = 1.20.1
-jei_version = 15.10.0.39
+jei_version = 15.19.0.85
 curios_minecraft_version = 1.20.1
 curios_version = 5.3.1
 

--- a/src/main/java/com/simibubi/create/AllFluids.java
+++ b/src/main/java/com/simibubi/create/AllFluids.java
@@ -7,6 +7,8 @@ import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
+import com.simibubi.create.content.fluids.VirtualFluid;
+
 import org.jetbrains.annotations.NotNull;
 import org.joml.Vector3f;
 
@@ -14,7 +16,6 @@ import com.mojang.blaze3d.shaders.FogShape;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.simibubi.create.AllTags.AllFluidTags;
 import com.simibubi.create.content.decoration.palettes.AllPaletteStoneTypes;
-import com.simibubi.create.content.fluids.VirtualFluid;
 import com.simibubi.create.content.fluids.potion.PotionFluid;
 import com.simibubi.create.content.fluids.potion.PotionFluid.PotionFluidType;
 import com.simibubi.create.foundation.utility.Color;
@@ -46,7 +47,7 @@ public class AllFluids {
 	}
 
 	public static final FluidEntry<PotionFluid> POTION =
-		REGISTRATE.virtualFluid("potion", PotionFluidType::new, PotionFluid::new)
+		REGISTRATE.virtualFluid("potion", PotionFluidType::new, PotionFluid::createSource, PotionFluid::createFlowing)
 			.lang("Potion")
 			.register();
 

--- a/src/main/java/com/simibubi/create/compat/jei/CreateJEI.java
+++ b/src/main/java/com/simibubi/create/compat/jei/CreateJEI.java
@@ -78,6 +78,7 @@ import mezz.jei.api.forge.ForgeTypes;
 import mezz.jei.api.gui.drawable.IDrawable;
 import mezz.jei.api.helpers.IPlatformFluidHelper;
 import mezz.jei.api.recipe.category.IRecipeCategory;
+import mezz.jei.api.registration.IExtraIngredientRegistration;
 import mezz.jei.api.registration.IGuiHandlerRegistration;
 import mezz.jei.api.registration.IRecipeCatalystRegistration;
 import mezz.jei.api.registration.IRecipeCategoryRegistration;
@@ -90,6 +91,7 @@ import net.minecraft.core.RegistryAccess;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.alchemy.Potion;
 import net.minecraft.world.item.crafting.AbstractCookingRecipe;
 import net.minecraft.world.item.crafting.CraftingRecipe;
 import net.minecraft.world.item.crafting.Recipe;
@@ -98,7 +100,9 @@ import net.minecraft.world.item.crafting.SmokingRecipe;
 import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraftforge.common.crafting.IShapedRecipe;
+import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fml.ModList;
+import net.minecraftforge.registries.ForgeRegistries;
 
 @JeiPlugin
 @SuppressWarnings("unused")
@@ -361,6 +365,17 @@ public class CreateJEI implements IModPlugin {
 		PotionFluid potionFluid = AllFluids.POTION.get();
 		registration.registerSubtypeInterpreter(ForgeTypes.FLUID_STACK, potionFluid.getSource(), interpreter);
 		registration.registerSubtypeInterpreter(ForgeTypes.FLUID_STACK, potionFluid.getFlowing(), interpreter);
+	}
+
+	@Override
+	public void registerExtraIngredients(IExtraIngredientRegistration registration) {
+		Collection<Potion> potions = ForgeRegistries.POTIONS.getValues();
+		Collection<FluidStack> potionFluids = new ArrayList<>(potions.size());
+		for (Potion potion : potions) {
+			FluidStack potionFluid = PotionFluid.of(1000, potion);
+			potionFluids.add(potionFluid);
+		}
+		registration.addExtraIngredients(ForgeTypes.FLUID_STACK, potionFluids);
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })

--- a/src/main/java/com/simibubi/create/compat/jei/CreateJEI.java
+++ b/src/main/java/com/simibubi/create/compat/jei/CreateJEI.java
@@ -370,10 +370,15 @@ public class CreateJEI implements IModPlugin {
 	@Override
 	public void registerExtraIngredients(IExtraIngredientRegistration registration) {
 		Collection<Potion> potions = ForgeRegistries.POTIONS.getValues();
-		Collection<FluidStack> potionFluids = new ArrayList<>(potions.size());
+		Collection<FluidStack> potionFluids = new ArrayList<>(potions.size() * 3);
 		for (Potion potion : potions) {
-			FluidStack potionFluid = PotionFluid.of(1000, potion);
-			potionFluids.add(potionFluid);
+			// @goshante: Ingame potion fluids always have Bottle tag that specifies
+			// to what bottle type this potion belongs
+			// Potion fluid without this tag wouldn't be recognized by other mods
+			for (PotionFluid.BottleType bottleType : PotionFluid.BottleType.values()) {
+				FluidStack potionFluid = PotionFluid.of(1000, potion, bottleType);
+				potionFluids.add(potionFluid);
+			}
 		}
 		registration.addExtraIngredients(ForgeTypes.FLUID_STACK, potionFluids);
 	}

--- a/src/main/java/com/simibubi/create/compat/jei/category/BasinCategory.java
+++ b/src/main/java/com/simibubi/create/compat/jei/category/BasinCategory.java
@@ -67,7 +67,7 @@ public class BasinCategory extends CreateRecipeCategory<BasinRecipe> {
 					.addSlot(RecipeIngredientRole.INPUT, 17 + xOffset + (i % 3) * 19, 51 - (i / 3) * 19)
 					.setBackground(getRenderedSlot(), -1, -1)
 					.addIngredients(ForgeTypes.FLUID_STACK, withImprovedVisibility(fluidIngredient.getMatchingFluidStacks()))
-					.addTooltipCallback(addFluidTooltip(fluidIngredient.getRequiredAmount()));
+					.addRichTooltipCallback(addFluidTooltip(fluidIngredient.getRequiredAmount()));
 			i++;
 		}
 
@@ -82,7 +82,7 @@ public class BasinCategory extends CreateRecipeCategory<BasinRecipe> {
 					.addSlot(RecipeIngredientRole.OUTPUT, xPosition, yPosition)
 					.setBackground(getRenderedSlot(result), -1, -1)
 					.addItemStack(result.getStack())
-					.addTooltipCallback(addStochasticTooltip(result));
+					.addRichTooltipCallback(addStochasticTooltip(result));
 			i++;
 		}
 
@@ -94,7 +94,7 @@ public class BasinCategory extends CreateRecipeCategory<BasinRecipe> {
 					.addSlot(RecipeIngredientRole.OUTPUT, xPosition, yPosition)
 					.setBackground(getRenderedSlot(), -1, -1)
 					.addIngredient(ForgeTypes.FLUID_STACK, withImprovedVisibility(fluidResult))
-					.addTooltipCallback(addFluidTooltip(fluidResult.getAmount()));
+					.addRichTooltipCallback(addFluidTooltip(fluidResult.getAmount()));
 			i++;
 		}
 

--- a/src/main/java/com/simibubi/create/compat/jei/category/CreateRecipeCategory.java
+++ b/src/main/java/com/simibubi/create/compat/jei/category/CreateRecipeCategory.java
@@ -8,6 +8,8 @@ import java.util.stream.Collectors;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import mezz.jei.api.gui.ingredient.IRecipeSlotRichTooltipCallback;
+
 import org.jetbrains.annotations.NotNull;
 
 import com.simibubi.create.AllFluids;
@@ -108,11 +110,11 @@ public abstract class CreateRecipeCategory<T extends Recipe<?>> implements IReci
 		return recipe.getResultItem(level.registryAccess());
 	}
 
-	public static IRecipeSlotTooltipCallback addStochasticTooltip(ProcessingOutput output) {
+	public static IRecipeSlotRichTooltipCallback addStochasticTooltip(ProcessingOutput output) {
 		return (view, tooltip) -> {
 			float chance = output.getChance();
 			if (chance != 1)
-				tooltip.add(1, Lang.translateDirect("recipe.processing.chance", chance < 0.01 ? "<1" : (int) (chance * 100))
+				tooltip.add(Lang.translateDirect("recipe.processing.chance", chance < 0.01 ? "<1" : (int) (chance * 100))
 					.withStyle(ChatFormatting.GOLD));
 		};
 	}
@@ -130,11 +132,11 @@ public abstract class CreateRecipeCategory<T extends Recipe<?>> implements IReci
 		return display;
 	}
 
-	public static IRecipeSlotTooltipCallback addFluidTooltip() {
+	public static IRecipeSlotRichTooltipCallback addFluidTooltip() {
 		return addFluidTooltip(-1);
 	}
 
-	public static IRecipeSlotTooltipCallback addFluidTooltip(int mbAmount) {
+	public static IRecipeSlotRichTooltipCallback addFluidTooltip(int mbAmount) {
 		return (view, tooltip) -> {
 			Optional<FluidStack> displayed = view.getDisplayedIngredient(ForgeTypes.FLUID_STACK);
 			if (displayed.isEmpty())
@@ -143,26 +145,14 @@ public abstract class CreateRecipeCategory<T extends Recipe<?>> implements IReci
 			FluidStack fluidStack = displayed.get();
 
 			if (fluidStack.getFluid().isSame(AllFluids.POTION.get())) {
-				Component name = fluidStack.getDisplayName();
-				if (tooltip.isEmpty())
-					tooltip.add(0, name);
-				else
-					tooltip.set(0, name);
-
 				ArrayList<Component> potionTooltip = new ArrayList<>();
 				PotionFluidHandler.addPotionTooltip(fluidStack, potionTooltip, 1);
-				tooltip.addAll(1, potionTooltip.stream().toList());
+				tooltip.addAll(potionTooltip.stream().toList());
 			}
 
 			int amount = mbAmount == -1 ? fluidStack.getAmount() : mbAmount;
 			Component text = Components.literal(String.valueOf(amount)).append(Lang.translateDirect("generic.unit.millibuckets")).withStyle(ChatFormatting.GOLD);
-			if (tooltip.isEmpty())
-				tooltip.add(0, text);
-			else {
-				List<Component> siblings = tooltip.get(0).getSiblings();
-				siblings.add(Components.literal(" "));
-				siblings.add(text);
-			}
+			tooltip.add(text);
 		};
 	}
 

--- a/src/main/java/com/simibubi/create/compat/jei/category/CrushingCategory.java
+++ b/src/main/java/com/simibubi/create/compat/jei/category/CrushingCategory.java
@@ -41,7 +41,7 @@ public class CrushingCategory extends CreateRecipeCategory<AbstractCrushingRecip
 				.addSlot(RecipeIngredientRole.OUTPUT, (xOffset) + layoutEntry.posX() + 1, yOffset + layoutEntry.posY() + 1)
 				.setBackground(getRenderedSlot(layoutEntry.output()), -1, -1)
 				.addItemStack(layoutEntry.output().getStack())
-				.addTooltipCallback(addStochasticTooltip(layoutEntry.output()))
+				.addRichTooltipCallback(addStochasticTooltip(layoutEntry.output()))
 		);
 	}
 

--- a/src/main/java/com/simibubi/create/compat/jei/category/DeployingCategory.java
+++ b/src/main/java/com/simibubi/create/compat/jei/category/DeployingCategory.java
@@ -47,7 +47,7 @@ public class DeployingCategory extends CreateRecipeCategory<DeployerApplicationR
 			builder.addSlot(RecipeIngredientRole.OUTPUT, single ? 132 : 132 + xOffset, 51 + yOffset)
 				.setBackground(getRenderedSlot(output), -1, -1)
 				.addItemStack(output.getStack())
-				.addTooltipCallback(addStochasticTooltip(output));
+				.addRichTooltipCallback(addStochasticTooltip(output));
 		}
 
 		if (recipe.shouldKeepHeldItem())

--- a/src/main/java/com/simibubi/create/compat/jei/category/ItemApplicationCategory.java
+++ b/src/main/java/com/simibubi/create/compat/jei/category/ItemApplicationCategory.java
@@ -58,7 +58,7 @@ public class ItemApplicationCategory extends CreateRecipeCategory<ItemApplicatio
 			builder.addSlot(RecipeIngredientRole.OUTPUT, single ? 132 : 132 + xOffset, 38 + yOffset)
 				.setBackground(getRenderedSlot(output), -1, -1)
 				.addItemStack(output.getStack())
-				.addTooltipCallback(addStochasticTooltip(output));
+				.addRichTooltipCallback(addStochasticTooltip(output));
 		}
 	}
 

--- a/src/main/java/com/simibubi/create/compat/jei/category/ItemDrainCategory.java
+++ b/src/main/java/com/simibubi/create/compat/jei/category/ItemDrainCategory.java
@@ -91,7 +91,7 @@ public class ItemDrainCategory extends CreateRecipeCategory<EmptyingRecipe> {
 				.addSlot(RecipeIngredientRole.OUTPUT, 132, 8)
 				.setBackground(getRenderedSlot(), -1, -1)
 				.addIngredient(ForgeTypes.FLUID_STACK, withImprovedVisibility(recipe.getResultingFluid()))
-				.addTooltipCallback(addFluidTooltip(recipe.getResultingFluid().getAmount()));
+				.addRichTooltipCallback(addFluidTooltip(recipe.getResultingFluid().getAmount()));
 		builder
 				.addSlot(RecipeIngredientRole.OUTPUT, 132, 27)
 				.setBackground(getRenderedSlot(), -1, -1)

--- a/src/main/java/com/simibubi/create/compat/jei/category/MillingCategory.java
+++ b/src/main/java/com/simibubi/create/compat/jei/category/MillingCategory.java
@@ -42,7 +42,7 @@ public class MillingCategory extends CreateRecipeCategory<AbstractCrushingRecipe
 					.addSlot(RecipeIngredientRole.OUTPUT, single ? 139 : 133 + xOffset, 27 + yOffset)
 					.setBackground(getRenderedSlot(output), -1, -1)
 					.addItemStack(output.getStack())
-					.addTooltipCallback(addStochasticTooltip(output));
+					.addRichTooltipCallback(addStochasticTooltip(output));
 
 			i++;
 		}

--- a/src/main/java/com/simibubi/create/compat/jei/category/PolishingCategory.java
+++ b/src/main/java/com/simibubi/create/compat/jei/category/PolishingCategory.java
@@ -40,7 +40,7 @@ public class PolishingCategory extends CreateRecipeCategory<SandPaperPolishingRe
 				.addSlot(RecipeIngredientRole.OUTPUT, 132, 29)
 				.setBackground(getRenderedSlot(output), -1, -1)
 				.addItemStack(output.getStack())
-				.addTooltipCallback(addStochasticTooltip(output));
+				.addRichTooltipCallback(addStochasticTooltip(output));
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/compat/jei/category/PressingCategory.java
+++ b/src/main/java/com/simibubi/create/compat/jei/category/PressingCategory.java
@@ -37,7 +37,7 @@ public class PressingCategory extends CreateRecipeCategory<PressingRecipe> {
 			builder.addSlot(RecipeIngredientRole.OUTPUT, 131 + 19 * i, 50)
 					.setBackground(getRenderedSlot(output), -1, -1)
 					.addItemStack(output.getStack())
-					.addTooltipCallback(addStochasticTooltip(output));
+					.addRichTooltipCallback(addStochasticTooltip(output));
 			i++;
 		}
 	}

--- a/src/main/java/com/simibubi/create/compat/jei/category/ProcessingViaFanCategory.java
+++ b/src/main/java/com/simibubi/create/compat/jei/category/ProcessingViaFanCategory.java
@@ -117,7 +117,7 @@ public abstract class ProcessingViaFanCategory<T extends Recipe<?>> extends Crea
 						.addSlot(RecipeIngredientRole.OUTPUT, 141 + xOffset, 48 + yOffset)
 						.setBackground(getRenderedSlot(output), -1, -1)
 						.addItemStack(output.getStack())
-						.addTooltipCallback(addStochasticTooltip(output));
+						.addRichTooltipCallback(addStochasticTooltip(output));
 				i++;
 			}
 		}

--- a/src/main/java/com/simibubi/create/compat/jei/category/SawingCategory.java
+++ b/src/main/java/com/simibubi/create/compat/jei/category/SawingCategory.java
@@ -40,7 +40,7 @@ public class SawingCategory extends CreateRecipeCategory<CuttingRecipe> {
 					.addSlot(RecipeIngredientRole.OUTPUT, 118 + xOffset, 48 + yOffset)
 					.setBackground(getRenderedSlot(output), -1, -1)
 					.addItemStack(output.getStack())
-					.addTooltipCallback(addStochasticTooltip(output));
+					.addRichTooltipCallback(addStochasticTooltip(output));
 			i++;
 		}
 	}

--- a/src/main/java/com/simibubi/create/compat/jei/category/SpoutCategory.java
+++ b/src/main/java/com/simibubi/create/compat/jei/category/SpoutCategory.java
@@ -103,7 +103,7 @@ public class SpoutCategory extends CreateRecipeCategory<FillingRecipe> {
 				.addSlot(RecipeIngredientRole.INPUT, 27, 32)
 				.setBackground(getRenderedSlot(), -1, -1)
 				.addIngredients(ForgeTypes.FLUID_STACK, withImprovedVisibility(recipe.getRequiredFluid().getMatchingFluidStacks()))
-				.addTooltipCallback(addFluidTooltip(recipe.getRequiredFluid().getRequiredAmount()));
+				.addRichTooltipCallback(addFluidTooltip(recipe.getRequiredFluid().getRequiredAmount()));
 		builder
 				.addSlot(RecipeIngredientRole.OUTPUT, 132, 51)
 				.setBackground(getRenderedSlot(), -1, -1)

--- a/src/main/java/com/simibubi/create/compat/jei/category/sequencedAssembly/SequencedAssemblySubCategory.java
+++ b/src/main/java/com/simibubi/create/compat/jei/category/sequencedAssembly/SequencedAssemblySubCategory.java
@@ -76,7 +76,7 @@ public abstract class SequencedAssemblySubCategory {
 					.addSlot(RecipeIngredientRole.INPUT, x + 4, 15)
 					.setBackground(CreateRecipeCategory.getRenderedSlot(), -1, -1)
 					.addIngredients(ForgeTypes.FLUID_STACK, CreateRecipeCategory.withImprovedVisibility(fluidIngredient.getMatchingFluidStacks()))
-					.addTooltipCallback(CreateRecipeCategory.addFluidTooltip(fluidIngredient.getRequiredAmount()));
+					.addRichTooltipCallback(CreateRecipeCategory.addFluidTooltip(fluidIngredient.getRequiredAmount()));
 		}
 
 		@Override

--- a/src/main/java/com/simibubi/create/content/fluids/VirtualFluid.java
+++ b/src/main/java/com/simibubi/create/content/fluids/VirtualFluid.java
@@ -1,5 +1,7 @@
 package com.simibubi.create.content.fluids;
 
+import com.simibubi.create.content.fluids.potion.PotionFluid;
+
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Blocks;
@@ -10,17 +12,35 @@ import net.minecraftforge.fluids.ForgeFlowingFluid;
 
 public class VirtualFluid extends ForgeFlowingFluid {
 
-	public VirtualFluid(Properties properties) {
+	public static VirtualFluid createSource(Properties properties) {
+		return new VirtualFluid(properties, true);
+	}
+
+	public static VirtualFluid createFlowing(Properties properties) {
+		return new VirtualFluid(properties, false);
+	}
+
+
+	private final boolean source;
+
+	public VirtualFluid(Properties properties, boolean source) {
 		super(properties);
+		this.source = source;
 	}
 
 	@Override
 	public Fluid getSource() {
+		if (source) {
+			return this;
+		}
 		return super.getSource();
 	}
 
 	@Override
 	public Fluid getFlowing() {
+		if (source) {
+			return super.getFlowing();
+		}
 		return this;
 	}
 
@@ -36,7 +56,7 @@ public class VirtualFluid extends ForgeFlowingFluid {
 
 	@Override
 	public boolean isSource(FluidState p_207193_1_) {
-		return false;
+		return source;
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/fluids/potion/PotionFluid.java
+++ b/src/main/java/com/simibubi/create/content/fluids/potion/PotionFluid.java
@@ -36,15 +36,17 @@ public class PotionFluid extends VirtualFluid {
 		super(properties, source);
 	}
 
-	public static FluidStack of(int amount, Potion potion) {
-		FluidStack fluidStack = new FluidStack(AllFluids.POTION.get()
-			.getSource(), amount);
+	public static FluidStack of(int amount, Potion potion, BottleType bottleType) {
+
+		FluidStack fluidStack;
+		fluidStack = new FluidStack(AllFluids.POTION.get().getSource(), amount);
 		addPotionToFluidStack(fluidStack, potion);
+		NBTHelper.writeEnum(fluidStack.getOrCreateTag(), "Bottle", bottleType);
 		return fluidStack;
 	}
 
 	public static FluidStack withEffects(int amount, Potion potion, List<MobEffectInstance> customEffects) {
-		FluidStack fluidStack = of(amount, potion);
+		FluidStack fluidStack = of(amount, potion, BottleType.REGULAR);
 		appendEffects(fluidStack, customEffects);
 		return fluidStack;
 	}

--- a/src/main/java/com/simibubi/create/content/fluids/potion/PotionFluid.java
+++ b/src/main/java/com/simibubi/create/content/fluids/potion/PotionFluid.java
@@ -24,8 +24,16 @@ import net.minecraftforge.fluids.FluidStack;
 
 public class PotionFluid extends VirtualFluid {
 
-	public PotionFluid(Properties properties) {
-		super(properties);
+	public static PotionFluid createSource(Properties properties) {
+		return new PotionFluid(properties, true);
+	}
+
+	public static PotionFluid createFlowing(Properties properties) {
+		return new PotionFluid(properties, false);
+	}
+
+	public PotionFluid(Properties properties, boolean source) {
+		super(properties, source);
 	}
 
 	public static FluidStack of(int amount, Potion potion) {

--- a/src/main/java/com/simibubi/create/content/fluids/potion/PotionFluidHandler.java
+++ b/src/main/java/com/simibubi/create/content/fluids/potion/PotionFluidHandler.java
@@ -42,7 +42,7 @@ public class PotionFluidHandler {
 		return stack.getItem() instanceof PotionItem && !(stack.getCraftingRemainingItem()
 			.getItem() instanceof BucketItem);
 	}
-	
+
 	public static Pair<FluidStack, ItemStack> emptyPotion(ItemStack stack, boolean simulate) {
 		FluidStack fluid = getFluidFromPotionItem(stack);
 		if (!simulate)
@@ -69,8 +69,7 @@ public class PotionFluidHandler {
 	public static FluidStack getFluidFromPotion(Potion potion, BottleType bottleType, int amount) {
 		if (potion == Potions.WATER && bottleType == BottleType.REGULAR)
 			return new FluidStack(Fluids.WATER, amount);
-		FluidStack fluid = PotionFluid.of(amount, potion);
-		NBTHelper.writeEnum(fluid.getOrCreateTag(), "Bottle", bottleType);
+		FluidStack fluid = PotionFluid.of(amount, potion, bottleType);
 		return fluid;
 	}
 

--- a/src/main/java/com/simibubi/create/foundation/data/CreateRegistrate.java
+++ b/src/main/java/com/simibubi/create/foundation/data/CreateRegistrate.java
@@ -172,29 +172,30 @@ public class CreateRegistrate extends AbstractRegistrate<CreateRegistrate> {
 	/* Fluids */
 
 	public <T extends ForgeFlowingFluid> FluidBuilder<T, CreateRegistrate> virtualFluid(String name,
-		FluidBuilder.FluidTypeFactory typeFactory, NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
+		FluidBuilder.FluidTypeFactory typeFactory, NonNullFunction<ForgeFlowingFluid.Properties, T> sourceFactory,
+		NonNullFunction<ForgeFlowingFluid.Properties, T> flowingFactory) {
 		return entry(name,
 			c -> new VirtualFluidBuilder<>(self(), self(), name, c, new ResourceLocation(getModid(), "fluid/" + name + "_still"),
-				new ResourceLocation(getModid(), "fluid/" + name + "_flow"), typeFactory, factory));
+				new ResourceLocation(getModid(), "fluid/" + name + "_flow"), typeFactory, sourceFactory, flowingFactory));
 	}
 
 	public <T extends ForgeFlowingFluid> FluidBuilder<T, CreateRegistrate> virtualFluid(String name,
 		ResourceLocation still, ResourceLocation flow, FluidBuilder.FluidTypeFactory typeFactory,
-		NonNullFunction<ForgeFlowingFluid.Properties, T> factory) {
-		return entry(name, c -> new VirtualFluidBuilder<>(self(), self(), name, c, still, flow, typeFactory, factory));
+		NonNullFunction<ForgeFlowingFluid.Properties, T> sourceFactory, NonNullFunction<ForgeFlowingFluid.Properties, T> flowingFactory) {
+		return entry(name, c -> new VirtualFluidBuilder<>(self(), self(), name, c, still, flow, typeFactory, sourceFactory, flowingFactory));
 	}
 
 	public FluidBuilder<VirtualFluid, CreateRegistrate> virtualFluid(String name) {
 		return entry(name,
 			c -> new VirtualFluidBuilder<VirtualFluid, CreateRegistrate>(self(), self(), name, c,
 				new ResourceLocation(getModid(), "fluid/" + name + "_still"), new ResourceLocation(getModid(), "fluid/" + name + "_flow"),
-				CreateRegistrate::defaultFluidType, VirtualFluid::new));
+				CreateRegistrate::defaultFluidType, VirtualFluid::createSource, VirtualFluid::createFlowing));
 	}
 
 	public FluidBuilder<VirtualFluid, CreateRegistrate> virtualFluid(String name, ResourceLocation still,
 		ResourceLocation flow) {
 		return entry(name, c -> new VirtualFluidBuilder<>(self(), self(), name, c, still, flow,
-			CreateRegistrate::defaultFluidType, VirtualFluid::new));
+			CreateRegistrate::defaultFluidType, VirtualFluid::createSource, VirtualFluid::createFlowing));
 	}
 
 	public FluidBuilder<ForgeFlowingFluid.Flowing, CreateRegistrate> standardFluid(String name) {

--- a/src/main/java/com/simibubi/create/foundation/data/VirtualFluidBuilder.java
+++ b/src/main/java/com/simibubi/create/foundation/data/VirtualFluidBuilder.java
@@ -17,9 +17,11 @@ public class VirtualFluidBuilder<T extends ForgeFlowingFluid, P> extends FluidBu
 
 	public VirtualFluidBuilder(AbstractRegistrate<?> owner, P parent, String name, BuilderCallback callback,
 		ResourceLocation stillTexture, ResourceLocation flowingTexture, FluidBuilder.FluidTypeFactory typeFactory,
-		NonNullFunction<Properties, T> factory) {
-		super(owner, parent, name, callback, stillTexture, flowingTexture, typeFactory, factory);
-		source(factory);
+		NonNullFunction<Properties, T> sourceFactory,
+	    NonNullFunction<Properties, T> flowingFactory
+   ) {
+		super(owner, parent, name, callback, stillTexture, flowingTexture, typeFactory, flowingFactory);
+		source(sourceFactory);
 	}
 
 	@Override

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -36,3 +36,10 @@ Technology that empowers the player.'''
     versionRange="[1.0.0-alpha,2.0)"
     ordering="AFTER"
     side="CLIENT"
+
+[[dependencies.create]]
+    modId="jei"
+    mandatory=false
+    versionRange="[15.19.0,)"
+    ordering="NONE"
+    side="CLIENT"


### PR DESCRIPTION
This feature was requested on my GitHub for JEI, but I found that it required a small update to Create in order to work.
Fixes https://github.com/mezz/JustEnoughItems/issues/3754

This also resolves a minor issue where all virtual fluids were registered in a way that they were considered "flowing". 
I doubt that was causing many issues but it did impact the fluid tooltips in JEI.

Note that tooltips callbacks are simplified in the latest JEI, you can only append to the tooltip.
The end result is slightly less fancy (fluid amount is on its own line) but the same functionality has been preserved.
JEI has improved fluid tooltips compared to before, and so some fluid tooltip logic in Create was made redundant and was able to be removed.

I have added a minimum version requirement for JEI (`15.19.0.+`) if it is present, because I added new APIs to JEI in order to support this feature.

![2024-09-12_16 52 24](https://github.com/user-attachments/assets/4b00ff64-d3eb-4f9e-b720-5e737486c849)
