### PR TITLE
fixes #7270 Deploying food may be missing particle, deploying bowl foods loses bowl

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/deployer/DeployerHandler.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/deployer/DeployerHandler.java
@@ -185,7 +185,7 @@ public class DeployerHandler {
 						FoodProperties foodProperties = item.getFoodProperties(stack, player);
 						if (playerEntity.canEat(foodProperties.canAlwaysEat())) {
 							ItemStack copy = stack.copy();
-							playerEntity.eat(world, stack);
+							player.setItemInHand(hand, stack.finishUsingItem(world, playerEntity));
 							player.spawnedItemEffects = copy;
 							success = true;
 						}

--- a/src/main/java/com/simibubi/create/content/kinetics/deployer/DeployerHandler.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/deployer/DeployerHandler.java
@@ -184,8 +184,9 @@ public class DeployerHandler {
 					if (stack.isEdible()) {
 						FoodProperties foodProperties = item.getFoodProperties(stack, player);
 						if (playerEntity.canEat(foodProperties.canAlwaysEat())) {
+							ItemStack copy = stack.copy();
 							playerEntity.eat(world, stack);
-							player.spawnedItemEffects = stack.copy();
+							player.spawnedItemEffects = copy;
 							success = true;
 						}
 					}


### PR DESCRIPTION
Fixing two issues:
When a deployer deploys a food item of stack size 1, the particle is missing
When a deployer deploys a food with a craft remainder such as stews/soups, the remainder item vanishes.

first issue I already fixed. it was caused by the itemstack being passed through an eat() method which decremented it before retrieving the particle, so it was attempting to get a particle from an empty itemstack.

second issue WIP at the moment