### PR TITLE
Refactor and fix PressingBehaviour.java

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/press/PressingBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/press/PressingBehaviour.java
@@ -190,7 +190,6 @@ public class PressingBehaviour extends BeltProcessingBehaviour {
 
 		if (!level.isClientSide && runningTicks > CYCLE) {
 			finished = true;
-			running = false;
 			particleItems.clear();
 			specifics.onPressingCompleted();
 			blockEntity.sendData();

--- a/src/main/java/com/simibubi/create/content/kinetics/press/PressingBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/press/PressingBehaviour.java
@@ -153,13 +153,13 @@ public class PressingBehaviour extends BeltProcessingBehaviour {
 				entityScanCooldown = ENTITY_SCAN;
 
 				if (BlockEntityBehaviour.get(level, worldPosition.below(2),
-						TransportedItemStackHandlerBehaviour.TYPE) != null)
+					TransportedItemStackHandlerBehaviour.TYPE) != null)
 					return;
 				if (BasinBlock.isBasin(level, worldPosition.below(2)))
 					return;
 
 				for (ItemEntity itemEntity : level.getEntitiesOfClass(ItemEntity.class,
-						new AABB(worldPosition.below()).deflate(.125f))) {
+					new AABB(worldPosition.below()).deflate(.125f))) {
 					if (!itemEntity.isAlive() || !itemEntity.onGround())
 						continue;
 					if (!specifics.tryProcessInWorld(itemEntity, true))
@@ -189,7 +189,7 @@ public class PressingBehaviour extends BeltProcessingBehaviour {
 				AllSoundEvents.MECHANICAL_PRESS_ACTIVATION_ON_BELT.playOnServer(level, worldPosition);
 			else
 				AllSoundEvents.MECHANICAL_PRESS_ACTIVATION.playOnServer(level, worldPosition, .5f,
-						.75f + (Math.abs(specifics.getKineticSpeed()) / 1024f));
+					.75f + (Math.abs(specifics.getKineticSpeed()) / 1024f));
 
 			if (!level.isClientSide)
 				blockEntity.sendData();
@@ -267,11 +267,10 @@ public class PressingBehaviour extends BeltProcessingBehaviour {
 
 		if (mode == Mode.BASIN)
 			particleItems
-					.forEach(stack -> makeCompactingParticleEffect(VecHelper.getCenterOf(worldPosition.below(2)),
-							stack));
+				.forEach(stack -> makeCompactingParticleEffect(VecHelper.getCenterOf(worldPosition.below(2)), stack));
 		if (mode == Mode.BELT)
 			particleItems.forEach(stack -> makePressingParticleEffect(VecHelper.getCenterOf(worldPosition.below(2))
-					.add(0, 8 / 16f, 0), stack));
+				.add(0, 8 / 16f, 0), stack));
 		if (mode == Mode.WORLD)
 			particleItems.forEach(stack -> makePressingParticleEffect(VecHelper.getCenterOf(worldPosition.below(1))
 					.add(0, -1 / 4f, 0), stack));
@@ -289,10 +288,10 @@ public class PressingBehaviour extends BeltProcessingBehaviour {
 			return;
 		for (int i = 0; i < amount; i++) {
 			Vec3 motion = VecHelper.offsetRandomly(Vec3.ZERO, level.random, .125f)
-					.multiply(1, 0, 1);
+				.multiply(1, 0, 1);
 			motion = motion.add(0, amount != 1 ? 0.125f : 1 / 16f, 0);
 			level.addParticle(new ItemParticleOption(ParticleTypes.ITEM, stack), pos.x, pos.y - .25f, pos.z, motion.x,
-					motion.y, motion.z);
+				motion.y, motion.z);
 		}
 	}
 
@@ -302,9 +301,9 @@ public class PressingBehaviour extends BeltProcessingBehaviour {
 			return;
 		for (int i = 0; i < 20; i++) {
 			Vec3 motion = VecHelper.offsetRandomly(Vec3.ZERO, level.random, .175f)
-					.multiply(1, 0, 1);
+				.multiply(1, 0, 1);
 			level.addParticle(new ItemParticleOption(ParticleTypes.ITEM, stack), pos.x, pos.y, pos.z, motion.x,
-					motion.y + .25f, motion.z);
+				motion.y + .25f, motion.z);
 		}
 	}
 

--- a/src/main/java/com/simibubi/create/content/kinetics/press/PressingBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/press/PressingBehaviour.java
@@ -240,7 +240,7 @@ public class PressingBehaviour extends BeltProcessingBehaviour {
 		float speed = specifics.getKineticSpeed();
 		if (speed == 0)
 			return 0;
-		return 30 * speed / 256;
+		return 30 * Mth.abs(speed) / 256;
 	}
 
 	protected void spawnParticles() {

--- a/src/main/java/com/simibubi/create/content/kinetics/press/PressingBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/press/PressingBehaviour.java
@@ -38,7 +38,7 @@ public class PressingBehaviour extends BeltProcessingBehaviour {
 	public int prevRunningTicks;
 	public int runningTicks;
 	public boolean running;
-	public boolean wentDown;
+	public boolean finished;
 	public Mode mode;
 
 	int entityScanCooldown;
@@ -72,7 +72,7 @@ public class PressingBehaviour extends BeltProcessingBehaviour {
 	public void read(CompoundTag compound, boolean clientPacket) {
 		running = compound.getBoolean("Running");
 		mode = Mode.values()[compound.getInt("Mode")];
-		wentDown = compound.getBoolean("WentDown");
+		finished = compound.getBoolean("Finished");
 		prevRunningTicks = runningTicks = compound.getInt("Ticks");
 		super.read(compound, clientPacket);
 
@@ -87,7 +87,7 @@ public class PressingBehaviour extends BeltProcessingBehaviour {
 	public void write(CompoundTag compound, boolean clientPacket) {
 		compound.putBoolean("Running", running);
 		compound.putInt("Mode", mode.ordinal());
-		compound.putBoolean("WentDown", wentDown);
+		compound.putBoolean("Finished", finished);
 		compound.putInt("Ticks", runningTicks);
 		super.write(compound, clientPacket);
 
@@ -110,7 +110,7 @@ public class PressingBehaviour extends BeltProcessingBehaviour {
 	public void start(Mode mode) {
 		this.mode = mode;
 		running = true;
-		wentDown = false;
+		finished = false;
 		prevRunningTicks = 0;
 		runningTicks = 0;
 		particleItems.clear();
@@ -174,7 +174,7 @@ public class PressingBehaviour extends BeltProcessingBehaviour {
 			return;
 		}
 
-		if (runningTicks >= CYCLE / 2 && !wentDown) {
+		if (runningTicks >= CYCLE / 2 && !finished) {
 			if (inWorld())
 				applyInWorld();
 			if (onBasin())
@@ -190,11 +190,11 @@ public class PressingBehaviour extends BeltProcessingBehaviour {
 			if (!level.isClientSide)
 				blockEntity.sendData();
 
-			wentDown = true;
+			finished = true;
 		}
 
 		if (!level.isClientSide && runningTicks > CYCLE) {
-			wentDown = false;
+			finished = false;
 			particleItems.clear();
 			specifics.onPressingCompleted();
 			blockEntity.sendData();

--- a/src/main/java/com/simibubi/create/content/kinetics/press/PressingBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/press/PressingBehaviour.java
@@ -128,14 +128,18 @@ public class PressingBehaviour extends BeltProcessingBehaviour {
 	public void tick() {
 		super.tick();
 
+		finished = false;
+		if (specifics.getKineticSpeed() == 0) {
+			running = false;
+			return;
+		}
+
 		Level level = getWorld();
 		BlockPos worldPosition = getPos();
 
 		if (!running || level == null) {
 			if (level != null && !level.isClientSide) {
 
-				if (specifics.getKineticSpeed() == 0)
-					return;
 				if (entityScanCooldown > 0)
 					entityScanCooldown--;
 				if (entityScanCooldown <= 0) {
@@ -190,6 +194,8 @@ public class PressingBehaviour extends BeltProcessingBehaviour {
 			particleItems.clear();
 			specifics.onPressingCompleted();
 			blockEntity.sendData();
+			prevRunningTicks = runningTicks - 240;
+			runningTicks += getRunningTickSpeed() - 240;
 			return;
 		}
 

--- a/src/main/java/com/simibubi/create/content/kinetics/press/PressingBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/press/PressingBehaviour.java
@@ -78,7 +78,7 @@ public class PressingBehaviour extends BeltProcessingBehaviour {
 
 		if (clientPacket) {
 			NBTHelper.iterateCompoundList(compound.getList("ParticleItems", Tag.TAG_COMPOUND),
-					c -> particleItems.add(ItemStack.of(c)));
+				c -> particleItems.add(ItemStack.of(c)));
 			spawnParticles();
 		}
 	}

--- a/src/main/java/com/simibubi/create/content/kinetics/press/PressingBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/press/PressingBehaviour.java
@@ -241,7 +241,7 @@ public class PressingBehaviour extends BeltProcessingBehaviour {
 		float speed = specifics.getKineticSpeed();
 		if (speed == 0)
 			return 0;
-		return (int) Mth.lerp(Mth.clamp(Math.abs(speed) / 512f, 0, 1), 1, 60);
+		return (int) Mth.lerp(Mth.clamp(Math.abs(speed) / 512f, 0, 1), 0, 60);
 	}
 
 	protected void spawnParticles() {

--- a/src/main/java/com/simibubi/create/content/kinetics/press/PressingBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/press/PressingBehaviour.java
@@ -241,7 +241,7 @@ public class PressingBehaviour extends BeltProcessingBehaviour {
 		float speed = specifics.getKineticSpeed();
 		if (speed == 0)
 			return 0;
-		return (int) Mth.lerp(Mth.clamp(Math.abs(speed) / 512f, 0, 1), 0, 60);
+		return (int) Mth.lerp(Mth.clamp(Math.abs(speed) / 512f, 0, 1), 1, 60);
 	}
 
 	protected void spawnParticles() {

--- a/src/main/java/com/simibubi/create/content/kinetics/press/PressingBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/press/PressingBehaviour.java
@@ -94,8 +94,7 @@ public class PressingBehaviour extends BeltProcessingBehaviour {
 		super.write(compound, clientPacket);
 
 		if (clientPacket) {
-			compound.put("ParticleItems",
-					NBTHelper.writeCompoundList(particleItems, NBTSerializer::serializeNBTCompound));
+			compound.put("ParticleItems", NBTHelper.writeCompoundList(particleItems, ItemStack::serializeNBT));
 			particleItems.clear();
 		}
 	}

--- a/src/main/java/com/simibubi/create/content/kinetics/press/PressingBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/press/PressingBehaviour.java
@@ -176,7 +176,8 @@ public class PressingBehaviour extends BeltProcessingBehaviour {
 			if (onBasin())
 				applyOnBasin();
 
-			if (level.getBlockState(worldPosition.below(2)).getSoundType() == SoundType.WOOL)
+			if (level.getBlockState(worldPosition.below(2))
+				.getSoundType() == SoundType.WOOL)
 				AllSoundEvents.MECHANICAL_PRESS_ACTIVATION_ON_BELT.playOnServer(level, worldPosition);
 			else
 				AllSoundEvents.MECHANICAL_PRESS_ACTIVATION.playOnServer(level, worldPosition, .5f,
@@ -257,7 +258,7 @@ public class PressingBehaviour extends BeltProcessingBehaviour {
 				.add(0, 8 / 16f, 0), stack));
 		if (mode == Mode.WORLD)
 			particleItems.forEach(stack -> makePressingParticleEffect(VecHelper.getCenterOf(worldPosition.below(1))
-					.add(0, -1 / 4f, 0), stack));
+				.add(0, -1 / 4f, 0), stack));
 
 		particleItems.clear();
 	}

--- a/src/main/java/com/simibubi/create/content/kinetics/press/PressingBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/press/PressingBehaviour.java
@@ -41,8 +41,6 @@ public class PressingBehaviour extends BeltProcessingBehaviour {
 	public boolean finished;
 	public Mode mode;
 
-	private boolean ticksPaused;
-
 	int entityScanCooldown;
 
 	public interface PressingBehaviourSpecifics {
@@ -172,13 +170,6 @@ public class PressingBehaviour extends BeltProcessingBehaviour {
 			return;
 		}
 
-		/*
-		if (level.isClientSide && ticksPaused) {
-			prevRunningTicks = CYCLE / 2;
-			return;
-		}
-		*/
-
 		if (runningTicks >= CYCLE / 2 && !finished) {
 			if (inWorld())
 				applyInWorld();
@@ -209,13 +200,6 @@ public class PressingBehaviour extends BeltProcessingBehaviour {
 
 		prevRunningTicks = runningTicks;
 		runningTicks += getRunningTickSpeed();
-		/*
-		if (prevRunningTicks < CYCLE / 2 && runningTicks >= CYCLE / 2) {
-			// Pause the ticks until a packet is received
-			if (level.isClientSide && !blockEntity.isVirtual())
-				ticksPaused = true;
-		}
-		*/
 	}
 
 	protected void applyOnBasin() {


### PR DESCRIPTION
PressingBehaviour now no longer idles for two ticks when doing logic, always works in direct proportion to speed at 75/128 * speed items per second, instead of 12/((59*speed/512)+1) items per second, and doesn't drop partial cycles at the end of a cycle.