### PR TITLE
Fix backtank crashing on ctrl+pick block

### DIFF
--- a/src/main/java/com/simibubi/create/content/equipment/armor/BacktankBlock.java
+++ b/src/main/java/com/simibubi/create/content/equipment/armor/BacktankBlock.java
@@ -184,8 +184,10 @@ public class BacktankBlock extends HorizontalKineticBlock implements IBE<Backtan
 		Optional<BacktankBlockEntity> blockEntityOptional = getBlockEntityOptional(blockGetter, pos);
 
 		CompoundTag forgeCapsTag = blockEntityOptional.map(BacktankBlockEntity::getForgeCapsTag)
+				.map(CompoundTag::copy)
 			.orElse(null);
 		CompoundTag vanillaTag = blockEntityOptional.map(BacktankBlockEntity::getVanillaTag)
+				.map(CompoundTag::copy)
 			.orElse(new CompoundTag());
 		int air = blockEntityOptional.map(BacktankBlockEntity::getAirLevel)
 			.orElse(0);

--- a/src/main/java/com/simibubi/create/content/equipment/armor/BacktankBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/equipment/armor/BacktankBlockEntity.java
@@ -120,10 +120,10 @@ public class BacktankBlockEntity extends KineticBlockEntity implements Nameable 
 		compound.putInt("Air", airLevel);
 		compound.putInt("Timer", airLevelTimer);
 		compound.putInt("CapacityEnchantment", capacityEnchantLevel);
-		
+
 		if (this.customName != null)
 			compound.putString("CustomName", Component.Serializer.toJson(this.customName));
-		
+
 		compound.put("VanillaTag", vanillaTag);
 		if (forgeCapsTag != null)
 			compound.put("ForgeCapsTag", forgeCapsTag);
@@ -136,10 +136,10 @@ public class BacktankBlockEntity extends KineticBlockEntity implements Nameable 
 		airLevel = compound.getInt("Air");
 		airLevelTimer = compound.getInt("Timer");
 		capacityEnchantLevel = compound.getInt("CapacityEnchantment");
-		
+
 		if (compound.contains("CustomName", 8))
 			this.customName = Component.Serializer.fromJson(compound.getString("CustomName"));
-		
+
 		vanillaTag = compound.getCompound("VanillaTag");
 		forgeCapsTag = compound.contains("ForgeCapsTag") ? compound.getCompound("ForgeCapsTag") : null;
 
@@ -181,16 +181,18 @@ public class BacktankBlockEntity extends KineticBlockEntity implements Nameable 
 	public void setCapacityEnchantLevel(int capacityEnchantLevel) {
 		this.capacityEnchantLevel = capacityEnchantLevel;
 	}
-	
+
 	public void setTags(CompoundTag vanillaTag, @Nullable CompoundTag forgeCapsTag) {
-		this.vanillaTag = vanillaTag;
-		this.forgeCapsTag = forgeCapsTag;
+		this.vanillaTag = vanillaTag.copy();
+		this.forgeCapsTag = forgeCapsTag == null ? null : forgeCapsTag.copy();
+		// Prevent nesting of the ctrl+pick block added tag
+		vanillaTag.remove("BlockEntityTag");
 	}
 
 	public CompoundTag getVanillaTag() {
 		return vanillaTag;
 	}
-	
+
 	public CompoundTag getForgeCapsTag() {
 		return forgeCapsTag;
 	}


### PR DESCRIPTION
### Issues Fixed
Fixes #7281

### Implemented Solution
- Copy vanilla/forgecaps compoundtags before adding them to the cloneitemstack. With ctrl+pick block, they end up in the BlockEntityTag that gets tacked onto the itemstack's tag. Which *was* vanillaTag and so vanillaTag now contained a reference to itself. This is all that's strictly necessary to fix the linked issue.
- Copy the tags on placement too so every backtank placed from the same stack has its own copy instead of sharing the tags.
- And throw out BlockEntityTag so it can't repeatedly nest and cause the same issue but then via recursion depth. It didn't meaningfully retain anything in that tag that wasn't in vanillaTag/forgeCaps anyhow when placed.