### PR TITLE
Null-check multiblock controllers when disassembling

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/Contraption.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/Contraption.java
@@ -1199,6 +1199,9 @@ public abstract class Contraption {
 			// swap nbt data to the new controller position
 			StructureBlockInfo prevControllerInfo = blocks.get(controllerPos);
 			StructureBlockInfo newControllerInfo = blocks.get(otherPos);
+			if (prevControllerInfo == null || newControllerInfo == null)
+				return;
+
 			blocks.put(otherPos, new StructureBlockInfo(newControllerInfo.pos(), newControllerInfo.state(), prevControllerInfo.nbt()));
 			blocks.put(controllerPos, new StructureBlockInfo(prevControllerInfo.pos(), prevControllerInfo.state(), newControllerInfo.nbt()));
 		});


### PR DESCRIPTION
Hi!

We run a public Create server (running Minecraft `1.20.1`) and it started crashing pretty regularly after updating to `0.5.1h`. Did some digging and found it's the same issue as #6915, albiet with gantries rather than pistons.

My understanding is: in rare cases, a second contraption can pick up multi-blocks too quickly and the `prevControllerInfo` ends up null, crashing the game/server. I suspect there might be a "better" solution of kinda "doing it right" to prevent the `null` from appearing in the first place, but my knowledge of the Create codebase is limited and this at least stops the server from crashing from this.

Fixes #6915 and #6925