### PR TITLE
Fix trains passing through portals causing crashes rarely

### DIFF
--- a/src/main/java/com/simibubi/create/content/schematics/SchematicAndQuillItem.java
+++ b/src/main/java/com/simibubi/create/content/schematics/SchematicAndQuillItem.java
@@ -61,27 +61,13 @@ public class SchematicAndQuillItem extends Item {
 			BlockPos blockpos = BlockPos.containing(vec3);
 
 			CompoundTag entityTag = new CompoundTag();
-			entityTag.put("pos", newDoubleList(vec3.x, vec3.y, vec3.z));
-			entityTag.put("blockPos", newIntegerList(blockpos.getX(), blockpos.getY(), blockpos.getZ()));
+			entityTag.put("pos", NBTHelper.newDoubleList(vec3.x, vec3.y, vec3.z));
+			entityTag.put("blockPos", NBTHelper.newIntegerList(blockpos.getX(), blockpos.getY(), blockpos.getZ()));
 			entityTag.put("nbt", compoundtag.copy());
 			listtag.add(entityTag);
 		}
 
 		nbt.put("entities", listtag);
-	}
-
-	private static ListTag newIntegerList(int... pValues) {
-		ListTag listtag = new ListTag();
-		for (int i : pValues)
-			listtag.add(IntTag.valueOf(i));
-		return listtag;
-	}
-
-	private static ListTag newDoubleList(double... pValues) {
-		ListTag listtag = new ListTag();
-		for (double d0 : pValues)
-			listtag.add(DoubleTag.valueOf(d0));
-		return listtag;
 	}
 
 }

--- a/src/main/java/com/simibubi/create/content/trains/entity/Carriage.java
+++ b/src/main/java/com/simibubi/create/content/trains/entity/Carriage.java
@@ -791,6 +791,7 @@ public class Carriage {
 		}
 
 		private void createEntity(Level level, boolean loadPassengers) {
+			serialisedEntity.put("Pos", NBTHelper.newDoubleList(positionAnchor.x(), positionAnchor.y(), positionAnchor.z()));
 			Entity entity = EntityType.create(serialisedEntity, level)
 				.orElse(null);
 
@@ -799,7 +800,6 @@ public class Carriage {
 				return;
 			}
 
-			entity.moveTo(positionAnchor);
 			this.entity = new WeakReference<>(cce);
 
 			cce.setCarriage(Carriage.this);

--- a/src/main/java/com/simibubi/create/foundation/utility/NBTHelper.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/NBTHelper.java
@@ -9,6 +9,7 @@ import javax.annotation.Nonnull;
 
 import net.minecraft.core.Vec3i;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.DoubleTag;
 import net.minecraft.nbt.FloatTag;
 import net.minecraft.nbt.IntTag;
 import net.minecraft.nbt.ListTag;
@@ -108,13 +109,13 @@ public class NBTHelper {
 			return inbt;
 		return new CompoundTag();
 	}
-	
+
 	public static CompoundTag intToCompound(int i) {
 		CompoundTag compoundTag = new CompoundTag();
 		compoundTag.putInt("V", i);
 		return compoundTag;
 	}
-	
+
 	public static int intFromCompound(CompoundTag compoundTag) {
 		return compoundTag.getInt("V");
 	}
@@ -127,4 +128,29 @@ public class NBTHelper {
 		return new ResourceLocation(nbt.getString(key));
 	}
 
+	/**
+	 * Creates a NBT list from the array of integers passed to this function
+	 */
+	public static ListTag newIntegerList(int... ints) {
+		ListTag listTag = new ListTag();
+
+		for (int i : ints) {
+			listTag.add(IntTag.valueOf(i));
+		}
+
+		return listTag;
+	}
+
+	/**
+	 * Creates a NBT list from the array of doubles passed to this function
+	 */
+	public static ListTag newDoubleList(double... doubles) {
+		ListTag listTag = new ListTag();
+
+		for (double d : doubles) {
+			listTag.add(DoubleTag.valueOf(d));
+		}
+
+		return listTag;
+	}
 }


### PR DESCRIPTION
Fixes #6795
Fixes #4892

Added utility nethods for newDoubleList and newIntegerList in NBTHelper and made SchematicAndQuillItem and Carriage use those.