### PR TITLE
Fix #7419: Chain conveyor animation does not respect player's main hand

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/render/PlayerSkyhookRenderer.java
+++ b/src/main/java/com/simibubi/create/foundation/render/PlayerSkyhookRenderer.java
@@ -9,7 +9,9 @@ import net.createmod.catnip.animation.AnimationTickHolder;
 import net.createmod.catnip.math.AngleHelper;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.HumanoidModel;
+import net.minecraft.client.model.geom.ModelPart;
 import net.minecraft.util.Mth;
+import net.minecraft.world.entity.HumanoidArm;
 import net.minecraft.world.entity.player.Player;
 
 public class PlayerSkyhookRenderer {
@@ -36,10 +38,10 @@ public class PlayerSkyhookRenderer {
 
 	public static void afterSetupAnim(Player player, HumanoidModel<?> model) {
 		if (hangingPlayers.contains(player.getUUID()))
-			setHangingPose(model);
+			setHangingPose(player.getMainArm() == HumanoidArm.LEFT, model);
 	}
 
-	private static void setHangingPose(HumanoidModel<?> model) {
+	private static void setHangingPose(boolean isLeftArmMain, HumanoidModel<?> model) {
 		if (Minecraft.getInstance().isPaused())
 			return;
 
@@ -56,57 +58,60 @@ public class PlayerSkyhookRenderer {
 		float limbCycle = Mth.sin(((float) (time * 0.3f / Math.PI)));
 		float bodySwing = AngleHelper.rad(15 + (mainCycle * 10));
 		float limbSwing = AngleHelper.rad(limbCycle * 15);
-
+		if (isLeftArmMain) bodySwing = -bodySwing;
 		model.body.zRot = bodySwing;
 		model.head.zRot = bodySwing;
 		model.hat.zRot = bodySwing;
 
-		model.rightArm.y -= 3;
+		ModelPart hangingArm = isLeftArmMain ? model.leftArm : model.rightArm;
+		ModelPart otherArm = isLeftArmMain ? model.rightArm : model.leftArm;
+		hangingArm.y -= 3;
 
-		float offsetX = model.rightArm.x;
-		float offsetY = model.rightArm.y;
+		float offsetX = hangingArm.x;
+		float offsetY = hangingArm.y;
 //		model.rightArm.x = offsetX * Mth.cos(bodySwing) - offsetY * Mth.sin(bodySwing);
 //		model.rightArm.y = offsetX * Mth.sin(bodySwing) + offsetY * Mth.cos(bodySwing);
-		float armPivotX = offsetX * Mth.cos(bodySwing) - offsetY * Mth.sin(bodySwing) + 4.5f;
+		float armPivotX = offsetX * Mth.cos(bodySwing) - offsetY * Mth.sin(bodySwing) + (isLeftArmMain ? -1 : 1) * 4.5f;
 		float armPivotY = offsetX * Mth.sin(bodySwing) + offsetY * Mth.cos(bodySwing) + 2;
-		model.rightArm.xRot = -AngleHelper.rad(150);
-		model.rightArm.zRot = AngleHelper.rad(15);
+		hangingArm.xRot = -AngleHelper.rad(150);
+		hangingArm.zRot = (isLeftArmMain ? -1 : 1) * AngleHelper.rad(15);
 
-		offsetX = model.leftArm.x;
-		offsetY = model.leftArm.y;
-		model.leftArm.x = offsetX * Mth.cos(bodySwing) - offsetY * Mth.sin(bodySwing);
-		model.leftArm.y = offsetX * Mth.sin(bodySwing) + offsetY * Mth.cos(bodySwing);
-		model.leftArm.zRot = -AngleHelper.rad(20) + 0.5f * bodySwing + limbSwing;
+		offsetX = otherArm.x;
+		offsetY = otherArm.y;
+		otherArm.x = offsetX * Mth.cos(bodySwing) - offsetY * Mth.sin(bodySwing);
+		otherArm.y = offsetX * Mth.sin(bodySwing) + offsetY * Mth.cos(bodySwing);
+		otherArm.zRot = (isLeftArmMain ? -1 : 1) * (-AngleHelper.rad(20)) + 0.5f * bodySwing + limbSwing;
 
-		model.rightLeg.y -= 0.2f;
-		offsetX = model.rightLeg.x;
-		offsetY = model.rightLeg.y;
-		model.rightLeg.x = offsetX * Mth.cos(bodySwing) - offsetY * Mth.sin(bodySwing);
-		model.rightLeg.y = offsetX * Mth.sin(bodySwing) + offsetY * Mth.cos(bodySwing);
-		model.rightLeg.xRot = -AngleHelper.rad(25);
-		model.rightLeg.zRot = AngleHelper.rad(10) + 0.5f * bodySwing + limbSwing;
+		ModelPart leadingLeg = isLeftArmMain ? model.leftLeg : model.rightLeg;
+		ModelPart trailingLeg = isLeftArmMain ? model.rightLeg : model.leftLeg;
 
-		model.leftLeg.y -= 0.8f;
-		offsetX = model.leftLeg.x;
-		offsetY = model.leftLeg.y;
-		model.leftLeg.x = offsetX * Mth.cos(bodySwing) - offsetY * Mth.sin(bodySwing);
-		model.leftLeg.y = offsetX * Mth.sin(bodySwing) + offsetY * Mth.cos(bodySwing);
-		model.leftLeg.xRot = AngleHelper.rad(10);
-		model.leftLeg.zRot = -AngleHelper.rad(10) + 0.5f * bodySwing + limbSwing;
-
+		leadingLeg.y -= 0.2f;
+		offsetX = leadingLeg.x;
+		offsetY = leadingLeg.y;
+		leadingLeg.x = offsetX * Mth.cos(bodySwing) - offsetY * Mth.sin(bodySwing);
+		leadingLeg.y = offsetX * Mth.sin(bodySwing) + offsetY * Mth.cos(bodySwing);
+		leadingLeg.xRot = -AngleHelper.rad(25);
+		leadingLeg.zRot = (isLeftArmMain ? -1 : 1) * (AngleHelper.rad(10)) + 0.5f * bodySwing + limbSwing;
+		trailingLeg.y -= 0.8f;
+		offsetX = trailingLeg.x;
+		offsetY = trailingLeg.y;
+		trailingLeg.x = offsetX * Mth.cos(bodySwing) - offsetY * Mth.sin(bodySwing);
+		trailingLeg.y = offsetX * Mth.sin(bodySwing) + offsetY * Mth.cos(bodySwing);
+		trailingLeg.xRot = AngleHelper.rad(10);
+		trailingLeg.zRot = (isLeftArmMain ? -1 : 1) * (-AngleHelper.rad(10)) + 0.5f * bodySwing + limbSwing;
 		model.hat.x -= armPivotX;
 		model.head.x -= armPivotX;
 		model.body.x -= armPivotX;
-		model.leftArm.x -= armPivotX;
-		model.leftLeg.x -= armPivotX;
-		model.rightLeg.x -= armPivotX;
+		otherArm.x -= armPivotX;
+		trailingLeg.x -= armPivotX;
+		leadingLeg.x -= armPivotX;
 
 		model.hat.y -= armPivotY;
 		model.head.y -= armPivotY;
 		model.body.y -= armPivotY;
-		model.leftArm.y -= armPivotY;
-		model.leftLeg.y -= armPivotY;
-		model.rightLeg.y -= armPivotY;
+		otherArm.y -= armPivotY;
+		trailingLeg.y -= armPivotY;
+		leadingLeg.y -= armPivotY;
 	}
 
 }


### PR DESCRIPTION
Description:
This pull request addresses a visual inconsistency described in Fix #7419 for left-handed players when using the wrench to hang from a chain. Previously, the wrench appeared in the left hand, but the model still showed the right arm raised, creating a mismatched perspective. This fix ensures both the wrench position and the raised arm are correct for left-handed players, maintaining visual consistency and improving the overall player experience.

Changes made:

- Updated animation handling to reflect the correct arm movement for left-handed mode.
- Adjusted positioning to sync with the raised arm.

Testing:

- Verified the animation and wrench positioning for both left-handed and right-handed modes.
- Ensured no regressions in right-handed player behavior.

Link: https://www.youtube.com/watch?v=bZErF311Sps

Notes: This fix improves immersion without affecting gameplay mechanics.