### PR TITLE
Updated Redstone Requester Peripheral

### DIFF
--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/ComputerBehaviour.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/ComputerBehaviour.java
@@ -4,6 +4,7 @@ import java.util.function.Supplier;
 
 import com.simibubi.create.compat.computercraft.AbstractComputerBehaviour;
 import com.simibubi.create.compat.computercraft.implementation.peripherals.DisplayLinkPeripheral;
+import com.simibubi.create.compat.computercraft.implementation.peripherals.PackagerPeripheral;
 import com.simibubi.create.compat.computercraft.implementation.peripherals.RedstoneRequesterPeripheral;
 import com.simibubi.create.compat.computercraft.implementation.peripherals.SequencedGearshiftPeripheral;
 import com.simibubi.create.compat.computercraft.implementation.peripherals.SpeedControllerPeripheral;
@@ -14,6 +15,7 @@ import com.simibubi.create.content.kinetics.gauge.SpeedGaugeBlockEntity;
 import com.simibubi.create.content.kinetics.gauge.StressGaugeBlockEntity;
 import com.simibubi.create.content.kinetics.speedController.SpeedControllerBlockEntity;
 import com.simibubi.create.content.kinetics.transmission.sequencer.SequencedGearshiftBlockEntity;
+import com.simibubi.create.content.logistics.packager.PackagerBlockEntity;
 import com.simibubi.create.content.logistics.redstoneRequester.RedstoneRequesterBlockEntity;
 import com.simibubi.create.content.redstone.displayLink.DisplayLinkBlockEntity;
 import com.simibubi.create.content.trains.station.StationBlockEntity;
@@ -49,6 +51,8 @@ public class ComputerBehaviour extends AbstractComputerBehaviour {
 			return () -> new StationPeripheral(sbe);
 		if (be instanceof RedstoneRequesterBlockEntity rrbe)
 			return () -> new RedstoneRequesterPeripheral(rrbe);
+		if (be instanceof PackagerBlockEntity pbe)
+			return () -> new PackagerPeripheral(pbe);
 
 		throw new IllegalArgumentException(
 			"No peripheral available for " + BuiltInRegistries.BLOCK_ENTITY_TYPE.getKey(be.getType()));

--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/ComputerBehaviour.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/ComputerBehaviour.java
@@ -4,6 +4,7 @@ import java.util.function.Supplier;
 
 import com.simibubi.create.compat.computercraft.AbstractComputerBehaviour;
 import com.simibubi.create.compat.computercraft.implementation.peripherals.DisplayLinkPeripheral;
+import com.simibubi.create.compat.computercraft.implementation.peripherals.RedstoneRequesterPeripheral;
 import com.simibubi.create.compat.computercraft.implementation.peripherals.SequencedGearshiftPeripheral;
 import com.simibubi.create.compat.computercraft.implementation.peripherals.SpeedControllerPeripheral;
 import com.simibubi.create.compat.computercraft.implementation.peripherals.SpeedGaugePeripheral;
@@ -13,6 +14,7 @@ import com.simibubi.create.content.kinetics.gauge.SpeedGaugeBlockEntity;
 import com.simibubi.create.content.kinetics.gauge.StressGaugeBlockEntity;
 import com.simibubi.create.content.kinetics.speedController.SpeedControllerBlockEntity;
 import com.simibubi.create.content.kinetics.transmission.sequencer.SequencedGearshiftBlockEntity;
+import com.simibubi.create.content.logistics.redstoneRequester.RedstoneRequesterBlockEntity;
 import com.simibubi.create.content.redstone.displayLink.DisplayLinkBlockEntity;
 import com.simibubi.create.content.trains.station.StationBlockEntity;
 import com.simibubi.create.foundation.blockEntity.SmartBlockEntity;
@@ -45,6 +47,8 @@ public class ComputerBehaviour extends AbstractComputerBehaviour {
 			return () -> new StressGaugePeripheral(sgbe);
 		if (be instanceof StationBlockEntity sbe)
 			return () -> new StationPeripheral(sbe);
+		if (be instanceof RedstoneRequesterBlockEntity rrbe)
+			return () -> new RedstoneRequesterPeripheral(rrbe);
 
 		throw new IllegalArgumentException(
 			"No peripheral available for " + BuiltInRegistries.BLOCK_ENTITY_TYPE.getKey(be.getType()));

--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/PackagerPeripheral.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/PackagerPeripheral.java
@@ -1,0 +1,29 @@
+package com.simibubi.create.compat.computercraft.implementation.peripherals;
+
+import com.simibubi.create.content.logistics.packager.PackagerBlockEntity;
+
+import dan200.computercraft.api.lua.IArguments;
+import dan200.computercraft.api.lua.LuaException;
+import dan200.computercraft.api.lua.LuaFunction;
+
+import org.jetbrains.annotations.NotNull;
+
+public class PackagerPeripheral extends SyncedPeripheral<PackagerBlockEntity> {
+
+	public PackagerPeripheral(PackagerBlockEntity blockEntity) {
+		super(blockEntity);
+	}
+
+	@LuaFunction(mainThread = true)
+	public final void createPackage(IArguments arguments) throws LuaException {
+
+		this.blockEntity.computerPacking(arguments.getString(0));
+	}
+
+	@NotNull
+	@Override
+	public String getType() {
+		return "Create_Packager";
+	}
+
+}

--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/RedstoneRequesterPeripheral.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/RedstoneRequesterPeripheral.java
@@ -1,0 +1,38 @@
+package com.simibubi.create.compat.computercraft.implementation.peripherals;
+
+import com.simibubi.create.content.logistics.BigItemStack;
+import com.simibubi.create.content.logistics.redstoneRequester.RedstoneRequesterBlockEntity;
+
+import dan200.computercraft.api.lua.IArguments;
+import dan200.computercraft.api.lua.LuaException;
+import dan200.computercraft.api.lua.LuaFunction;
+
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class RedstoneRequesterPeripheral  extends SyncedPeripheral<RedstoneRequesterBlockEntity> {
+
+	public RedstoneRequesterPeripheral(RedstoneRequesterBlockEntity blockEntity) {
+		super(blockEntity);
+	}
+
+	@LuaFunction(mainThread = true)
+	public final void orderPackage(IArguments arguments) throws LuaException {
+		List<BigItemStack> items = new java.util.ArrayList<>(List.of());
+
+		items.add(new BigItemStack(new ItemStack(BuiltInRegistries.ITEM.get(ResourceLocation.parse(arguments.getString(1)))), arguments.getInt(2)));
+		this.blockEntity.computerRequest(items, arguments.getString(0));
+	}
+
+	@NotNull
+	@Override
+	public String getType() {
+		return "Create_RedstoneRequester";
+	}
+
+}

--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/RedstoneRequesterPeripheral.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/RedstoneRequesterPeripheral.java
@@ -1,19 +1,27 @@
 package com.simibubi.create.compat.computercraft.implementation.peripherals;
 
 import com.simibubi.create.content.logistics.BigItemStack;
+import com.simibubi.create.content.logistics.packager.InventorySummary;
 import com.simibubi.create.content.logistics.redstoneRequester.RedstoneRequesterBlockEntity;
+
+import com.simibubi.create.content.logistics.redstoneRequester.RedstoneRequesterEffectPacket;
+
+import com.simibubi.create.content.logistics.stockTicker.StockCheckingBlockEntity;
 
 import dan200.computercraft.api.lua.IArguments;
 import dan200.computercraft.api.lua.LuaException;
 import dan200.computercraft.api.lua.LuaFunction;
 
+import net.createmod.catnip.platform.CatnipServices;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.ItemStack;
 
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
+import java.util.Map;
 
 public class RedstoneRequesterPeripheral  extends SyncedPeripheral<RedstoneRequesterBlockEntity> {
 
@@ -23,9 +31,31 @@ public class RedstoneRequesterPeripheral  extends SyncedPeripheral<RedstoneReque
 
 	@LuaFunction(mainThread = true)
 	public final void orderPackage(IArguments arguments) throws LuaException {
-		List<BigItemStack> items = new java.util.ArrayList<>(List.of());
+		List<BigItemStack> items = new java.util.ArrayList<>();
 
-		items.add(new BigItemStack(new ItemStack(BuiltInRegistries.ITEM.get(ResourceLocation.parse(arguments.getString(1)))), arguments.getInt(2)));
+		Object obj = arguments.get(1);
+		if (obj instanceof String itemName) {
+			Object sizeOrNull = arguments.get(2);
+			int size = 1;
+			if (sizeOrNull instanceof Number theSize) size = theSize.intValue();
+			items.add(new BigItemStack(new ItemStack(BuiltInRegistries.ITEM.get(ResourceLocation.parse(itemName))), size));
+		} else {
+			Map<String, Double> itemsMap = (Map<String, Double>) obj;
+			for (var itemEntry : itemsMap.entrySet()) {
+				items.add(new BigItemStack(new ItemStack(BuiltInRegistries.ITEM.get(ResourceLocation.parse(itemEntry.getKey()))), itemEntry.getValue().intValue()));
+			}
+		}
+
+		InventorySummary summary = this.blockEntity.getAccurateSummary();
+		for (BigItemStack entry : items) {
+			if (summary.getCountOf(entry.stack) >= entry.count) {
+				continue;
+			}
+			if (!this.blockEntity.allowPartialRequests && this.blockEntity.getLevel() instanceof ServerLevel) {
+				throw new LuaException("Request Failed (Are you out of stock?)");
+			}
+		}
+
 		this.blockEntity.computerRequest(items, arguments.getString(0));
 	}
 

--- a/src/main/java/com/simibubi/create/content/logistics/packager/PackagerBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/packager/PackagerBlockEntity.java
@@ -10,6 +10,9 @@ import com.simibubi.create.AllBlockEntityTypes;
 import com.simibubi.create.AllBlocks;
 import com.simibubi.create.AllSoundEvents;
 import com.simibubi.create.Create;
+import com.simibubi.create.compat.Mods;
+import com.simibubi.create.compat.computercraft.AbstractComputerBehaviour;
+import com.simibubi.create.compat.computercraft.ComputerCraftProxy;
 import com.simibubi.create.content.contraptions.actors.psi.PortableStorageInterfaceBlockEntity;
 import com.simibubi.create.content.kinetics.crafter.MechanicalCrafterBlockEntity;
 import com.simibubi.create.content.logistics.BigItemStack;
@@ -35,6 +38,7 @@ import com.simibubi.create.foundation.blockEntity.behaviour.inventory.InvManipul
 import com.simibubi.create.foundation.blockEntity.behaviour.inventory.VersionedInventoryTrackerBehaviour;
 import com.simibubi.create.foundation.item.ItemHelper;
 
+import dan200.computercraft.api.peripheral.PeripheralCapability;
 import net.createmod.catnip.codecs.CatnipCodecUtils;
 import net.createmod.catnip.data.Iterate;
 import net.createmod.catnip.nbt.NBTHelper;
@@ -84,6 +88,8 @@ public class PackagerBlockEntity extends SmartBlockEntity {
 
 	private AdvancementBehaviour advancements;
 
+	public AbstractComputerBehaviour computerBehaviour;
+
 	//
 
 	public PackagerBlockEntity(BlockEntityType<?> typeIn, BlockPos pos, BlockState state) {
@@ -106,6 +112,14 @@ public class PackagerBlockEntity extends SmartBlockEntity {
 			AllBlockEntityTypes.PACKAGER.get(),
 			(be, context) -> be.inventory
 		);
+
+		if (Mods.COMPUTERCRAFT.isLoaded()) {
+			event.registerBlockEntity(
+				PeripheralCapability.get(),
+				AllBlockEntityTypes.PACKAGER.get(),
+				(be, context) -> be.computerBehaviour.getPeripheralCapability()
+			);
+		}
 	}
 
 	@Override
@@ -114,6 +128,7 @@ public class PackagerBlockEntity extends SmartBlockEntity {
 			.withFilter(this::supportsBlockEntity));
 		behaviours.add(invVersionTracker = new VersionedInventoryTrackerBehaviour(this));
 		behaviours.add(advancements = new AdvancementBehaviour(this, AllAdvancements.PACKAGER));
+		behaviours.add(computerBehaviour = ComputerCraftProxy.behaviour(this));
 	}
 
 	private boolean supportsBlockEntity(BlockEntity target) {
@@ -327,6 +342,15 @@ public class PackagerBlockEntity extends SmartBlockEntity {
 
 		// dont send multiple packages when a button signal length is received
 		buttonCooldown = 40;
+	}
+
+	public void computerPacking(String string) {
+		if (string.isEmpty()) {
+			updateSignAddress();
+		} else {
+		signBasedAddress = string;
+		}
+		attemptToSend(null);
 	}
 
 	public boolean unwrapBox(ItemStack box, boolean simulate) {
@@ -680,4 +704,9 @@ public class PackagerBlockEntity extends SmartBlockEntity {
 		return false;
 	}
 
+	@Override
+	public void invalidate() {
+		super.invalidate();
+		computerBehaviour.removePeripheral();
+	}
 }

--- a/src/main/java/com/simibubi/create/content/logistics/redstoneRequester/RedstoneRequesterBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/redstoneRequester/RedstoneRequesterBlockEntity.java
@@ -1,6 +1,10 @@
 package com.simibubi.create.content.logistics.redstoneRequester;
 
+import com.simibubi.create.AllBlockEntityTypes;
 import com.simibubi.create.AllSoundEvents;
+import com.simibubi.create.compat.Mods;
+import com.simibubi.create.compat.computercraft.AbstractComputerBehaviour;
+import com.simibubi.create.compat.computercraft.ComputerCraftProxy;
 import com.simibubi.create.content.logistics.BigItemStack;
 import com.simibubi.create.content.logistics.packager.InventorySummary;
 import com.simibubi.create.content.logistics.packagerLink.LogisticallyLinkedBehaviour.RequestType;
@@ -8,6 +12,9 @@ import com.simibubi.create.content.logistics.packagerLink.WiFiParticle;
 import com.simibubi.create.content.logistics.stockTicker.PackageOrder;
 import com.simibubi.create.content.logistics.stockTicker.StockCheckingBlockEntity;
 
+import com.simibubi.create.foundation.blockEntity.behaviour.BlockEntityBehaviour;
+
+import dan200.computercraft.api.peripheral.PeripheralCapability;
 import net.createmod.catnip.codecs.CatnipCodecUtils;
 import net.createmod.catnip.platform.CatnipServices;
 import net.minecraft.core.BlockPos;
@@ -25,7 +32,10 @@ import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
 
+import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
 import net.neoforged.neoforge.common.util.FakePlayer;
+
+import java.util.List;
 
 public class RedstoneRequesterBlockEntity extends StockCheckingBlockEntity implements MenuProvider {
 
@@ -38,9 +48,27 @@ public class RedstoneRequesterBlockEntity extends StockCheckingBlockEntity imple
 
 	protected boolean redstonePowered;
 
+	public AbstractComputerBehaviour computerBehaviour;
+
 	public RedstoneRequesterBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
 		super(type, pos, state);
 		allowPartialRequests = false;
+	}
+
+	@Override
+	public void addBehaviours(List<BlockEntityBehaviour> behaviours) {
+		super.addBehaviours(behaviours);
+		behaviours.add(computerBehaviour = ComputerCraftProxy.behaviour(this));
+	}
+
+	public static void registerCapabilities(RegisterCapabilitiesEvent event) {
+		if (Mods.COMPUTERCRAFT.isLoaded()) {
+			event.registerBlockEntity(
+				PeripheralCapability.get(),
+				AllBlockEntityTypes.REDSTONE_REQUESTER.get(),
+				(be, context) -> be.computerBehaviour.getPeripheralCapability()
+			);
+		}
 	}
 
 	protected void onRedstonePowerChanged() {
@@ -83,6 +111,10 @@ public class RedstoneRequesterBlockEntity extends StockCheckingBlockEntity imple
 		if (level instanceof ServerLevel serverLevel)
 			CatnipServices.NETWORK.sendToClientsAround(serverLevel, worldPosition, 32, new RedstoneRequesterEffectPacket(worldPosition, anySucceeded));
 		lastRequestSucceeded = true;
+	}
+
+	public boolean computerRequest(List<BigItemStack> itemStacks, String targetAddress) {
+		return broadcastPackageRequest(RequestType.REDSTONE, new PackageOrder(itemStacks), null, targetAddress, encodedRequestContext.isEmpty() ? null : encodedRequestContext);
 	}
 
 	@Override
@@ -150,6 +182,12 @@ public class RedstoneRequesterBlockEntity extends StockCheckingBlockEntity imple
 			AllSoundEvents.DENY.playAt(level, worldPosition, 0.5f, 1, false);
 			level.addParticle(ParticleTypes.ENCHANTED_HIT, vec3.x, vec3.y + 1, vec3.z, 0, 0, 0);
 		}
+	}
+
+	@Override
+	public void invalidate() {
+		super.invalidate();
+		computerBehaviour.removePeripheral();
 	}
 
 }

--- a/src/main/java/com/simibubi/create/foundation/events/CommonEvents.java
+++ b/src/main/java/com/simibubi/create/foundation/events/CommonEvents.java
@@ -41,6 +41,7 @@ import com.simibubi.create.content.logistics.packagePort.frogport.FrogportBlockE
 import com.simibubi.create.content.logistics.packagePort.postbox.PostboxBlockEntity;
 import com.simibubi.create.content.logistics.packager.PackagerBlockEntity;
 import com.simibubi.create.content.logistics.packager.repackager.RepackagerBlockEntity;
+import com.simibubi.create.content.logistics.redstoneRequester.RedstoneRequesterBlockEntity;
 import com.simibubi.create.content.logistics.stockTicker.StockTickerBlockEntity;
 import com.simibubi.create.content.logistics.tunnel.BeltTunnelBlockEntity;
 import com.simibubi.create.content.logistics.tunnel.BrassTunnelBlockEntity;
@@ -289,6 +290,7 @@ public class CommonEvents {
 			DisplayLinkBlockEntity.registerCapabilities(event);
 			StockTickerBlockEntity.registerCapabilities(event);
 			PackagerBlockEntity.registerCapabilities(event);
+			RedstoneRequesterBlockEntity.registerCapabilities(event);
 			RepackagerBlockEntity.registerCapabilities(event);
 			PostboxBlockEntity.registerCapabilities(event);
 			FrogportBlockEntity.registerCapabilities(event);


### PR DESCRIPTION
Changed how #7558 handled the redstone requester

Redstone requester peripheral can now take in tables aswell for bulk orders, it also will throw if the network does not have the items needed