### PR TITLE
Add pressing recipes for coarse_dirt->dirt_path and rooted_dirt->dirt_path

### DIFF
--- a/src/generated/resources/data/create/recipes/pressing/path.json
+++ b/src/generated/resources/data/create/recipes/pressing/path.json
@@ -7,6 +7,12 @@
       },
       {
         "item": "minecraft:dirt"
+      },
+      {
+        "item": "minecraft:coarse_dirt"
+      },
+      {
+        "item": "minecraft:rooted_dirt"
       }
     ]
   ],

--- a/src/main/java/com/simibubi/create/foundation/data/recipe/PressingRecipeGen.java
+++ b/src/main/java/com/simibubi/create/foundation/data/recipe/PressingRecipeGen.java
@@ -14,7 +14,7 @@ public class PressingRecipeGen extends ProcessingRecipeGen {
 
 	SUGAR_CANE = create(() -> Items.SUGAR_CANE, b -> b.output(Items.PAPER)),
 
-		PATH = create("path", b -> b.require(Ingredient.of(Items.GRASS_BLOCK, Items.DIRT))
+		PATH = create("path", b -> b.require(Ingredient.of(Items.GRASS_BLOCK, Items.DIRT, Items.COARSE_DIRT, Items.ROOTED_DIRT))
 			.output(Items.DIRT_PATH)),
 
 		IRON = create("iron_ingot", b -> b.require(I.iron())


### PR DESCRIPTION
Currently, Create allows you to craft path blocks (`minecraft:dirt_path`) only from dirt or grass blocks using the Mechanical Press. In vanilla Minecraft coarse dirt, mycelium, podzol and rooted dirt can be used as well to produce path blocks ([wiki page](https://minecraft.wiki/w/Dirt_Path#Post-generation)). This PR adds such pressing recipes for coarse and rooted dirt.

Making dirt paths from coarse dirt is of particular interest because it effectively allows players to convert gravel to dirt. You can already automate this process with deployers, albeit at the cost of a shovel's durability.

This suggestion has previously seen positive feedback [on the discord](https://discord.com/channels/620934202875183104/620937151915360268/1267334941436542997).

I have opted not to include mycelium or podzol (for now?) because the recipes could clash with compat recipes for Environmental's paths: https://github.com/Creators-of-Create/Create/blob/d48a504486311f3175f4ebef3b0649140e728fbb/src/main/java/com/simibubi/create/foundation/data/recipe/PressingRecipeGen.java#L36-L43