### PR TITLE
Fixed positioning when attaching to chain conveyer not respecting player's scale attribute

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/chainConveyor/ChainConveyorRidingHandler.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/chainConveyor/ChainConveyorRidingHandler.java
@@ -62,9 +62,10 @@ public class ChainConveyorRidingHandler {
 
 		clbe.prepareStats();
 
+		float chainYOffset = 0.5f * mc.player.getScale();
 		Vec3 playerPosition = mc.player.position()
 			.add(0, mc.player.getBoundingBox()
-				.getYsize() + 0.5, 0);
+				.getYsize() + chainYOffset, 0);
 
 		updateTargetPosition(mc, clbe);
 


### PR DESCRIPTION
As the player grows bigger or smaller, the y-offset (to make sure the wrench attached to the chain matches up) doesn't adjust. This makes that y-offset scale based off of the player's scale attribute.