### PR TITLE
Add config for diving helmet scaling render distance

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/events/ClientEvents.java
+++ b/src/main/java/com/simibubi/create/foundation/events/ClientEvents.java
@@ -322,17 +322,14 @@ public class ClientEvents {
 
 		ItemStack divingHelmet = DivingHelmetItem.getWornItem(entity);
 		if (!divingHelmet.isEmpty()) {
-			if (FluidHelper.isWater(fluid)) {
+			if (FluidHelper.isWater(fluid) && AllConfigs.server().equipment.shouldScaleWaterFogDistance.get()) {
 				event.scaleFarPlaneDistance(6.25f);
-				event.setCanceled(true);
-				return;
 			} else if (FluidHelper.isLava(fluid) && NetheriteDivingHandler.isNetheriteDivingHelmet(divingHelmet)) {
 				event.setNearPlaneDistance(-4.0f);
 				event.setFarPlaneDistance(20.0f);
-				event.setCanceled(true);
-				return;
 			}
 		}
+		event.setCanceled(true);
 	}
 
 	@SubscribeEvent

--- a/src/main/java/com/simibubi/create/infrastructure/config/CEquipment.java
+++ b/src/main/java/com/simibubi/create/infrastructure/config/CEquipment.java
@@ -4,7 +4,6 @@ package com.simibubi.create.infrastructure.config;
 import net.createmod.catnip.config.ConfigBase;
 
 public class CEquipment extends ConfigBase {
-
 	public final ConfigInt maxSymmetryWandRange = i(50, 10, "maxSymmetryWandRange", Comments.symmetryRange);
 	public final ConfigInt placementAssistRange = i(12, 3, "placementAssistRange", Comments.placementRange);
 	public final ConfigInt toolboxRange = i(10, 1, "toolboxRange", Comments.toolboxRange);
@@ -13,6 +12,7 @@ public class CEquipment extends ConfigBase {
 
 	public final ConfigInt maxExtendoGripActions = i(1000, 0, "maxExtendoGripActions", Comments.maxExtendoGripActions);
 	public final ConfigInt maxPotatoCannonShots = i(200, 0, "maxPotatoCannonShots", Comments.maxPotatoCannonShots);
+	public final ConfigBool shouldScaleWaterFogDistance = b(true, "shouldScaleWaterFogDistance", Comments.shouldScaleWaterFogDistance);
 
 //	public ConfigInt zapperUndoLogLength = i(10, 0, "zapperUndoLogLength", Comments.zapperUndoLogLength); NYI
 
@@ -35,6 +35,8 @@ public class CEquipment extends ConfigBase {
 			"Amount of free Extendo Grip actions provided by one filled Copper Backtank. Set to 0 makes Extendo Grips unbreakable";
 		static String maxPotatoCannonShots =
 			"Amount of free Potato Cannon shots provided by one filled Copper Backtank. Set to 0 makes Potato Cannons unbreakable";
+		static String shouldScaleWaterFogDistance =
+			"Scale the range of visibility of the diving helmet underwater";
 //		static String zapperUndoLogLength = "The maximum amount of operations a blockzapper can remember for undoing. (0 to disable undo)";
 	}
 

--- a/src/main/java/com/simibubi/create/infrastructure/config/CEquipment.java
+++ b/src/main/java/com/simibubi/create/infrastructure/config/CEquipment.java
@@ -36,7 +36,7 @@ public class CEquipment extends ConfigBase {
 		static String maxPotatoCannonShots =
 			"Amount of free Potato Cannon shots provided by one filled Copper Backtank. Set to 0 makes Potato Cannons unbreakable";
 		static String shouldScaleWaterFogDistance =
-			"Scale the range of visibility of the diving helmet underwater";
+			"Scale the underwater visibility range of the diving helmet";
 //		static String zapperUndoLogLength = "The maximum amount of operations a blockzapper can remember for undoing. (0 to disable undo)";
 	}
 


### PR DESCRIPTION
Add a configuration for disabling diving helmet fog rendering scale. It can be useful for Alex's Caves' abyssal chasm biome, where the main feature is a very low render distance.

Before:

![2025-03-12_10 48 10](https://github.com/user-attachments/assets/77363ddb-87ce-4b87-b008-fa6d7199e36f)


After:

![2025-03-12_10 48 35](https://github.com/user-attachments/assets/4a4ad589-98c7-4d02-af24-b8b1f68aa681)