### PR TITLE
fix: Resolve issue with book & quills on lectern contraptions

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/utility/NBTProcessors.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/NBTProcessors.java
@@ -15,13 +15,16 @@ import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.StringTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.world.item.EnchantedBookItem;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.entity.SpawnerBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.registries.ForgeRegistries;
 
 public final class NBTProcessors {
 
@@ -43,14 +46,14 @@ public final class NBTProcessors {
 				return data;
 			CompoundTag book = data.getCompound("Book");
 
+			// Writable books can't have click events, so they're safe to keep
+			ResourceLocation writableBookResource = ForgeRegistries.ITEMS.getKey(Items.WRITABLE_BOOK);
+			if (writableBookResource != null && book.getString("id").equals(writableBookResource.toString()))
+				return data;
+
 			if (!book.contains("tag", Tag.TAG_COMPOUND))
 				return data;
 			CompoundTag tag = book.getCompound("tag");
-
-			// Check for book & quill, which does not have json pages and
-			// therefore can't have click events. Written books have an "author" tag.
-			if (!tag.contains("author", Tag.TAG_LIST))
-				return data;
 
 			if (!tag.contains("pages", Tag.TAG_LIST))
 				return data;

--- a/src/main/java/com/simibubi/create/foundation/utility/NBTProcessors.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/NBTProcessors.java
@@ -47,6 +47,11 @@ public final class NBTProcessors {
 				return data;
 			CompoundTag tag = book.getCompound("tag");
 
+			// Check for book & quill, which does not have json pages and
+			// therefore can't have click events. Written books have an "author" tag.
+			if (!tag.contains("author", Tag.TAG_LIST))
+				return data;
+
 			if (!tag.contains("pages", Tag.TAG_LIST))
 				return data;
 			ListTag pages = tag.getList("pages", Tag.TAG_STRING);
@@ -67,7 +72,7 @@ public final class NBTProcessors {
 			if (!book.contains("tag", Tag.TAG_COMPOUND))
 				return data;
 			CompoundTag itemData = book.getCompound("tag");
-			
+
 			for (List<String> entries : NBTHelper.readCompoundList(itemData.getList("Pages", Tag.TAG_COMPOUND),
 				pageTag -> NBTHelper.readCompoundList(pageTag.getList("Entries", Tag.TAG_COMPOUND),
 					tag -> tag.getString("Text")))) {


### PR DESCRIPTION
Resolves #7253. Where an attempt to parse JSON out of a writable book (not a written book), which has raw string data for the pages array caused a game crash.


Compound tags for a written book on a lectern:
`{Book:{Count:1b,id:"minecraft:written_book",tag:{author:"Dev",filtered_title:"aa",pages:['{"text":"aaaa"}','{"text":"bbbb"}'],resolved:1b,title:"aa"}},Page:0,id:"minecraft:lectern"}`

Compound tags for a writable book on a lectern:
`{Book:{Count:1b,id:"minecraft:writable_book",tag:{pages:["cccc","ddddd"]}},Page:0,id:"minecraft:lectern"}`

An attempt to parse "cccc" as JSON caused the crash.