### PR TITLE
Allow sandpaper to be used in deploying recipe

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/deployer/DeployerBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/deployer/DeployerBlockEntity.java
@@ -551,7 +551,10 @@ public class DeployerBlockEntity extends KineticBlockEntity {
 		ItemStack heldItemMainhand = player.getMainHandItem();
 		if (heldItemMainhand.getItem() instanceof SandPaperItem) {
 			sandpaperInv.setItem(0, stack);
-			return checkRecipe(AllRecipeTypes.SANDPAPER_POLISHING, sandpaperInv, level).orElse(null);
+			Optional<? extends Recipe<? extends Container>> polishingRecipe = checkRecipe(AllRecipeTypes.SANDPAPER_POLISHING, sandpaperInv, level);
+			if (polishingRecipe.isPresent()){
+				return polishingRecipe.get();
+			}
 		}
 
 		recipeInv.setItem(0, stack);


### PR DESCRIPTION
### Issues Fixed
Closes #6626

### Implemented Solution
If no sandpaper polishing recipe is found, continue with finding a recipe instead of returning null. This will allow sandpaper to be used in deploying recipes and thus by extension sequenced assembly.