### PR TITLE
Increase elevator pulley view distance to 512

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/elevator/ElevatorPulleyRenderer.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/elevator/ElevatorPulleyRenderer.java
@@ -105,7 +105,7 @@ public class ElevatorPulleyRenderer extends KineticBlockEntityRenderer<ElevatorP
 
 	@Override
 	public int getViewDistance() {
-		return 128;
+		return 512;
 	}
 
 	@Override


### PR DESCRIPTION
This change ensures that elevator pulley cables are still visible even if the elevator contraption drops below 128 blocks from the elevator pulley block.


Please tell me if this won't have the effect I'm expecting it to have.

Feedback is greatly appreciated!