### PR TITLE
Add DyeHelper api

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/actors/contraptionControls/ContraptionControlsBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/actors/contraptionControls/ContraptionControlsBlockEntity.java
@@ -107,7 +107,7 @@ public class ContraptionControlsBlockEntity extends SmartBlockEntity {
 
 	public static void sendStatus(Player player, ItemStack filter, boolean enabled) {
 		MutableComponent state = Lang.translate("contraption.controls.actor_toggle." + (enabled ? "on" : "off"))
-			.color(DyeHelper.DYE_TABLE.get(enabled ? DyeColor.LIME : DyeColor.ORANGE)
+			.color(DyeHelper.getDyeColors(enabled ? DyeColor.LIME : DyeColor.ORANGE)
 				.getFirst())
 			.component();
 

--- a/src/main/java/com/simibubi/create/content/contraptions/actors/contraptionControls/ContraptionControlsRenderer.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/actors/contraptionControls/ContraptionControlsRenderer.java
@@ -83,7 +83,7 @@ public class ContraptionControlsRenderer extends SmartBlockEntityRenderer<Contra
 			: ctx.position.distanceToSqr(cameraEntity.getEyePosition()));
 
 		float flicker = r.nextFloat();
-		Couple<Integer> couple = DyeHelper.DYE_TABLE.get(efs.targetYEqualsSelection ? DyeColor.WHITE : DyeColor.ORANGE);
+		Couple<Integer> couple = DyeHelper.getDyeColors(efs.targetYEqualsSelection ? DyeColor.WHITE : DyeColor.ORANGE);
 		int brightColor = couple.getFirst();
 		int darkColor = couple.getSecond();
 		int flickeringBrightColor = Color.mixColors(brightColor, darkColor, flicker / 4);

--- a/src/main/java/com/simibubi/create/content/redstone/nixieTube/NixieTubeRenderer.java
+++ b/src/main/java/com/simibubi/create/content/redstone/nixieTube/NixieTubeRenderer.java
@@ -86,7 +86,7 @@ public class NixieTubeRenderer extends SafeBlockEntityRenderer<NixieTubeBlockEnt
 		float charWidth = fontRenderer.width(c);
 		float shadowOffset = .5f;
 		float flicker = r.nextFloat();
-		Couple<Integer> couple = DyeHelper.DYE_TABLE.get(color);
+		Couple<Integer> couple = DyeHelper.getDyeColors(color);
 		int brightColor = couple.getFirst();
 		int darkColor = couple.getSecond();
 		int flickeringBrightColor = Color.mixColors(brightColor, darkColor, flicker / 4);

--- a/src/main/java/com/simibubi/create/content/trains/display/FlapDisplayBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/trains/display/FlapDisplayBlockEntity.java
@@ -141,7 +141,7 @@ public class FlapDisplayBlockEntity extends KineticBlockEntity {
 		List<FlapDisplayLayout> lines = getLines();
 		if (lineIndex >= lines.size())
 			return;
-		
+
 		FlapDisplayLayout layout = lines.get(lineIndex);
 		if (!layout.isLayout("Default"))
 			layout.loadDefault(getMaxCharCount());
@@ -173,7 +173,7 @@ public class FlapDisplayBlockEntity extends KineticBlockEntity {
 		colour[lineIndex] = color == DyeColor.WHITE ? null : color;
 		notifyUpdate();
 	}
-	
+
 	public void setGlowing(int lineIndex) {
 		glowingLines[lineIndex] = true;
 		notifyUpdate();
@@ -210,7 +210,7 @@ public class FlapDisplayBlockEntity extends KineticBlockEntity {
 		for (int j = 0; j < manualLines.length; j++)
 			if (manualLines[j])
 				NBTHelper.putMarker(tag, "CustomLine" + j);
-		
+
 		for (int j = 0; j < glowingLines.length; j++)
 			if (glowingLines[j])
 				NBTHelper.putMarker(tag, "GlowingLine" + j);
@@ -239,7 +239,7 @@ public class FlapDisplayBlockEntity extends KineticBlockEntity {
 		manualLines = new boolean[ySize * 2];
 		for (int i = 0; i < ySize * 2; i++)
 			manualLines[i] = tag.contains("CustomLine" + i);
-		
+
 		glowingLines = new boolean[ySize * 2];
 		for (int i = 0; i < ySize * 2; i++)
 			glowingLines[i] = tag.contains("GlowingLine" + i);
@@ -323,12 +323,12 @@ public class FlapDisplayBlockEntity extends KineticBlockEntity {
 	public int getLineColor(int line) {
 		DyeColor color = colour[line];
 		return color == null ? 0xFF_D3C6BA
-			: DyeHelper.DYE_TABLE.get(color)
+			: DyeHelper.getDyeColors(color)
 				.getFirst() | 0xFF_000000;
 	}
-	
+
 	public boolean isLineGlowing(int line) {
 		return glowingLines[line];
 	}
-	
+
 }

--- a/src/main/java/com/simibubi/create/foundation/utility/DyeHelper.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/DyeHelper.java
@@ -1,8 +1,8 @@
 package com.simibubi.create.foundation.utility;
 
+import java.util.HashMap;
 import java.util.Map;
-
-import com.google.common.collect.ImmutableMap;
+import java.util.function.Supplier;
 
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.level.ItemLike;
@@ -11,66 +11,53 @@ import net.minecraft.world.level.block.Blocks;
 public class DyeHelper {
 
 	public static ItemLike getWoolOfDye(DyeColor color) {
-		switch (color) {
-		case BLACK:
-			return Blocks.BLACK_WOOL;
-		case BLUE:
-			return Blocks.BLUE_WOOL;
-		case BROWN:
-			return Blocks.BROWN_WOOL;
-		case CYAN:
-			return Blocks.CYAN_WOOL;
-		case GRAY:
-			return Blocks.GRAY_WOOL;
-		case GREEN:
-			return Blocks.GREEN_WOOL;
-		case LIGHT_BLUE:
-			return Blocks.LIGHT_BLUE_WOOL;
-		case LIGHT_GRAY:
-			return Blocks.LIGHT_GRAY_WOOL;
-		case LIME:
-			return Blocks.LIME_WOOL;
-		case MAGENTA:
-			return Blocks.MAGENTA_WOOL;
-		case ORANGE:
-			return Blocks.ORANGE_WOOL;
-		case PINK:
-			return Blocks.PINK_WOOL;
-		case PURPLE:
-			return Blocks.PURPLE_WOOL;
-		case RED:
-			return Blocks.RED_WOOL;
-		case YELLOW:
-			return Blocks.YELLOW_WOOL;
-		case WHITE:
-		default:
-			return Blocks.WHITE_WOOL;
-		}
+		return WOOL_TABLE.getOrDefault(color, () -> Blocks.WHITE_WOOL).get();
 	}
 
-	public static final Map<DyeColor, Couple<Integer>> DYE_TABLE = new ImmutableMap.Builder<DyeColor, Couple<Integer>>()
-	
-	// DyeColor, ( Front RGB, Back RGB )
-	.put(DyeColor.BLACK, Couple.create(0x45403B, 0x21201F))
-	.put(DyeColor.RED, Couple.create(0xB13937, 0x632737))
-	.put(DyeColor.GREEN, Couple.create(0x208A46, 0x1D6045))
-	.put(DyeColor.BROWN, Couple.create(0xAC855C, 0x68533E))
-	
-	.put(DyeColor.BLUE, Couple.create(0x5391E1, 0x504B90))
-	.put(DyeColor.GRAY, Couple.create(0x5D666F, 0x313538))
-	.put(DyeColor.LIGHT_GRAY, Couple.create(0x95969B, 0x707070))
-	.put(DyeColor.PURPLE, Couple.create(0x9F54AE, 0x63366C))
-	
-	.put(DyeColor.CYAN, Couple.create(0x3EABB4, 0x3C7872))
-	.put(DyeColor.PINK, Couple.create(0xD5A8CB, 0xB86B95))
-	.put(DyeColor.LIME, Couple.create(0xA3DF55, 0x4FB16F))
-	.put(DyeColor.YELLOW, Couple.create(0xE6D756, 0xE9AC29))
-	
-	.put(DyeColor.LIGHT_BLUE, Couple.create(0x69CED2, 0x508AA5))
-	.put(DyeColor.ORANGE, Couple.create(0xEE9246, 0xD94927))
-	.put(DyeColor.MAGENTA, Couple.create(0xF062B0, 0xC04488))
-	.put(DyeColor.WHITE, Couple.create(0xEDEAE5, 0xBBB6B0))
-	
-	.build();
+	public static Couple<Integer> getDyeColors(DyeColor color){
+		return DYE_TABLE.getOrDefault(color, DYE_TABLE.get(DyeColor.WHITE));
+	}
 
+	/**
+	 * Adds a dye color s.t. Create's blocks can use it instead of defaulting to white.
+	 * @param color Dye color to add
+	 * @param brightColor Front (bright) RGB color
+	 * @param darkColor Back (dark) RGB color
+	 * @param wool Supplier of wool item/block corresponding to the color
+	 */
+	public static void addDye(DyeColor color, Integer brightColor, Integer darkColor, Supplier<ItemLike> wool){
+		DYE_TABLE.put(color, Couple.create(brightColor, darkColor));
+		WOOL_TABLE.put(color, wool);
+	}
+
+	private static void addDye(DyeColor color, Integer brightColor, Integer darkColor, ItemLike wool){
+		addDye(color, brightColor, darkColor, () -> wool);
+	}
+
+	private static final Map<DyeColor, Supplier<ItemLike>> WOOL_TABLE = new HashMap<>();
+
+	private static final Map<DyeColor, Couple<Integer>> DYE_TABLE = new HashMap<>();
+
+	static {
+		// DyeColor, ( Front RGB, Back RGB )
+		addDye(DyeColor.BLACK, 0x45403B, 0x21201F, Blocks.BLACK_WOOL);
+		addDye(DyeColor.RED, 0xB13937, 0x632737, Blocks.RED_WOOL);
+		addDye(DyeColor.GREEN, 0x208A46, 0x1D6045, Blocks.GREEN_WOOL);
+		addDye(DyeColor.BROWN, 0xAC855C, 0x68533E, Blocks.BROWN_WOOL);
+
+		addDye(DyeColor.BLUE, 0x5391E1, 0x504B90, Blocks.BLUE_WOOL);
+		addDye(DyeColor.GRAY, 0x5D666F, 0x313538, Blocks.GRAY_WOOL);
+		addDye(DyeColor.LIGHT_GRAY, 0x95969B, 0x707070, Blocks.LIGHT_GRAY_WOOL);
+		addDye(DyeColor.PURPLE, 0x9F54AE, 0x63366C, Blocks.PURPLE_WOOL);
+
+		addDye(DyeColor.CYAN, 0x3EABB4, 0x3C7872, Blocks.CYAN_WOOL);
+		addDye(DyeColor.PINK, 0xD5A8CB, 0xB86B95, Blocks.PINK_WOOL);
+		addDye(DyeColor.LIME, 0xA3DF55, 0x4FB16F, Blocks.LIME_WOOL);
+		addDye(DyeColor.YELLOW, 0xE6D756, 0xE9AC29, Blocks.YELLOW_WOOL);
+
+		addDye(DyeColor.LIGHT_BLUE, 0x69CED2, 0x508AA5, Blocks.LIGHT_BLUE_WOOL);
+		addDye(DyeColor.ORANGE, 0xEE9246, 0xD94927, Blocks.ORANGE_WOOL);
+		addDye(DyeColor.MAGENTA, 0xF062B0, 0xC04488, Blocks.MAGENTA_WOOL);
+		addDye(DyeColor.WHITE, 0xEDEAE5, 0xBBB6B0, Blocks.WHITE_WOOL);
+	}
 }

--- a/src/main/java/com/simibubi/create/infrastructure/debugInfo/ServerDebugInfoPacket.java
+++ b/src/main/java/com/simibubi/create/infrastructure/debugInfo/ServerDebugInfoPacket.java
@@ -84,7 +84,7 @@ public class ServerDebugInfoPacket extends SimplePacketBase {
 		String text = output.toString();
 		Minecraft.getInstance().keyboardHandler.setClipboard(text);
 		Lang.translate("command.debuginfo.saved_to_clipboard")
-			.color(DyeHelper.DYE_TABLE.get(DyeColor.LIME)
+			.color(DyeHelper.getDyeColors(DyeColor.LIME)
 				.getFirst())
 			.sendChat(player);
 	}


### PR DESCRIPTION
### Issues Fixed
Fixes #6694

### Implemented Solution
Use getOrDefault instead of get when accessing DyeHelper.DYE_TABLE, defaulting to white, like getWoolForDye did before.

Additionally adds an api that mods that extend the dyecolor enum can use to register the colors that should be used for the display board/nixie tube, as well as the wool; should getWoolForDye ever get used for something other than datagen.