### PR TITLE
Optimize spout recipe generation by avoiding filling non-empty items

### DIFF
--- a/src/main/java/com/simibubi/create/compat/jei/category/SpoutCategory.java
+++ b/src/main/java/com/simibubi/create/compat/jei/category/SpoutCategory.java
@@ -63,7 +63,16 @@ public class SpoutCategory extends CreateRecipeCategory<FillingRecipe> {
 			if (!capability.isPresent())
 				continue;
 
+			var existingFluidHandler = capability.orElse(null);
+			int numTanks = existingFluidHandler.getTanks();
+			FluidStack existingFluid = numTanks == 1 ? existingFluidHandler.getFluidInTank(0) : FluidStack.EMPTY;
+
 			for (FluidStack fluidStack : fluidStacks) {
+				// Hoist the fluid equality check to avoid the work of copying the stack + populating capabilities
+				// when most fluids will not match
+				if (numTanks == 1 && (!existingFluid.isEmpty() && !existingFluid.isFluidEqual(fluidStack))) {
+					continue;
+				}
 				ItemStack copy = stack.copy();
 				copy.getCapability(ForgeCapabilities.FLUID_HANDLER_ITEM)
 					.ifPresent(fhi -> {


### PR DESCRIPTION
Much of the time spent in Create's JEI plugin initialization is spent in `SpoutCategory`, where it iterates the entire list of JEI ingredients to generate filling recipes.

Most of the bottleneck is in `getCapability` as Forge fires an event for every single call (due to the item stacks being freshly constructed). The optimization here is to avoid the second `getCapability` call (that runs per registered fluid) by hoisting a check for whether the item could even be filled above the call. (We assume that a single-tank item cannot simultaneously be filled with two non-equal fluids.)

Another player and myself see a 7-10x improvement in the `create:jei_plugin` loading time with this change, tested on 1.20.1 with the following mods:

* GTCEu Modern
* NuclearCraft
* Mekanism
* Thermal
* Tinkers' Construct
* Create

An additional optimization would be to reduce the number of items being probed for capabilities, e.g. by iterating the item registry, instead of iterating the list of ingredients in JEI. I did not implement this as it would likely cause some edge case recipes to disappear.