### PR TITLE
Fix enchantments getting trimmed from non-filter items

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/filter/FilterItemStack.java
+++ b/src/main/java/com/simibubi/create/content/logistics/filter/FilterItemStack.java
@@ -23,14 +23,15 @@ public class FilterItemStack {
 
 	public static FilterItemStack of(ItemStack filter) {
 		if (filter.hasTag()) {
-			CompoundTag stackTag = filter.getTag();
-			stackTag.remove("Enchantments");
-			stackTag.remove("AttributeModifiers");
 
-			if (AllItems.FILTER.isIn(filter))
+			if (AllItems.FILTER.isIn(filter)){
+				trimFilterTag(filter);
 				return new ListFilterItemStack(filter);
-			if (AllItems.ATTRIBUTE_FILTER.isIn(filter))
+			}
+			if (AllItems.ATTRIBUTE_FILTER.isIn(filter)){
+				trimFilterTag(filter);
 				return new AttributeFilterItemStack(filter);
+			}
 		}
 
 		return new FilterItemStack(filter);
@@ -39,9 +40,15 @@ public class FilterItemStack {
 	public static FilterItemStack of(CompoundTag tag) {
 		return of(ItemStack.of(tag));
 	}
-	
+
 	public static FilterItemStack empty() {
 		return of(ItemStack.EMPTY);
+	}
+
+	private static void trimFilterTag(ItemStack filter){
+		CompoundTag stackTag = filter.getTag();
+		stackTag.remove("Enchantments");
+		stackTag.remove("AttributeModifiers");
 	}
 
 	public boolean isEmpty() {
@@ -51,16 +58,16 @@ public class FilterItemStack {
 	public CompoundTag serializeNBT() {
 		return filterItemStack.serializeNBT();
 	}
-	
+
 	public ItemStack item() {
 		return filterItemStack;
 	}
-	
+
 	public FluidStack fluid(Level level) {
 		resolveFluid(level);
 		return filterFluidStack;
 	}
-	
+
 	public boolean isFilterItem() {
 		return filterItemStack.getItem() instanceof FilterItem;
 	}
@@ -98,7 +105,7 @@ public class FilterItemStack {
 	}
 
 	//
-	
+
 	private void resolveFluid(Level world) {
 		if (!fluidExtracted) {
 			fluidExtracted = true;


### PR DESCRIPTION
### Issues Fixed
Fixes #7214

### Implemented Solution
Move the tag trimming to after the isIn checks. I've added a new private static method s.t. if new problematic tag elements need to get trimmed it's all in one place. 