### PR TITLE
Fix lighter-than-air fluids being displayed upside down in basin/drain

### DIFF
--- a/src/main/java/com/simibubi/create/compat/jei/category/animations/AnimatedSpout.java
+++ b/src/main/java/com/simibubi/create/compat/jei/category/animations/AnimatedSpout.java
@@ -75,7 +75,7 @@ public class AnimatedSpout extends AnimatedKinetics {
 		matrixStack.scale(16, 16, 16);
 		float from = 3f / 16f;
 		float to = 17f / 16f;
-		FluidRenderer.renderFluidBox(fluids.get(0), from, from, from, to, to, to, buffer, matrixStack, LightTexture.FULL_BRIGHT, false);
+		FluidRenderer.renderFluidBoxGassesInverted(fluids.get(0), from, from, from, to, to, to, buffer, matrixStack, LightTexture.FULL_BRIGHT, false);
 		matrixStack.popPose();
 
 		float width = 1 / 128f * squeeze;
@@ -85,7 +85,7 @@ public class AnimatedSpout extends AnimatedKinetics {
 		matrixStack.translate(-0.5f, 0, -0.5f);
 		from = -width / 2 + 0.5f;
 		to = width / 2 + 0.5f;
-		FluidRenderer.renderFluidBox(fluids.get(0), from, 0, from, to, 2, to, buffer, matrixStack, LightTexture.FULL_BRIGHT,
+		FluidRenderer.renderFluidBoxGassesInverted(fluids.get(0), from, 0, from, to, 2, to, buffer, matrixStack, LightTexture.FULL_BRIGHT,
 			false);
 		buffer.endBatch();
 		Lighting.setupFor3DItems();

--- a/src/main/java/com/simibubi/create/content/fluids/spout/SpoutRenderer.java
+++ b/src/main/java/com/simibubi/create/content/fluids/spout/SpoutRenderer.java
@@ -51,7 +51,7 @@ public class SpoutRenderer extends SafeBlockEntityRenderer<SpoutBlockEntity> {
 			if (!top) ms.translate(0, yOffset, 0);
 			else ms.translate(0, max - min, 0);
 
-			FluidRenderer.renderFluidBox(fluidStack,
+			FluidRenderer.renderFluidBoxGassesInverted(fluidStack,
 					min, min - yOffset, min,
 					max, min, max,
 					buffer, ms, light, false);
@@ -68,7 +68,7 @@ public class SpoutRenderer extends SafeBlockEntityRenderer<SpoutBlockEntity> {
 		if (processingTicks != -1) {
 			radius = (float) (Math.pow(((2 * processingProgress) - 1), 2) - 1);
 			AABB bb = new AABB(0.5, .5, 0.5, 0.5, -1.2, 0.5).inflate(radius / 32f);
-			FluidRenderer.renderFluidBox(fluidStack, (float) bb.minX, (float) bb.minY, (float) bb.minZ,
+			FluidRenderer.renderFluidBoxGassesInverted(fluidStack, (float) bb.minX, (float) bb.minY, (float) bb.minZ,
 				(float) bb.maxX, (float) bb.maxY, (float) bb.maxZ, buffer, ms, light, true);
 		}
 

--- a/src/main/java/com/simibubi/create/content/fluids/tank/FluidTankRenderer.java
+++ b/src/main/java/com/simibubi/create/content/fluids/tank/FluidTankRenderer.java
@@ -73,7 +73,7 @@ public class FluidTankRenderer extends SafeBlockEntityRenderer<FluidTankBlockEnt
 
 		ms.pushPose();
 		ms.translate(0, clampedLevel - totalHeight, 0);
-		FluidRenderer.renderFluidBox(fluidStack, xMin, yMin, zMin, xMax, yMax, zMax, buffer, ms, light, false);
+		FluidRenderer.renderFluidBoxGassesInverted(fluidStack, xMin, yMin, zMin, xMax, yMax, zMax, buffer, ms, light, false);
 		ms.popPose();
 	}
 

--- a/src/main/java/com/simibubi/create/foundation/fluid/FluidRenderer.java
+++ b/src/main/java/com/simibubi/create/foundation/fluid/FluidRenderer.java
@@ -90,11 +90,17 @@ public class FluidRenderer {
 	public static void renderFluidBox(FluidStack fluidStack, float xMin, float yMin, float zMin, float xMax, float yMax,
 		float zMax, MultiBufferSource buffer, PoseStack ms, int light, boolean renderBottom) {
 		renderFluidBox(fluidStack, xMin, yMin, zMin, xMax, yMax, zMax, getFluidBuilder(buffer), ms, light,
-			renderBottom);
+			renderBottom, false);
+	}
+
+	public static void renderFluidBoxGassesInverted(FluidStack fluidStack, float xMin, float yMin, float zMin, float xMax, float yMax,
+													float zMax, MultiBufferSource buffer, PoseStack ms, int light, boolean renderBottom) {
+		renderFluidBox(fluidStack, xMin, yMin, zMin, xMax, yMax, zMax, getFluidBuilder(buffer), ms, light,
+				renderBottom, true);
 	}
 
 	public static void renderFluidBox(FluidStack fluidStack, float xMin, float yMin, float zMin, float xMax, float yMax,
-		float zMax, VertexConsumer builder, PoseStack ms, int light, boolean renderBottom) {
+		float zMax, VertexConsumer builder, PoseStack ms, int light, boolean renderBottom, boolean shouldInvertGasses) {
 		Fluid fluid = fluidStack.getFluid();
 		IClientFluidTypeExtensions clientFluid = IClientFluidTypeExtensions.of(fluid);
 		FluidType fluidAttributes = fluid.getFluidType();
@@ -109,7 +115,7 @@ public class FluidRenderer {
 
 		Vec3 center = new Vec3(xMin + (xMax - xMin) / 2, yMin + (yMax - yMin) / 2, zMin + (zMax - zMin) / 2);
 		ms.pushPose();
-		if (fluidAttributes.isLighterThanAir())
+		if (shouldInvertGasses && fluidAttributes.isLighterThanAir())
 			TransformStack.of(ms)
 				.translate(center)
 				.rotateXDegrees(180)


### PR DESCRIPTION
### Issues Fixed
Fixes #7236

### Implemented solution
Changes the default behaviour of `FluidRenderer.renderFluidBox` to not invert these fluids. Adds a new method that will invert these fluids and calls this one in the spout and fluid tank.