### PR TITLE
Fix nested LangBuilder in LangBuilder.forGoggles not inheriting parent namespace

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/utility/LangBuilder.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/LangBuilder.java
@@ -165,7 +165,7 @@ public class LangBuilder {
 	}
 
 	public void forGoggles(List<? super MutableComponent> tooltip, int indents) {
-		tooltip.add(Lang.builder()
+		tooltip.add(Lang.builder(namespace)
 			.text(Strings.repeat(' ', getIndents(Minecraft.getInstance().font, 4 + indents)))
 			.add(this)
 			.component());


### PR DESCRIPTION
In LangBuilder.forGoggles, a nested LangBuilder is constructed to format the goggles tooltip, but it does not use the namespace of the currently used LangBuilder, making this code harder to reuse in addons. The fix seems simple enough, and seems backward compatible with current usages of the default namespacefor both the parent and nested LangBuilders.