### PR TITLE
Better package ordering

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/packagePort/PackagePortScreen.java
+++ b/src/main/java/com/simibubi/create/content/logistics/packagePort/PackagePortScreen.java
@@ -14,6 +14,7 @@ import com.simibubi.create.foundation.gui.AllIcons;
 import com.simibubi.create.foundation.gui.menu.AbstractSimiContainerScreen;
 import com.simibubi.create.foundation.gui.widget.IconButton;
 import com.simibubi.create.foundation.utility.CreateLang;
+import com.simibubi.create.infrastructure.config.AllConfigs;
 
 import net.createmod.catnip.gui.element.GuiGameElement;
 import net.createmod.catnip.gui.widget.AbstractSimiWidget;
@@ -121,6 +122,9 @@ public class PackagePortScreen extends AbstractSimiContainerScreen<PackagePortMe
 
 		String text = addressBox.getValue();
 		if (!addressBox.isFocused()) {
+			if (addressBox.getValue().contains("@s") && AllConfigs.server().logistics.allowSelfAddress.get()) {
+				addressBox.setValue(addressBox.getValue().replace("@s", this.getMenu().player.getName().getString()));
+			}
 			if (addressBox.getValue()
 				.isEmpty()) {
 				text = icon.getHoverName()
@@ -177,6 +181,9 @@ public class PackagePortScreen extends AbstractSimiContainerScreen<PackagePortMe
 
 	@Override
 	public void removed() {
+		addressBox.setValue(addressBox.getValue().replace(
+			"@s", AllConfigs.server().logistics.allowSelfAddress.get() ? this.getMenu().player.getName().getString() : "@s"
+		));
 		AllPackets.getChannel()
 			.sendToServer(new PackagePortConfigurationPacket(menu.contentHolder.getBlockPos(), addressBox.getValue(),
 				acceptPackages.green));

--- a/src/main/java/com/simibubi/create/content/logistics/stockTicker/PackageOrderRequestPacket.java
+++ b/src/main/java/com/simibubi/create/content/logistics/stockTicker/PackageOrderRequestPacket.java
@@ -1,11 +1,13 @@
 package com.simibubi.create.content.logistics.stockTicker;
 
+import com.simibubi.create.AllBlocks;
 import com.simibubi.create.AllSoundEvents;
 import com.simibubi.create.content.logistics.packagerLink.LogisticallyLinkedBehaviour.RequestType;
 import com.simibubi.create.content.logistics.packagerLink.WiFiEffectPacket;
 import com.simibubi.create.content.logistics.redstoneRequester.RedstoneRequesterBlock;
 import com.simibubi.create.foundation.advancement.AllAdvancements;
 import com.simibubi.create.foundation.networking.BlockEntityConfigurationPacket;
+import com.simibubi.create.infrastructure.config.AllConfigs;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
@@ -52,7 +54,10 @@ public class PackageOrderRequestPacket extends BlockEntityConfigurationPacket<St
 			if (!order.isEmpty())
 				AllSoundEvents.CONFIRM.playOnServer(be.getLevel(), pos);
 			player.closeContainer();
-			RedstoneRequesterBlock.programRequester(player, be, order, address);
+			boolean shouldReplace = AllBlocks.REDSTONE_REQUESTER.isIn(player.getMainHandItem()) && AllConfigs.server().logistics.allowSelfAddress.get();
+			RedstoneRequesterBlock.programRequester(player, be, order,
+				address.replace("@s", shouldReplace ? player.getName().getString() : "@s")
+			);
 			return;
 		}
 
@@ -62,7 +67,10 @@ public class PackageOrderRequestPacket extends BlockEntityConfigurationPacket<St
 			WiFiEffectPacket.send(player.level(), pos);
 		}
 
-		be.broadcastPackageRequest(RequestType.PLAYER, order, null, address);
+		be.broadcastPackageRequest(RequestType.PLAYER, order, null,
+			address.replace("@s", AllConfigs.server().logistics.allowSelfAddress.get() ? player.getName().getString() : "@s")
+		);
+		be.previouslyUsedAddress = address;
 		return;
 	}
 

--- a/src/main/java/com/simibubi/create/content/logistics/stockTicker/StockTickerInteractionHandler.java
+++ b/src/main/java/com/simibubi/create/content/logistics/stockTicker/StockTickerInteractionHandler.java
@@ -15,6 +15,8 @@ import com.simibubi.create.content.logistics.tableCloth.ShoppingListItem;
 import com.simibubi.create.content.logistics.tableCloth.ShoppingListItem.ShoppingList;
 import com.simibubi.create.foundation.utility.CreateLang;
 
+import com.simibubi.create.infrastructure.config.AllConfigs;
+
 import net.minecraftforge.event.entity.player.PlayerInteractEvent.EntityInteractSpecific;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
@@ -191,7 +193,8 @@ public class StockTickerInteractionHandler {
 			toTransfer.forEach(s -> ItemHandlerHelper.insertItemStacked(tickerBE.receivedPayments, s, false));
 		}
 
-		tickerBE.broadcastPackageRequest(RequestType.PLAYER, order, null, ShoppingListItem.getAddress(mainHandItem));
+		tickerBE.broadcastPackageRequest(RequestType.PLAYER, order, null, ShoppingListItem.getAddress(mainHandItem)
+			.replace("@s", AllConfigs.server().logistics.allowSelfAddress.get() ? player.getName().getString() : "@s"));
 		player.setItemInHand(InteractionHand.MAIN_HAND, ItemStack.EMPTY);
 		if (!order.isEmpty())
 			AllSoundEvents.STOCK_TICKER_TRADE.playOnServer(level, tickerBE.getBlockPos());

--- a/src/main/java/com/simibubi/create/infrastructure/config/CLogistics.java
+++ b/src/main/java/com/simibubi/create/infrastructure/config/CLogistics.java
@@ -9,6 +9,7 @@ public class CLogistics extends ConfigBase {
 	public final ConfigInt psiTimeout = i(60, 1, "psiTimeout", Comments.psiTimeout);
 	public final ConfigInt mechanicalArmRange = i(5, 1, "mechanicalArmRange", Comments.mechanicalArmRange);
 	public final ConfigInt packagePortRange = i(5, 1, "packagePortRange", Comments.packagePortRange);
+	public final ConfigBool allowSelfAddress = b(true, "allowSelfAddress", Comments.allowSelfAddress);
 	public final ConfigInt linkRange = i(256, 1, "linkRange", Comments.linkRange);
 	public final ConfigInt displayLinkRange = i(64, 1, "displayLinkRange", Comments.displayLinkRange);
 	public final ConfigInt vaultCapacity = i(20, 1, 2048, "vaultCapacity", Comments.vaultCapacity);
@@ -32,6 +33,7 @@ public class CLogistics extends ConfigBase {
 			"The amount of ticks a portable storage interface waits for transfers until letting contraptions move along.";
 		static String mechanicalArmRange = "Maximum distance in blocks a Mechanical Arm can reach across.";
 		static String packagePortRange = "Maximum distance in blocks a Package Port can be placed at from its target.";
+		static String allowSelfAddress = "Whether '@s' should be substituted for the player's name when ordering a package at a shopkeeper";
 		static String vaultCapacity = "The total amount of stacks a vault can hold per block in size.";
 		static String chainConveyorCapacity = "The amount of packages a chain conveyor can carry at a time.";
 		static String brassTunnelTimer = "The amount of ticks a brass tunnel waits between distributions.";


### PR DESCRIPTION
- Added a key (@s) to package addresses which will be substituted for the ordering player's name.
- Added a config specifying if the key should be substituted. (default is true)
- Allow @s to be used in Package Port addresses

This allows for shops to send packages directly to peoples homes instead of a front desk. Just set the address to @s (or something containing it, depending on the way you decide to specify your home address) when configuring a table cloth. When ordering at the cloth, the key will be substituted by the name of the player that hands the shopping list to the shopkeeper. You can also use @s when configuring a redstone requester to make it use the name of the player that's configuring it.