### PR TITLE
fix the blueprint printing command bug for the sign (1.21.1)

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/CreateNBTProcessors.java
+++ b/src/main/java/com/simibubi/create/foundation/CreateNBTProcessors.java
@@ -6,21 +6,26 @@ import com.simibubi.create.AllBlockEntityTypes;
 
 import net.createmod.catnip.nbt.NBTHelper;
 import net.createmod.catnip.nbt.NBTProcessors;
+import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
+import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 
 public class CreateNBTProcessors {
 	public static void register() {
-
+		// Remove the first layer of commands while preserving the styles.
+		// Since recursive instructions won't be executed, there's no need to handle them.
 		NBTProcessors.addProcessor(BlockEntityType.SIGN, data -> {
+			var front_text = data.getCompound("front_text").getList("messages", Tag.TAG_STRING);
+			var back_text = data.getCompound("back_text").getList("messages", Tag.TAG_STRING);
 			for (int i = 0; i < 4; ++i) {
-				if (NBTProcessors.textComponentHasClickEvent(data.getString("Text" + (i + 1))))
-					return null;
+				tryRemovingCommand(front_text, i);
+				tryRemovingCommand(back_text, i);
 			}
 			return data;
 		});
@@ -54,6 +59,19 @@ public class CreateNBTProcessors {
 
 		NBTProcessors.addProcessor(AllBlockEntityTypes.CREATIVE_CRATE.get(), NBTProcessors.itemProcessor("Filter"));
 		NBTProcessors.addProcessor(AllBlockEntityTypes.PLACARD.get(), NBTProcessors.itemProcessor("Item"));
+	}
+
+	private static void tryRemovingCommand(ListTag front_text, int i) {
+		if(NBTProcessors.textComponentHasClickEvent(front_text.get(i).getAsString()))
+		{
+			var text =
+				Component.Serializer.fromJson(front_text.get(i).getAsString(), RegistryAccess.EMPTY);
+			if (text != null) {
+				text.setStyle(text.getStyle().withClickEvent(null));
+				front_text.remove(i);
+				front_text.add(i,net.minecraft.nbt.StringTag.valueOf(Component.Serializer.toJson(text, RegistryAccess.EMPTY)));
+			}
+		}
 	}
 
 	public static CompoundTag clipboardProcessor(CompoundTag data) {


### PR DESCRIPTION
Fixed the dangerous operation where signs with command would be fully printed and preserve the styles.