### PR TITLE
Fixed the Cardboard Armor's crouch behavior not respecting the player's scale attribute

### DIFF
--- a/src/main/java/com/simibubi/create/content/equipment/armor/CardboardArmorHandler.java
+++ b/src/main/java/com/simibubi/create/content/equipment/armor/CardboardArmorHandler.java
@@ -34,7 +34,14 @@ public class CardboardArmorHandler {
 		if (!testForStealth(entity))
 			return;
 
-		event.setNewSize(EntityDimensions.fixed(0.6F, 0.8F).withEyeHeight(0.6F));
+		float scale;
+		if(entity instanceof LivingEntity le) {
+			scale = le.getScale();
+		} else {
+			scale = 1.0F;
+		}
+
+		event.setNewSize(EntityDimensions.fixed(0.6F * scale, 0.8F * scale).withEyeHeight(0.6F * scale));
 
 		if (!entity.level()
 			.isClientSide() && entity instanceof Player p)

--- a/src/main/java/com/simibubi/create/content/equipment/armor/CardboardArmorHandlerClient.java
+++ b/src/main/java/com/simibubi/create/content/equipment/armor/CardboardArmorHandlerClient.java
@@ -13,8 +13,11 @@ import dev.engine_room.flywheel.lib.model.baked.PartialModel;
 import net.createmod.catnip.animation.AnimationTickHolder;
 import net.minecraft.client.CameraType;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.AbstractClientPlayer;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.player.Player;
+
+import net.minecraft.world.phys.Vec3;
 
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.EventPriority;
@@ -54,7 +57,9 @@ public class CardboardArmorHandlerClient {
 
 		PoseStack ms = event.getPoseStack();
 		ms.pushPose();
-		ms.translate(0, 2 / 16f, 0);
+
+		Vec3 renderOffset = event.getRenderer().getRenderOffset((AbstractClientPlayer)player, event.getPartialTick());
+		ms.translate(0, -renderOffset.y, 0);
 
 		float movement = (float) player.position()
 			.subtract(player.xo, player.yo, player.zo)
@@ -62,10 +67,13 @@ public class CardboardArmorHandlerClient {
 
 		if (player.onGround())
 			ms.translate(0,
-				Math.min(Math.abs(Mth.cos((AnimationTickHolder.getRenderTime() % 256) / 2.0f)) * 2 / 16f, movement * 5),
+				Math.min(Math.abs(Mth.cos((AnimationTickHolder.getRenderTime() % 256) / 2.0f)) * -renderOffset.y, movement * 5),
 				0);
 
 		float interpolatedYaw = Mth.lerp(event.getPartialTick(), player.yRotO, player.getYRot());
+
+		float scale = player.getScale();
+		ms.scale(scale, scale, scale);
 
 		try {
 			PartialModel model = AllPartialModels.PACKAGES_TO_HIDE_AS.get(getCurrentBoxIndex(player));


### PR DESCRIPTION
Currently, the cardboard box mechanic for crouching with cardboard armor doesn't respect the player's scale attribute.

This PR makes it so that the box is correctly offset from the ground and is the correct size, as well as making sure the player's hitbox is adjusted when they are a box with respect to their scale.

[Before](https://www.youtube.com/watch?v=3vrUbZ5AX1k)
[After](https://youtu.be/Y-aiu8vXiNw)