### PR TITLE
Prevent damage to Extendo-Grip from Frost Walker

### DIFF
--- a/src/main/java/com/simibubi/create/content/equipment/extendoGrip/ExtendoGripItem.java
+++ b/src/main/java/com/simibubi/create/content/equipment/extendoGrip/ExtendoGripItem.java
@@ -1,5 +1,6 @@
 package com.simibubi.create.content.equipment.extendoGrip;
 
+import java.util.Map;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -29,6 +30,9 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.projectile.ProjectileUtil;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraft.world.item.enchantment.Enchantments;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.EntityHitResult;
@@ -182,8 +186,18 @@ public class ExtendoGripItem extends Item {
 	@SubscribeEvent(priority = EventPriority.LOWEST)
 	public static void consumeDurabilityOnPlace(EntityPlaceEvent event) {
 		Entity entity = event.getEntity();
-		if (entity instanceof Player)
-			findAndDamageExtendoGrip((Player) entity);
+		if (entity instanceof Player player) {
+			if (event.getPlacedBlock().is(Blocks.FROSTED_ICE)) {
+				for (ItemStack armorSlot : player.getArmorSlots()) {
+					for (Enchantment enchantment : armorSlot.getAllEnchantments().keySet()) {
+						if (!enchantment.equals(Enchantments.FROST_WALKER)) {
+							findAndDamageExtendoGrip(player);
+						}
+					}
+				}
+			}
+			else findAndDamageExtendoGrip(player);
+		}
 	}
 
 //	@SubscribeEvent(priority = EventPriority.LOWEST)

--- a/src/main/java/com/simibubi/create/content/equipment/extendoGrip/ExtendoGripItem.java
+++ b/src/main/java/com/simibubi/create/content/equipment/extendoGrip/ExtendoGripItem.java
@@ -31,7 +31,9 @@ import net.minecraft.world.entity.projectile.ProjectileUtil;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.item.enchantment.Enchantments;
+import net.minecraft.world.item.enchantment.FrostWalkerEnchantment;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.BlockHitResult;
@@ -49,6 +51,7 @@ import net.minecraftforge.event.entity.living.LivingKnockBackEvent;
 import net.minecraftforge.event.entity.player.AttackEntityEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.event.level.BlockEvent;
 import net.minecraftforge.event.level.BlockEvent.BreakEvent;
 import net.minecraftforge.event.level.BlockEvent.EntityPlaceEvent;
 import net.minecraftforge.eventbus.api.EventPriority;
@@ -187,16 +190,8 @@ public class ExtendoGripItem extends Item {
 	public static void consumeDurabilityOnPlace(EntityPlaceEvent event) {
 		Entity entity = event.getEntity();
 		if (entity instanceof Player player) {
-			if (event.getPlacedBlock().is(Blocks.FROSTED_ICE)) {
-				for (ItemStack armorSlot : player.getArmorSlots()) {
-					for (Enchantment enchantment : armorSlot.getAllEnchantments().keySet()) {
-						if (!enchantment.equals(Enchantments.FROST_WALKER)) {
-							findAndDamageExtendoGrip(player);
-						}
-					}
-				}
-			}
-			else findAndDamageExtendoGrip(player);
+			if (!event.getBlockSnapshot().getReplacedBlock().is(Blocks.WATER) && !event.getBlockSnapshot().getCurrentBlock().is(Blocks.WATER))
+				findAndDamageExtendoGrip(player);
 		}
 	}
 


### PR DESCRIPTION
Frost Walker places frosted ice blocks through the EntityPlaceEvent. Currently, the event then damages the Extendo-Grip for every frosted ice block placed by the enchantment, rapidly breaking it. This fix prevents damage to the Extendo-Grip when the block is Frosted Ice and the player's equipment has Frost Walker.