### PR TITLE
Fix IndexOutOfBoundsException

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/mixin/ClientboundMapItemDataPacketMixin.java
+++ b/src/main/java/com/simibubi/create/foundation/mixin/ClientboundMapItemDataPacketMixin.java
@@ -55,6 +55,10 @@ public class ClientboundMapItemDataPacketMixin {
 
 	@Inject(method = "<init>(Lnet/minecraft/network/FriendlyByteBuf;)V", at = @At("RETURN"))
 	private void create$onInit(FriendlyByteBuf buf, CallbackInfo ci) {
+		if(!buf.isReadable()) {
+			return;
+		}
+
 		create$stationIndices = buf.readVarIntArray();
 
 		if (decorations != null) {


### PR DESCRIPTION
When using this mod to connect to a Vanilla server, it results in an IndexOutOfBoundsException error, which is caused by the lack of compatibility with Vanilla's ClientboundMapItemDataPacket.