### PR TITLE
Fix JEI Deploying Category shows manual only Manual Application recipes

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/deployer/ManualApplicationRecipe.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/deployer/ManualApplicationRecipe.java
@@ -62,10 +62,10 @@ public class ManualApplicationRecipe extends ItemApplicationRecipe {
 
 		if (foundRecipe.isEmpty())
 			return;
-		
+
 		event.setCancellationResult(InteractionResult.SUCCESS);
 		event.setCanceled(true);
-		
+
 		if (level.isClientSide())
 			return;
 
@@ -117,9 +117,9 @@ public class ManualApplicationRecipe extends ItemApplicationRecipe {
 
 	public static DeployerApplicationRecipe asDeploying(Recipe<?> recipe) {
 		ManualApplicationRecipe mar = (ManualApplicationRecipe) recipe;
+		ResourceLocation id = AllRecipeTypes.CAN_BE_AUTOMATED.test(recipe) ? mar.id : mar.id.withSuffix("_using_deployer");
 		ProcessingRecipeBuilder<DeployerApplicationRecipe> builder =
-			new ProcessingRecipeBuilder<>(DeployerApplicationRecipe::new,
-				new ResourceLocation(mar.id.getNamespace(), mar.id.getPath() + "_using_deployer"))
+			new ProcessingRecipeBuilder<>(DeployerApplicationRecipe::new, id)
 					.require(mar.ingredients.get(0))
 					.require(mar.ingredients.get(1));
 		for (ProcessingOutput output : mar.results)

--- a/src/main/java/com/simibubi/create/content/kinetics/deployer/ManualApplicationRecipe.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/deployer/ManualApplicationRecipe.java
@@ -117,7 +117,7 @@ public class ManualApplicationRecipe extends ItemApplicationRecipe {
 
 	public static DeployerApplicationRecipe asDeploying(Recipe<?> recipe) {
 		ManualApplicationRecipe mar = (ManualApplicationRecipe) recipe;
-		ResourceLocation id = AllRecipeTypes.CAN_BE_AUTOMATED.test(recipe) ? mar.id : mar.id.withSuffix("_using_deployer");
+		ResourceLocation id = AllRecipeTypes.CAN_BE_AUTOMATED.test(recipe) ? mar.id.withSuffix("_using_deployer") : mar.id;
 		ProcessingRecipeBuilder<DeployerApplicationRecipe> builder =
 			new ProcessingRecipeBuilder<>(DeployerApplicationRecipe::new, id)
 					.require(mar.ingredients.get(0))


### PR DESCRIPTION
Fixes #8044 JEI Deploying Category shows manual only Manual Application recipes.
Note that implementation of `ManualApplicationRecipe#asDeploying` in 1.21.1 is also broken, it should use the id from the `RecipeHolder`, the used `ProcessingRecipe#id` and `ProcessingRecipeParams#id` is basically defunct in 1.21.1 as recipes no longer have access to its id upon deserialization (See also: #7945 Processing Recipe Rework).