### PR TITLE
Use actual remaining items to calculate remainders for basin recipes

### DIFF
--- a/src/main/java/com/simibubi/create/content/processing/basin/BasinRecipe.java
+++ b/src/main/java/com/simibubi/create/content/processing/basin/BasinRecipe.java
@@ -22,6 +22,8 @@ import com.simibubi.create.foundation.recipe.IRecipeTypeInfo;
 import com.simibubi.create.foundation.utility.Iterate;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.world.Container;
+import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.CraftingRecipe;
 import net.minecraft.world.item.crafting.Ingredient;
@@ -32,7 +34,7 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.items.IItemHandler;
 
-public class BasinRecipe extends ProcessingRecipe<SmartInventory> {
+public class BasinRecipe extends ProcessingRecipe<Container> {
 
 	public static boolean match(BasinBlockEntity basin, Recipe<?> recipe) {
 		FilteringBehaviour filter = basin.getFilter();
@@ -148,23 +150,24 @@ public class BasinRecipe extends ProcessingRecipe<SmartInventory> {
 			}
 
 			if (simulate) {
+				CraftingContainer remainderContainer = new DummyCraftingContainer(availableItems, extractedItemsFromSlot);
+
 				if (recipe instanceof BasinRecipe basinRecipe) {
 					recipeOutputItems.addAll(basinRecipe.rollResults());
-					
+
 					for (FluidStack fluidStack : basinRecipe.getFluidResults())
 						if (!fluidStack.isEmpty())
 							recipeOutputFluids.add(fluidStack);
-					for (ItemStack stack : basinRecipe.getRemainingItems(basin.getInputInventory()))
+					for (ItemStack stack : basinRecipe.getRemainingItems(remainderContainer))
 						if (!stack.isEmpty())
 							recipeOutputItems.add(stack);
-					
+
 				} else {
 					recipeOutputItems.add(recipe.getResultItem(basin.getLevel()
 						.registryAccess()));
 
 					if (recipe instanceof CraftingRecipe craftingRecipe) {
-						for (ItemStack stack : craftingRecipe
-							.getRemainingItems(new DummyCraftingContainer(availableItems, extractedItemsFromSlot)))
+						for (ItemStack stack : craftingRecipe.getRemainingItems(remainderContainer))
 							if (!stack.isEmpty())
 								recipeOutputItems.add(stack);
 					}
@@ -225,7 +228,7 @@ public class BasinRecipe extends ProcessingRecipe<SmartInventory> {
 	}
 
 	@Override
-	public boolean matches(SmartInventory inv, @Nonnull Level worldIn) {
+	public boolean matches(Container inv, @Nonnull Level worldIn) {
 		return false;
 	}
 


### PR DESCRIPTION
This is a proposed fix for #6963.

This PR solves the there mentioned problem by using the same method to calculate remainder items as it is used for shapeless crafting recipes.

Here are two example recipes to test the bug and it's solution with:

<details>
  <summary>Recipe 1</summary>
  
  ```json
{
  "type": "create:mixing",
  "ingredients": [
    {
      "item": "water_bucket"
    },
    {
      "tag": "forge:ingots/zinc"
    }
  ],
  "results": [
    {
      "count": 2,
      "item": "diamond"
    }
  ]
}
  ```
  
</details>

<details>
  <summary>Recipe 2</summary>
  
  ```json
{
  "type": "create:mixing",
  "ingredients": [
    {
      "item": "water_bucket"
    },
    {
      "item": "lava_bucket"
    }
  ],
  "results": [
    {
      "count": 1,
      "item": "obsidian"
    }
  ]
}
  ```
  
</details>