### PR TITLE
Update BogeyBlockEntityVisual.java | Fixed bogey lighting not updatin…

### DIFF
--- a/src/main/java/com/simibubi/create/content/trains/bogey/BogeyBlockEntityVisual.java
+++ b/src/main/java/com/simibubi/create/content/trains/bogey/BogeyBlockEntityVisual.java
@@ -63,9 +63,8 @@ public class BogeyBlockEntityVisual extends AbstractBlockEntityVisual<AbstractBo
 			}
 			lastStyle = style;
 			bogey = lastStyle.createVisual(bogeySize, visualizationContext, context.partialTick(), false);
+			updateLight(context.partialTick());
 		}
-
-		updateLight(context.partialTick());
 		
 		updateBogey(context.partialTick());
 	}

--- a/src/main/java/com/simibubi/create/content/trains/bogey/BogeyBlockEntityVisual.java
+++ b/src/main/java/com/simibubi/create/content/trains/bogey/BogeyBlockEntityVisual.java
@@ -65,6 +65,8 @@ public class BogeyBlockEntityVisual extends AbstractBlockEntityVisual<AbstractBo
 			bogey = lastStyle.createVisual(bogeySize, visualizationContext, context.partialTick(), false);
 		}
 
+		updateLight(context.partialTick());
+		
 		updateBogey(context.partialTick());
 	}
 


### PR DESCRIPTION
…g correctly while style switching

Found the issue while adding custom bogeys. The bogeys wouldn't update their lighting while switching styles, occurred with the standard bogeys also. Probably was overlooked because Create only has one bogey style. Thanks to Roselle for solving this issue.