### PR TITLE
Add api to add custom conductors to trains

### DIFF
--- a/src/main/java/com/simibubi/create/AllBlocks.java
+++ b/src/main/java/com/simibubi/create/AllBlocks.java
@@ -3,6 +3,9 @@ package com.simibubi.create;
 import static com.simibubi.create.AllInteractionBehaviours.interactionBehaviour;
 import static com.simibubi.create.AllMovementBehaviours.movementBehaviour;
 import static com.simibubi.create.Create.REGISTRATE;
+
+import com.simibubi.create.api.contraption.train.TrainConductorHandler;
+
 import static com.simibubi.create.content.redstone.displayLink.AllDisplayBehaviours.assignDataBehaviour;
 import static com.simibubi.create.foundation.data.BlockStateGen.axisBlock;
 import static com.simibubi.create.foundation.data.BlockStateGen.simpleCubeAll;
@@ -185,7 +188,7 @@ import com.simibubi.create.content.processing.basin.BasinGenerator;
 import com.simibubi.create.content.processing.basin.BasinMovementBehaviour;
 import com.simibubi.create.content.processing.burner.BlazeBurnerBlock;
 import com.simibubi.create.content.processing.burner.BlazeBurnerBlockItem;
-import com.simibubi.create.content.processing.burner.BlazeBurnerInteractionBehaviour;
+import com.simibubi.create.content.processing.burner.BlockBasedTrainConductorInteractionBehaviour;
 import com.simibubi.create.content.processing.burner.BlazeBurnerMovementBehaviour;
 import com.simibubi.create.content.processing.burner.LitBlazeBurnerBlock;
 import com.simibubi.create.content.redstone.RoseQuartzLampBlock;
@@ -708,7 +711,7 @@ public class AllBlocks {
 			.loot((lt, block) -> lt.add(block, BlazeBurnerBlock.buildLootTable()))
 			.blockstate((c, p) -> p.simpleBlock(c.getEntry(), AssetLookup.partialBaseModel(c, p)))
 			.onRegister(movementBehaviour(new BlazeBurnerMovementBehaviour()))
-			.onRegister(interactionBehaviour(new BlazeBurnerInteractionBehaviour()))
+			.onRegister(block -> TrainConductorHandler.registerBlazeBurner())
 			.item(BlazeBurnerBlockItem::withBlaze)
 			.model(AssetLookup.customBlockItemModel("blaze_burner", "block_with_blaze"))
 			.build()

--- a/src/main/java/com/simibubi/create/api/contraption/train/TrainConductorHandler.java
+++ b/src/main/java/com/simibubi/create/api/contraption/train/TrainConductorHandler.java
@@ -1,0 +1,54 @@
+package com.simibubi.create.api.contraption.train;
+
+import com.simibubi.create.AllBlocks;
+import com.simibubi.create.AllInteractionBehaviours;
+import com.simibubi.create.content.processing.burner.BlazeBurnerBlock;
+
+import com.simibubi.create.content.processing.burner.BlockBasedTrainConductorInteractionBehaviour;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.block.state.BlockState;
+
+
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+
+/**
+ * All required methods to make your block a train conductor similar to the blaze burner
+ */
+public interface TrainConductorHandler {
+
+	@ApiStatus.Internal
+	List<TrainConductorHandler> CONDUCTOR_HANDLERS = new ArrayList<>();
+
+
+
+	boolean isValidConductor(BlockState state);
+
+	private static void registerHandler(TrainConductorHandler handler) {
+		CONDUCTOR_HANDLERS.add(handler);
+	}
+
+	static void registerConductor(ResourceLocation blockRl, Predicate<BlockState> isValidConductor, UpdateScheduleCallback updateScheduleCallback) {
+		AllInteractionBehaviours.registerBehaviour(blockRl, new BlockBasedTrainConductorInteractionBehaviour(isValidConductor, updateScheduleCallback));
+		registerHandler(isValidConductor::test);
+	}
+
+	@ApiStatus.Internal
+	static void registerBlazeBurner() {
+		registerConductor(AllBlocks.BLAZE_BURNER.getId(), blockState ->  AllBlocks.BLAZE_BURNER.has(blockState)
+					&& blockState.getValue(BlazeBurnerBlock.HEAT_LEVEL) != BlazeBurnerBlock.HeatLevel.NONE, UpdateScheduleCallback.EMPTY);
+	}
+
+	interface UpdateScheduleCallback {
+
+		UpdateScheduleCallback EMPTY = (hasSchedule, blockState, blockStateSetter) -> {};
+
+		void update(boolean hasSchedule, BlockState currentBlockState, Consumer<BlockState> blockStateSetter);
+	}
+}

--- a/src/main/java/com/simibubi/create/content/trains/entity/CarriageContraptionEntity.java
+++ b/src/main/java/com/simibubi/create/content/trains/entity/CarriageContraptionEntity.java
@@ -492,8 +492,8 @@ public class CarriageContraptionEntity extends OrientedContraptionEntity {
 		if (!(contraption instanceof CarriageContraption cc))
 			return sides;
 
-		sides.setFirst(cc.blazeBurnerConductors.getFirst());
-		sides.setSecond(cc.blazeBurnerConductors.getSecond());
+		sides.setFirst(cc.blockConductors.getFirst());
+		sides.setSecond(cc.blockConductors.getSecond());
 
 		for (Entity entity : getPassengers()) {
 			if (entity instanceof Player)


### PR DESCRIPTION
Currently to add new conductors you would need a mixin and to duplicate a decent bit of create code or replace that with another mixin. These changes make it easier and more stable to add custom train conductors for addons.