### PR TITLE
Schematic Caching

### DIFF
--- a/src/main/java/com/simibubi/create/Create.java
+++ b/src/main/java/com/simibubi/create/Create.java
@@ -2,6 +2,8 @@ package com.simibubi.create;
 
 import java.util.Random;
 
+import net.minecraftforge.fml.loading.FMLLoader;
+
 import org.slf4j.Logger;
 
 import com.google.gson.Gson;
@@ -152,6 +154,9 @@ public class Create {
 
 		// FIXME: this is not thread-safe
 		Mods.CURIOS.executeIfInstalled(() -> () -> Curios.init(modEventBus, forgeEventBus));
+
+		if (FMLLoader.getDist().isDedicatedServer())
+			SCHEMATIC_RECEIVER.computeHashes();
 	}
 
 	public static void init(final FMLCommonSetupEvent event) {

--- a/src/main/java/com/simibubi/create/content/schematics/SchematicFile.java
+++ b/src/main/java/com/simibubi/create/content/schematics/SchematicFile.java
@@ -1,0 +1,3 @@
+package com.simibubi.create.content.schematics;
+
+public record SchematicFile(String playerName, String schematicName) {}

--- a/src/main/java/com/simibubi/create/content/schematics/SchematicItem.java
+++ b/src/main/java/com/simibubi/create/content/schematics/SchematicItem.java
@@ -57,6 +57,10 @@ public class SchematicItem extends Item {
 		super(properties);
 	}
 
+	public static ItemStack create(HolderGetter<Block> lookup, SchematicFile schematicFile) {
+		return create(lookup, schematicFile.schematicName(), schematicFile.playerName());
+	}
+
 	public static ItemStack create(HolderGetter<Block> lookup, String schematic, String owner) {
 		ItemStack blueprint = AllItems.SCHEMATIC.asStack();
 

--- a/src/main/java/com/simibubi/create/content/schematics/ServerSchematicLoader.java
+++ b/src/main/java/com/simibubi/create/content/schematics/ServerSchematicLoader.java
@@ -82,15 +82,18 @@ public class ServerSchematicLoader {
 					(filePath, attributes) -> filePath.toString().endsWith(".nbt"))) {
 				for (Path path : filePaths.toList()) {
 					try (InputStream stream = new FileInputStream(path.toFile())) {
-						String[] pathSplit = path.toString()
-								.replace("schematics/uploaded/", "")
-								.replace(".nbt", "")
-								.split("/");
-						String playerName = pathSplit[0];
-						String schematicName = pathSplit[1];
 						String schematicMd5Hex = DigestUtils.md5Hex(stream);
 
-						sumToSchematic.computeIfAbsent(schematicMd5Hex, k -> new SchematicFile(playerName, schematicName));
+						sumToSchematic.computeIfAbsent(schematicMd5Hex, k -> {
+							String[] pathSplit = path.toString()
+									.replace("schematics/uploaded/", "")
+									.replace(".nbt", "")
+									.split("/");
+							String playerName = pathSplit[0];
+							String schematicName = pathSplit[1];
+
+							return new SchematicFile(playerName, schematicName);
+						});
 					}
 				}
 			} catch (IOException ignored) {}

--- a/src/main/java/com/simibubi/create/content/schematics/client/ClientSchematicLoader.java
+++ b/src/main/java/com/simibubi/create/content/schematics/client/ClientSchematicLoader.java
@@ -28,6 +28,8 @@ import net.minecraft.network.chat.Component;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
+import org.apache.commons.codec.digest.DigestUtils;
+
 @OnlyIn(Dist.CLIENT)
 public class ClientSchematicLoader {
 
@@ -73,7 +75,11 @@ public class ClientSchematicLoader {
 
 			in = Files.newInputStream(path, StandardOpenOption.READ);
 			activeUploads.put(schematic, in);
-			AllPackets.getChannel().sendToServer(SchematicUploadPacket.begin(schematic, size));
+
+			try (InputStream stream = Files.newInputStream(path, StandardOpenOption.READ)) {
+				String md5 = DigestUtils.md5Hex(stream);
+				AllPackets.getChannel().sendToServer(SchematicUploadPacket.begin(schematic, size, md5));
+			}
 		} catch (IOException e) {
 			e.printStackTrace();
 		}


### PR DESCRIPTION
Currently schematics are always reuploaded even if they already exist on the server, these changes make it so if they already exist on the server, a schematic pointing towards that is made instead of requiring a full reupload.

Fixes https://github.com/Creators-of-Create/Create/issues/7042