### PR TITLE
stop adventure mode from changing block configs

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/blockEntity/behaviour/ValueSettingsInputHandler.java
+++ b/src/main/java/com/simibubi/create/foundation/blockEntity/behaviour/ValueSettingsInputHandler.java
@@ -92,7 +92,7 @@ public class ValueSettingsInputHandler {
 	}
 
 	public static boolean canInteract(Player player) {
-		return player != null && !player.isSpectator() && !player.isShiftKeyDown();
+		return player != null && player.getAbilities().mayBuild && !player.isShiftKeyDown();
 	}
 
 }

--- a/src/main/java/com/simibubi/create/foundation/blockEntity/behaviour/ValueSettingsInputHandler.java
+++ b/src/main/java/com/simibubi/create/foundation/blockEntity/behaviour/ValueSettingsInputHandler.java
@@ -5,6 +5,7 @@ import com.simibubi.create.AllTags.AllItemTags;
 import com.simibubi.create.CreateClient;
 import com.simibubi.create.foundation.blockEntity.SmartBlockEntity;
 import com.simibubi.create.foundation.blockEntity.behaviour.filtering.SidedFilteringBehaviour;
+import com.simibubi.create.foundation.utility.AdventureUtil;
 import com.simibubi.create.foundation.utility.RaycastHelper;
 
 import net.minecraft.core.BlockPos;
@@ -92,7 +93,6 @@ public class ValueSettingsInputHandler {
 	}
 
 	public static boolean canInteract(Player player) {
-		return player != null && player.getAbilities().mayBuild && !player.isShiftKeyDown();
+		return player != null && !player.isSpectator() && !player.isShiftKeyDown() && !AdventureUtil.isAdventure(player);
 	}
-
 }

--- a/src/main/java/com/simibubi/create/foundation/networking/BlockEntityConfigurationPacket.java
+++ b/src/main/java/com/simibubi/create/foundation/networking/BlockEntityConfigurationPacket.java
@@ -2,11 +2,11 @@ package com.simibubi.create.foundation.networking;
 
 import com.simibubi.create.foundation.blockEntity.SyncedBlockEntity;
 
+import com.simibubi.create.foundation.utility.AdventureUtil;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.server.level.ServerPlayerGameMode;
-import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.network.NetworkEvent.Context;
@@ -35,7 +35,7 @@ public abstract class BlockEntityConfigurationPacket<BE extends SyncedBlockEntit
 	public boolean handle(Context context) {
 		context.enqueueWork(() -> {
 			ServerPlayer player = context.getSender();
-			if (player == null || !player.getAbilities().mayBuild)
+			if (player == null || player.isSpectator() || AdventureUtil.isAdventure(player))
 				return;
 			Level world = player.level();
 			if (world == null || !world.isLoaded(pos))

--- a/src/main/java/com/simibubi/create/foundation/networking/BlockEntityConfigurationPacket.java
+++ b/src/main/java/com/simibubi/create/foundation/networking/BlockEntityConfigurationPacket.java
@@ -5,6 +5,8 @@ import com.simibubi.create.foundation.blockEntity.SyncedBlockEntity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.level.ServerPlayerGameMode;
+import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.network.NetworkEvent.Context;
@@ -33,7 +35,7 @@ public abstract class BlockEntityConfigurationPacket<BE extends SyncedBlockEntit
 	public boolean handle(Context context) {
 		context.enqueueWork(() -> {
 			ServerPlayer player = context.getSender();
-			if (player == null)
+			if (player == null || !player.getAbilities().mayBuild)
 				return;
 			Level world = player.level();
 			if (world == null || !world.isLoaded(pos))
@@ -63,7 +65,7 @@ public abstract class BlockEntityConfigurationPacket<BE extends SyncedBlockEntit
 	protected void applySettings(ServerPlayer player, BE be) {
 		applySettings(be);
 	}
-	
+
 	protected boolean causeUpdate() {
 		return true;
 	}

--- a/src/main/java/com/simibubi/create/foundation/utility/AdventureUtil.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/AdventureUtil.java
@@ -1,0 +1,11 @@
+package com.simibubi.create.foundation.utility;
+
+import net.minecraft.world.entity.player.Player;
+
+import org.jetbrains.annotations.Nullable;
+
+public class AdventureUtil {
+	public static boolean isAdventure(@Nullable Player player) {
+		return player != null && !player.mayBuild() && !player.isSpectator();
+	}
+}


### PR DESCRIPTION
fixes #2964 
prevents adventure mode players from changing block configurations (like speed on a creative motor, filters, etc.)