### PR TITLE
Feat: Stock ticker input additions

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/stockTicker/StockKeeperRequestScreen.java
+++ b/src/main/java/com/simibubi/create/content/logistics/stockTicker/StockKeeperRequestScreen.java
@@ -500,7 +500,7 @@ public class StockKeeperRequestScreen extends AbstractSimiContainerScreen<StockK
 				.style(ChatFormatting.ITALIC)
 				.component(), addressBox.getX(), addressBox.getY(), 0xff_CDBCA8, false);
 		}
-		
+
 		// Render keeper
 		int entitySizeOffset = 0;
 		LivingEntity keeper = stockKeeper.get();
@@ -1032,11 +1032,11 @@ public class StockKeeperRequestScreen extends AbstractSimiContainerScreen<StockK
 
 	@Override
 	public boolean mouseClicked(double pMouseX, double pMouseY, int pButton) {
-		boolean lmb = pButton == GLFW.GLFW_MOUSE_BUTTON_LEFT;
-		boolean rmb = pButton == GLFW.GLFW_MOUSE_BUTTON_RIGHT;
+		boolean lmbClicked = pButton == GLFW.GLFW_MOUSE_BUTTON_LEFT;
+		boolean rmbClicked = pButton == GLFW.GLFW_MOUSE_BUTTON_RIGHT;
 
 		// Search
-		if (rmb && searchBox.isMouseOver(pMouseX, pMouseY)) {
+		if (rmbClicked && searchBox.isMouseOver(pMouseX, pMouseY)) {
 			searchBox.setValue("");
 			refreshSearchNextTick = true;
 			moveToTopNextTick = true;
@@ -1058,7 +1058,7 @@ public class StockKeeperRequestScreen extends AbstractSimiContainerScreen<StockK
 
 		// Scroll bar
 		int barX = itemsX + cols * colWidth - 1;
-		if (getMaxScroll() > 0 && lmb && pMouseX > barX && pMouseX <= barX + 8 && pMouseY > getGuiTop() + 15
+		if (getMaxScroll() > 0 && lmbClicked && pMouseX > barX && pMouseX <= barX + 8 && pMouseY > getGuiTop() + 15
 			&& pMouseY < getGuiTop() + windowHeight - 82) {
 			scrollHandleActive = true;
 			if (minecraft.isWindowActive())
@@ -1070,7 +1070,7 @@ public class StockKeeperRequestScreen extends AbstractSimiContainerScreen<StockK
 		Couple<Integer> hoveredSlot = getHoveredSlot((int) pMouseX, (int) pMouseY);
 
 		// Lock
-		if (isAdmin && itemScroll.getChaseTarget() == 0 && lmb && pMouseX > lockX && pMouseX <= lockX + 15
+		if (isAdmin && itemScroll.getChaseTarget() == 0 && lmbClicked && pMouseX > lockX && pMouseX <= lockX + 15
 			&& pMouseY > lockY && pMouseY <= lockY + 15) {
 			isLocked = !isLocked;
 			AllPackets.getChannel()
@@ -1080,7 +1080,7 @@ public class StockKeeperRequestScreen extends AbstractSimiContainerScreen<StockK
 		}
 
 		// Confirm
-		if (lmb && isConfirmHovered((int) pMouseX, (int) pMouseY)) {
+		if (lmbClicked && isConfirmHovered((int) pMouseX, (int) pMouseY)) {
 			sendIt();
 			playUiSound(SoundEvents.UI_BUTTON_CLICK.value(), 1, 1);
 			return true;
@@ -1088,7 +1088,7 @@ public class StockKeeperRequestScreen extends AbstractSimiContainerScreen<StockK
 
 		// Category hiding
 		int localY = (int) (pMouseY - itemsY);
-		if (itemScroll.settled() && lmb && !categories.isEmpty() && pMouseX >= itemsX
+		if (itemScroll.settled() && lmbClicked && !categories.isEmpty() && pMouseX >= itemsX
 			&& pMouseX < itemsX + cols * colWidth && pMouseY >= getGuiTop() + 16
 			&& pMouseY <= getGuiTop() + windowHeight - 80) {
 			for (int categoryIndex = 0; categoryIndex < displayedItems.size(); categoryIndex++) {
@@ -1118,7 +1118,7 @@ public class StockKeeperRequestScreen extends AbstractSimiContainerScreen<StockK
 			}
 		}
 
-		if (hoveredSlot == noneHovered || !lmb && !rmb)
+		if (hoveredSlot == noneHovered || !lmbClicked && !rmbClicked)
 			return super.mouseClicked(pMouseX, pMouseY, pButton);
 
 		// Items
@@ -1133,17 +1133,17 @@ public class StockKeeperRequestScreen extends AbstractSimiContainerScreen<StockK
 		int transfer = hasShiftDown() ? itemStack.getMaxStackSize() : hasControlDown() ? 10 : 1;
 
 		if (recipeClicked && entry instanceof CraftableBigItemStack cbis) {
-			if (rmb && cbis.count == 0) {
+			if (rmbClicked && cbis.count == 0) {
 				recipesToOrder.remove(cbis);
 				return true;
 			}
-			requestCraftable(cbis, rmb ? -transfer : transfer);
+			requestCraftable(cbis, rmbClicked ? -transfer : transfer);
 			return true;
 		}
 
 		BigItemStack existingOrder = getOrderForItem(entry.stack);
 		if (existingOrder == null) {
-			if (itemsToOrder.size() >= cols || rmb)
+			if (itemsToOrder.size() >= cols || rmbClicked)
 				return true;
 			itemsToOrder.add(existingOrder = new BigItemStack(itemStack.copyWithCount(1), 0));
 			playUiSound(SoundEvents.WOOL_STEP, 0.75f, 1.2f);
@@ -1152,7 +1152,7 @@ public class StockKeeperRequestScreen extends AbstractSimiContainerScreen<StockK
 
 		int current = existingOrder.count;
 
-		if (rmb || orderClicked) {
+		if (rmbClicked || orderClicked) {
 			existingOrder.count = current - transfer;
 			if (existingOrder.count <= 0) {
 				itemsToOrder.remove(existingOrder);
@@ -1614,5 +1614,5 @@ public class StockKeeperRequestScreen extends AbstractSimiContainerScreen<StockK
 		if (Mods.JEI.isLoaded() && AllConfigs.client().syncJeiSearch.get())
 			CreateJEI.runtime.getIngredientFilter().setFilterText(searchBox.getValue());
 	}
-	
+
 }

--- a/src/main/java/com/simibubi/create/content/logistics/stockTicker/StockKeeperRequestScreen.java
+++ b/src/main/java/com/simibubi/create/content/logistics/stockTicker/StockKeeperRequestScreen.java
@@ -1126,8 +1126,7 @@ public class StockKeeperRequestScreen extends AbstractSimiContainerScreen<StockK
 		boolean recipeClicked = hoveredSlot.getFirst() == -2;
 		BigItemStack entry = recipeClicked ? recipesToOrder.get(hoveredSlot.getSecond())
 			: orderClicked ? itemsToOrder.get(hoveredSlot.getSecond())
-			: displayedItems.get(hoveredSlot.getFirst())
-			.get(hoveredSlot.getSecond());
+			: displayedItems.get(hoveredSlot.getFirst()).get(hoveredSlot.getSecond());
 
 		ItemStack itemStack = entry.stack;
 		int transfer = hasShiftDown() ? itemStack.getMaxStackSize() : hasControlDown() ? 10 : 1;
@@ -1153,6 +1152,9 @@ public class StockKeeperRequestScreen extends AbstractSimiContainerScreen<StockK
 		int current = existingOrder.count;
 
 		if (rmbClicked || orderClicked) {
+			if (rmbClicked) {
+				transfer = existingOrder.count == 1 ? 1 : existingOrder.count / 2;
+			}
 			existingOrder.count = current - transfer;
 			if (existingOrder.count <= 0) {
 				itemsToOrder.remove(existingOrder);
@@ -1197,10 +1199,10 @@ public class StockKeeperRequestScreen extends AbstractSimiContainerScreen<StockK
 		boolean recipeClicked = hoveredSlot.getFirst() == -2;
 		BigItemStack entry = recipeClicked ? recipesToOrder.get(hoveredSlot.getSecond())
 			: orderClicked ? itemsToOrder.get(hoveredSlot.getSecond())
-			: displayedItems.get(hoveredSlot.getFirst())
-			.get(hoveredSlot.getSecond());
+			: displayedItems.get(hoveredSlot.getFirst()).get(hoveredSlot.getSecond());
 
 		boolean remove = delta < 0;
+		int stackSnapping = entry.stack.getMaxStackSize() / 4;
 		int transfer = Mth.ceil(Math.abs(delta)) * (hasControlDown() ? 10 : 1);
 
 		if (recipeClicked && entry instanceof CraftableBigItemStack cbis) {
@@ -1212,12 +1214,16 @@ public class StockKeeperRequestScreen extends AbstractSimiContainerScreen<StockK
 		if (existingOrder == null) {
 			if (itemsToOrder.size() >= cols || remove)
 				return true;
-			itemsToOrder.add(existingOrder = new BigItemStack(entry.stack.copyWithCount(1), 0));
+			itemsToOrder.add(existingOrder = new BigItemStack(entry.stack.copyWithCount(hasShiftDown() ? stackSnapping : 1), 0));
 			playUiSound(SoundEvents.WOOL_STEP, 0.75f, 1.2f);
 			playUiSound(SoundEvents.BAMBOO_WOOD_STEP, 0.75f, 0.8f);
 		}
 
 		int current = existingOrder.count;
+
+		if (hasShiftDown()) {
+			transfer = (remove ? -1 : 1) * (((Math.floorDiv(current, stackSnapping) + (remove ? -1 : 1)) * stackSnapping) - current);
+		}
 
 		if (remove) {
 			existingOrder.count = current - transfer;

--- a/src/main/java/com/simibubi/create/content/logistics/stockTicker/StockKeeperRequestScreen.java
+++ b/src/main/java/com/simibubi/create/content/logistics/stockTicker/StockKeeperRequestScreen.java
@@ -246,6 +246,7 @@ public class StockKeeperRequestScreen extends AbstractSimiContainerScreen<StockK
 		searchBox.setMaxLength(50);
 		searchBox.setBordered(false);
 		searchBox.setTextColor(0x4A2D31);
+		searchBox.setFocused(true);
 		addWidget(searchBox);
 
 		boolean initial = addressBox == null;

--- a/src/main/java/com/simibubi/create/content/logistics/stockTicker/StockKeeperRequestScreen.java
+++ b/src/main/java/com/simibubi/create/content/logistics/stockTicker/StockKeeperRequestScreen.java
@@ -1222,7 +1222,9 @@ public class StockKeeperRequestScreen extends AbstractSimiContainerScreen<StockK
 		int current = existingOrder.count;
 
 		if (hasShiftDown()) {
-			transfer = (remove ? -1 : 1) * (((Math.floorDiv(current, stackSnapping) + (remove ? -1 : 1)) * stackSnapping) - current);
+			int target = ((Math.floorDiv(current, stackSnapping) + (remove ? -1 : 1)) * stackSnapping);
+			target = Math.max(1, target);
+			transfer = (remove ? -1 : 1) * (target - current);
 		}
 
 		if (remove) {


### PR DESCRIPTION
Love the stock ticker, but I thought that the input could be improved in these ways (without taking away any existing functionality):

 - ### Search bar doesn't automatically select
Felt like there wasn't much of a reason for this since no keyboard input is required elsewhere, the creative menu is the same way too so its nothing new for compat

 - ### Right click and left click on the requested stack had the same effect
Right click now removes half the stack, very useful to quickly narrow down like 8 of an item
Similar effect to shift scroll but since the player isn't really told the exact controls, its better to give options to explore, and more mechanically precise

 - ### Scroll is very useful, but requires lots of movement and isn't very precise
Shift + scroll now snaps the item to the nearest 1/4 stack, so its much quicker to scale

(sorry for the wrong branch earlier, i confused myself with the two /dev branches, tested everything and it still works)