### PR TITLE
Fix curved track targeting at high track max placement length

### DIFF
--- a/src/main/java/com/simibubi/create/content/trains/track/CurvedTrackDestroyPacket.java
+++ b/src/main/java/com/simibubi/create/content/trains/track/CurvedTrackDestroyPacket.java
@@ -67,7 +67,7 @@ public class CurvedTrackDestroyPacket extends BlockEntityConfigurationPacket<Tra
 		if (wrench) {
 			AllSoundEvents.WRENCH_REMOVE.playOnServer(player.level(), soundSource, 1,
 				Create.RANDOM.nextFloat() * .5f + .5f);
-			if (!player.isCreative() && bezierConnection != null) 
+			if (!player.isCreative() && bezierConnection != null)
 				bezierConnection.addItemsToPlayer(player);
 		} else if (!player.isCreative() && bezierConnection != null)
 			bezierConnection.spawnItems(level);
@@ -83,7 +83,7 @@ public class CurvedTrackDestroyPacket extends BlockEntityConfigurationPacket<Tra
 
 	@Override
 	protected int maxRange() {
-		return 64;
+		return AllConfigs.server().trains.maxTrackPlacementLength.get() + 16;
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/trains/track/CurvedTrackSelectionPacket.java
+++ b/src/main/java/com/simibubi/create/content/trains/track/CurvedTrackSelectionPacket.java
@@ -1,5 +1,7 @@
 package com.simibubi.create.content.trains.track;
 
+import com.simibubi.create.infrastructure.config.AllConfigs;
+
 import org.apache.commons.lang3.mutable.MutableObject;
 
 import com.simibubi.create.AllBlocks;
@@ -96,7 +98,7 @@ public class CurvedTrackSelectionPacket extends BlockEntityConfigurationPacket<T
 
 	@Override
 	protected int maxRange() {
-		return 64;
+		return AllConfigs.server().trains.maxTrackPlacementLength.get() + 16;
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/trains/track/TrackTargetingBlockItem.java
+++ b/src/main/java/com/simibubi/create/content/trains/track/TrackTargetingBlockItem.java
@@ -3,6 +3,8 @@ package com.simibubi.create.content.trains.track;
 import java.util.List;
 import java.util.function.BiConsumer;
 
+import com.simibubi.create.infrastructure.config.AllConfigs;
+
 import org.apache.commons.lang3.mutable.MutableObject;
 
 import com.simibubi.create.AllPackets;
@@ -118,7 +120,7 @@ public class TrackTargetingBlockItem extends BlockItem {
 
 		boolean bezier = tag.contains("Bezier");
 
-		if (!selectedPos.closerThan(placedPos, bezier ? 64 + 16 : 16)) {
+		if (!selectedPos.closerThan(placedPos, bezier ? AllConfigs.server().trains.maxTrackPlacementLength.get() + 16 : 16)) {
 			player.displayClientMessage(CreateLang.translateDirect("track_target.too_far")
 				.withStyle(ChatFormatting.RED), true);
 			return InteractionResult.FAIL;


### PR DESCRIPTION
Fixes #6965 

Simply replaced hardcoded range values to use the max track placement length config value plus 16 for a bit of breathing room. This seemed to fix the issue in my testing.

Let me know if you need/want any changes.