### PR TITLE
fix spout weird rendering and rare client crash

### DIFF
--- a/src/main/java/com/simibubi/create/content/fluids/spout/SpoutBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/fluids/spout/SpoutBlockEntity.java
@@ -232,7 +232,7 @@ public class SpoutBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 	protected void spawnProcessingParticles(FluidStack fluid) {
 		if (isVirtual())
 			return;
-		if(fluid.isEmpty())
+		if (fluid.isEmpty())
 			return;
 		Vec3 vec = VecHelper.getCenterOf(worldPosition);
 		vec = vec.subtract(0, 8 / 16f, 0);

--- a/src/main/java/com/simibubi/create/content/fluids/spout/SpoutBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/fluids/spout/SpoutBlockEntity.java
@@ -232,6 +232,8 @@ public class SpoutBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 	protected void spawnProcessingParticles(FluidStack fluid) {
 		if (isVirtual())
 			return;
+		if(fluid.isEmpty())
+			return;
 		Vec3 vec = VecHelper.getCenterOf(worldPosition);
 		vec = vec.subtract(0, 8 / 16f, 0);
 		ParticleOptions particle = FluidFX.getFluidParticle(fluid);

--- a/src/main/java/com/simibubi/create/content/fluids/spout/SpoutRenderer.java
+++ b/src/main/java/com/simibubi/create/content/fluids/spout/SpoutRenderer.java
@@ -65,9 +65,9 @@ public class SpoutRenderer extends SafeBlockEntityRenderer<SpoutBlockEntity> {
 		processingProgress = Mth.clamp(processingProgress, 0, 1);
 		float radius = 0;
 
-		if (processingTicks != -1) {
+		if (!fluidStack.isEmpty() && processingTicks != -1) {
 			radius = (float) (Math.pow(((2 * processingProgress) - 1), 2) - 1);
-			AABB bb = new AABB(0.5, .5, 0.5, 0.5, -1.2, 0.5).inflate(radius / 32f);
+			AABB bb = new AABB(0.5, 0.0, 0.5, 0.5, -1.2, 0.5).inflate(radius / 32f);
 			FluidRenderer.renderFluidBox(fluidStack, (float) bb.minX, (float) bb.minY, (float) bb.minZ,
 				(float) bb.maxX, (float) bb.maxY, (float) bb.maxZ, buffer, ms, light, true);
 		}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/effc6dbf-8048-416c-8fa5-5a76aa07a8be)
When the spout is working, the fluid starts at centre of the spout which is weird

And when the spout is working, use other mod to drain the spout to empty, the client will crash.