### PR TITLE
Fix: fans that cannot process cancelling progress of processing fans

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/belt/transport/TransportedItemStack.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/transport/TransportedItemStack.java
@@ -1,6 +1,8 @@
 package com.simibubi.create.content.kinetics.belt.transport;
 
+import java.util.HashSet;
 import java.util.Random;
+import java.util.Set;
 
 import com.simibubi.create.content.kinetics.belt.BeltHelper;
 import com.simibubi.create.content.kinetics.fan.processing.FanProcessingType;
@@ -27,6 +29,7 @@ public class TransportedItemStack implements Comparable<TransportedItemStack> {
 
 	public FanProcessingType processedBy;
 	public int processingTime;
+	public Set<FanProcessingType> cannotBeProcessedBy;
 
 	public TransportedItemStack(ItemStack stack) {
 		this.stack = stack;
@@ -34,6 +37,7 @@ public class TransportedItemStack implements Comparable<TransportedItemStack> {
 		angle = centered ? 180 : R.nextInt(360);
 		sideOffset = prevSideOffset = getTargetSideOffset();
 		insertedFrom = Direction.UP;
+		cannotBeProcessedBy = new HashSet<>();
 	}
 
 	public float getTargetSideOffset() {

--- a/src/main/java/com/simibubi/create/content/kinetics/fan/processing/FanProcessing.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/fan/processing/FanProcessing.java
@@ -53,18 +53,21 @@ public class FanProcessing {
 
 	public static TransportedResult applyProcessing(TransportedItemStack transported, Level world, FanProcessingType type) {
 		TransportedResult ignore = TransportedResult.doNothing();
+		if (transported.cannotBeProcessedBy.contains(type)) {
+			return ignore;
+		}
 		if (transported.processedBy != type) {
+			if (!type.canProcess(transported.stack, world)) {
+				transported.cannotBeProcessedBy.add(type);
+				return ignore;
+			}
 			transported.processedBy = type;
 			int timeModifierForStackSize = ((transported.stack.getCount() - 1) / 16) + 1;
 			int processingTime =
 				(int) (AllConfigs.server().kinetics.fanProcessingTime.get() * timeModifierForStackSize) + 1;
 			transported.processingTime = processingTime;
-			if (!type.canProcess(transported.stack, world))
-				transported.processingTime = -1;
 			return ignore;
 		}
-		if (transported.processingTime == -1)
-			return ignore;
 		if (transported.processingTime-- > 0)
 			return ignore;
 


### PR DESCRIPTION
### Issues Fixed
Fixes #7298

### Implemented Solution
Bring forward the canProcess check and exit early to not reset the processing time.
Cache the processing types that cannot process the stack so that we can still have an early return and don't keep rechecking whether we can process.