### PR TITLE
Configurable factory gauge request timer

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/factoryBoard/FactoryPanelBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/logistics/factoryBoard/FactoryPanelBehaviour.java
@@ -387,6 +387,7 @@ public class FactoryPanelBehaviour extends FilteringBehaviour implements MenuPro
 		if (satisfied || promisedSatisfied || waitingForNetwork || redstonePowered)
 			return;
 		if (timer > 0) {
+			timer = Math.min(timer, getConfigRequestIntervalInTicks());
 			timer--;
 			return;
 		}
@@ -822,7 +823,7 @@ public class FactoryPanelBehaviour extends FilteringBehaviour implements MenuPro
 		filter = FilterItemStack.of(panelTag.getCompound("Filter"));
 		count = panelTag.getInt("FilterAmount");
 		upTo = panelTag.getBoolean("UpTo");
-		timer = Math.min(panelTag.getInt("Timer"), getConfigRequestIntervalInTicks());
+		timer = panelTag.getInt("Timer");
 		lastReportedLevelInStorage = panelTag.getInt("LastLevel");
 		lastReportedPromises = panelTag.getInt("LastPromised");
 		lastReportedUnloadedLinks = panelTag.getInt("LastUnloadedLinks");

--- a/src/main/java/com/simibubi/create/content/logistics/factoryBoard/FactoryPanelBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/logistics/factoryBoard/FactoryPanelBehaviour.java
@@ -86,7 +86,6 @@ public class FactoryPanelBehaviour extends FilteringBehaviour implements MenuPro
 	public static final BehaviourType<FactoryPanelBehaviour> TOP_RIGHT = new BehaviourType<>();
 	public static final BehaviourType<FactoryPanelBehaviour> BOTTOM_LEFT = new BehaviourType<>();
 	public static final BehaviourType<FactoryPanelBehaviour> BOTTOM_RIGHT = new BehaviourType<>();
-//	public static final int REQUEST_INTERVAL = 100;
 
 	public Map<FactoryPanelPosition, FactoryPanelConnection> targetedBy;
 	public Map<BlockPos, FactoryPanelConnection> targetedByLinks;

--- a/src/main/java/com/simibubi/create/content/logistics/factoryBoard/FactoryPanelBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/logistics/factoryBoard/FactoryPanelBehaviour.java
@@ -1,5 +1,7 @@
 package com.simibubi.create.content.logistics.factoryBoard;
 
+import com.simibubi.create.infrastructure.config.AllConfigs;
+
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -84,7 +86,7 @@ public class FactoryPanelBehaviour extends FilteringBehaviour implements MenuPro
 	public static final BehaviourType<FactoryPanelBehaviour> TOP_RIGHT = new BehaviourType<>();
 	public static final BehaviourType<FactoryPanelBehaviour> BOTTOM_LEFT = new BehaviourType<>();
 	public static final BehaviourType<FactoryPanelBehaviour> BOTTOM_RIGHT = new BehaviourType<>();
-	public static final int REQUEST_INTERVAL = 100;
+//	public static final int REQUEST_INTERVAL = 100;
 
 	public Map<FactoryPanelPosition, FactoryPanelConnection> targetedBy;
 	public Map<BlockPos, FactoryPanelConnection> targetedByLinks;
@@ -386,7 +388,6 @@ public class FactoryPanelBehaviour extends FilteringBehaviour implements MenuPro
 		if (satisfied || promisedSatisfied || waitingForNetwork || redstonePowered)
 			return;
 		if (timer > 0) {
-			timer = Math.min(timer, REQUEST_INTERVAL);
 			timer--;
 			return;
 		}
@@ -743,11 +744,15 @@ public class FactoryPanelBehaviour extends FilteringBehaviour implements MenuPro
 	}
 
 	public void resetTimer() {
-		timer = REQUEST_INTERVAL;
+		timer = getConfigRequestIntervalInTicks();
 	}
 
 	public void resetTimerSlightly() {
-		timer = REQUEST_INTERVAL / 2;
+		timer = getConfigRequestIntervalInTicks() / 2;
+	}
+
+	private int getConfigRequestIntervalInTicks() {
+		return AllConfigs.server().logistics.factoryGaugeTimer.get();
 	}
 
 	private int getPromiseExpiryTimeInTicks() {
@@ -818,7 +823,7 @@ public class FactoryPanelBehaviour extends FilteringBehaviour implements MenuPro
 		filter = FilterItemStack.of(panelTag.getCompound("Filter"));
 		count = panelTag.getInt("FilterAmount");
 		upTo = panelTag.getBoolean("UpTo");
-		timer = panelTag.getInt("Timer");
+		timer = Math.min(panelTag.getInt("Timer"), getConfigRequestIntervalInTicks());
 		lastReportedLevelInStorage = panelTag.getInt("LastLevel");
 		lastReportedPromises = panelTag.getInt("LastPromised");
 		lastReportedUnloadedLinks = panelTag.getInt("LastUnloadedLinks");

--- a/src/main/java/com/simibubi/create/infrastructure/config/CLogistics.java
+++ b/src/main/java/com/simibubi/create/infrastructure/config/CLogistics.java
@@ -14,6 +14,7 @@ public class CLogistics extends ConfigBase {
 	public final ConfigInt vaultCapacity = i(20, 1, 2048, "vaultCapacity", Comments.vaultCapacity);
 	public final ConfigInt chainConveyorCapacity = i(20, 1, "chainConveyorCapacity", Comments.chainConveyorCapacity);
 	public final ConfigInt brassTunnelTimer = i(10, 1, 10, "brassTunnelTimer", Comments.brassTunnelTimer);
+	public final ConfigInt factoryGaugeTimer = i(100, 5, "factoryGaugeTimer", Comments.factoryGaugeTimer);
 	public final ConfigBool seatHostileMobs = b(true, "seatHostileMobs", Comments.seatHostileMobs);
 
 	@Override
@@ -34,6 +35,7 @@ public class CLogistics extends ConfigBase {
 		static String vaultCapacity = "The total amount of stacks a vault can hold per block in size.";
 		static String chainConveyorCapacity = "The amount of packages a chain conveyor can carry at a time.";
 		static String brassTunnelTimer = "The amount of ticks a brass tunnel waits between distributions.";
+		static String factoryGaugeTimer = "The amount of ticks a factory gauge waits between requests.";
 		static String seatHostileMobs = "Whether hostile mobs walking near a seat will start riding it.";
 	}
 


### PR DESCRIPTION
This PR introduces a new logistics server configuration for factory gauges, enabling users to customize the request interval instead of using the previously hardcoded value of 100 ticks.

Additionally, it refactors the Math.min logic in the NBT read method to prevent configuration read spam.