### PR TITLE
Improved JEI visualization for Filling and Polishing

### DIFF
--- a/src/main/java/com/simibubi/create/compat/jei/category/PolishingCategory.java
+++ b/src/main/java/com/simibubi/create/compat/jei/category/PolishingCategory.java
@@ -47,15 +47,11 @@ public class PolishingCategory extends CreateRecipeCategory<SandPaperPolishingRe
 		AllGuiTextures.JEI_SHADOW.render(graphics, 61, 21);
 		AllGuiTextures.JEI_LONG_ARROW.render(graphics, 52, 32);
 
-		NonNullList<Ingredient> ingredients = recipe.getIngredients();
-		ItemStack[] matchingStacks = ingredients.get(0)
-			.getItems();
-		if (matchingStacks.length == 0)
-			return;
+		ItemStack stack = iRecipeSlotsView.getSlotViews().get(0).getDisplayedItemStack().orElse(ItemStack.EMPTY);
 
 
 		CompoundTag tag = renderedSandpaper.getOrCreateTag();
-		tag.put("Polishing", matchingStacks[0].serializeNBT());
+		tag.put("Polishing", stack.serializeNBT());
 		tag.putBoolean("JEI", true);
 		GuiGameElement.of(renderedSandpaper)
 				.<GuiGameElement.GuiRenderBuilder>at(getBackground().getWidth() / 2 - 16, 0, 0)

--- a/src/main/java/com/simibubi/create/compat/jei/category/SequencedAssemblyCategory.java
+++ b/src/main/java/com/simibubi/create/compat/jei/category/SequencedAssemblyCategory.java
@@ -62,14 +62,16 @@ public class SequencedAssemblyCategory extends CreateRecipeCategory<SequencedAss
 
 		int width = 0;
 		int margin = 3;
-		for (SequencedRecipe<?> sequencedRecipe : recipe.getSequence())
+		var sequence = recipe.getSequence();
+		for (SequencedRecipe<?> sequencedRecipe : sequence)
 			width += getSubCategory(sequencedRecipe).getWidth() + margin;
 		width -= margin;
 		int x = width / -2 + getBackground().getWidth() / 2;
 
-		for (SequencedRecipe<?> sequencedRecipe : recipe.getSequence()) {
+		for (int i = 0; i < sequence.size(); i++) {
+			var sequencedRecipe = sequence.get(i);
 			SequencedAssemblySubCategory subCategory = getSubCategory(sequencedRecipe);
-			subCategory.setRecipe(builder, sequencedRecipe, focuses, x);
+			subCategory.setRecipe(builder, sequencedRecipe, focuses, x, i);
 			x += subCategory.getWidth() + margin;
 		}
 	}
@@ -131,7 +133,7 @@ public class SequencedAssemblyCategory extends CreateRecipeCategory<SequencedAss
 			int subWidth = subCategory.getWidth();
             MutableComponent component = Component.literal("" + romans[Math.min(i, 6)]);
 			graphics.drawString(font, component, font.width(component) / -2 + subWidth / 2, 2, 0x888888, false);
-			subCategory.draw(sequencedRecipe, graphics, mouseX, mouseY, i);
+			subCategory.draw(sequencedRecipe, iRecipeSlotsView, graphics, mouseX, mouseY, i);
 			matrixStack.translate(subWidth + margin, 0, 0);
 		}
 		matrixStack.popPose();

--- a/src/main/java/com/simibubi/create/compat/jei/category/SpoutCategory.java
+++ b/src/main/java/com/simibubi/create/compat/jei/category/SpoutCategory.java
@@ -121,9 +121,10 @@ public class SpoutCategory extends CreateRecipeCategory<FillingRecipe> {
 	public void draw(FillingRecipe recipe, IRecipeSlotsView iRecipeSlotsView, GuiGraphics graphics, double mouseX, double mouseY) {
 		AllGuiTextures.JEI_SHADOW.render(graphics, 62, 57);
 		AllGuiTextures.JEI_DOWN_ARROW.render(graphics, 126, 29);
-		spout.withFluids(recipe.getRequiredFluid()
-			.getMatchingFluidStacks())
-			.draw(graphics, getBackground().getWidth() / 2 - 13, 22);
+		var fluid = iRecipeSlotsView.getSlotViews().get(1)
+			.getDisplayedIngredient(ForgeTypes.FLUID_STACK)
+			.orElse(FluidStack.EMPTY);
+		spout.withFluid(fluid).draw(graphics, getBackground().getWidth() / 2 - 13, 22);
 	}
 
 }

--- a/src/main/java/com/simibubi/create/compat/jei/category/animations/AnimatedSpout.java
+++ b/src/main/java/com/simibubi/create/compat/jei/category/animations/AnimatedSpout.java
@@ -22,10 +22,19 @@ import net.minecraftforge.fluids.FluidStack;
 
 public class AnimatedSpout extends AnimatedKinetics {
 
-	private List<FluidStack> fluids;
+	private FluidStack fluid = FluidStack.EMPTY;
 
+	/**
+	 * @deprecated Use the single fluid stack version
+	 */
+	@Deprecated(forRemoval = true)
 	public AnimatedSpout withFluids(List<FluidStack> fluids) {
-		this.fluids = fluids;
+		this.fluid = fluids.get(0);
+		return this;
+	}
+
+	public AnimatedSpout withFluid(FluidStack fluid) {
+		this.fluid = fluid;
 		return this;
 	}
 
@@ -68,28 +77,33 @@ public class AnimatedSpout extends AnimatedKinetics {
 			.scale(scale)
 			.render(graphics);
 
-		AnimatedKinetics.DEFAULT_LIGHTING.applyLighting();
-		BufferSource buffer = MultiBufferSource.immediate(Tesselator.getInstance()
-			.getBuilder());
-		matrixStack.pushPose();
-		UIRenderHelper.flipForGuiRender(matrixStack);
-		matrixStack.scale(16, 16, 16);
-		float from = 3f / 16f;
-		float to = 17f / 16f;
-		FluidStack fluidStack = fluids.get(0);
-		FluidRenderer.renderFluidBox(fluidStack.getFluid(), fluidStack.getAmount(), from, from, from, to, to, to, buffer, matrixStack, LightTexture.FULL_BRIGHT, false, true, fluidStack.getTag());
-		matrixStack.popPose();
+		if (!fluid.isEmpty()) {
+			AnimatedKinetics.DEFAULT_LIGHTING.applyLighting();
+			matrixStack.pushPose();
+			UIRenderHelper.flipForGuiRender(matrixStack);
+			matrixStack.scale(16, 16, 16);
+			float from = 3f / 16f;
+			float to = 17f / 16f;
+			FluidRenderer.renderFluidBox(fluid.getFluid(), fluid.getAmount(),
+				from, from, from, to, to, to,
+				graphics.bufferSource(), matrixStack, LightTexture.FULL_BRIGHT,
+				false, true, fluid.getTag());
+			matrixStack.popPose();
 
-		float width = 1 / 128f * squeeze;
-		matrixStack.translate(scale / 2f, scale * 1.5f, scale / 2f);
-		UIRenderHelper.flipForGuiRender(matrixStack);
-		matrixStack.scale(16, 16, 16);
-		matrixStack.translate(-0.5f, 0, -0.5f);
-		from = -width / 2 + 0.5f;
-		to = width / 2 + 0.5f;
-		FluidRenderer.renderFluidBox(fluidStack.getFluid(), fluidStack.getAmount(), from, 0, from, to, 2, to, buffer, matrixStack, LightTexture.FULL_BRIGHT, false, true, fluidStack.getTag());
-		buffer.endBatch();
-		Lighting.setupFor3DItems();
+			float width = 1 / 128f * squeeze;
+			matrixStack.translate(scale / 2f, scale * 1.5f, scale / 2f);
+			UIRenderHelper.flipForGuiRender(matrixStack);
+			matrixStack.scale(16, 16, 16);
+			matrixStack.translate(-0.5f, 0, -0.5f);
+			from = -width / 2 + 0.5f;
+			to = width / 2 + 0.5f;
+			FluidRenderer.renderFluidBox(fluid.getFluid(), fluid.getAmount(),
+				from, 0, from, to, 2, to,
+				graphics.bufferSource(), matrixStack, LightTexture.FULL_BRIGHT,
+				false, true, fluid.getTag());
+			graphics.flush();
+			Lighting.setupFor3DItems();
+		}
 
 		matrixStack.popPose();
 	}

--- a/src/main/java/com/simibubi/create/compat/jei/category/sequencedAssembly/SequencedAssemblySubCategory.java
+++ b/src/main/java/com/simibubi/create/compat/jei/category/sequencedAssembly/SequencedAssemblySubCategory.java
@@ -11,12 +11,16 @@ import com.simibubi.create.content.processing.sequenced.SequencedRecipe;
 import com.simibubi.create.foundation.fluid.FluidIngredient;
 import com.simibubi.create.foundation.utility.CreateLang;
 
+import mezz.jei.api.forge.ForgeTypes;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.builder.IRecipeSlotBuilder;
+import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
 import mezz.jei.api.recipe.IFocusGroup;
 import mezz.jei.api.recipe.RecipeIngredientRole;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.GuiGraphics;
+
+import net.minecraftforge.fluids.FluidStack;
 
 public abstract class SequencedAssemblySubCategory {
 
@@ -30,9 +34,19 @@ public abstract class SequencedAssemblySubCategory {
 		return width;
 	}
 
+	@Deprecated(forRemoval = true)
 	public void setRecipe(IRecipeLayoutBuilder builder, SequencedRecipe<?> recipe, IFocusGroup focuses, int x) {}
 
-	public abstract void draw(SequencedRecipe<?> recipe, GuiGraphics graphics, double mouseX, double mouseY, int index);
+	public void setRecipe(IRecipeLayoutBuilder builder, SequencedRecipe<?> recipe, IFocusGroup focuses, int x, int index) {
+		setRecipe(builder, recipe, focuses, x);
+	}
+
+	@Deprecated(forRemoval = true)
+	public void draw(SequencedRecipe<?> recipe, GuiGraphics graphics, double mouseX, double mouseY, int index) {}
+
+	public void draw(SequencedRecipe<?> recipe, IRecipeSlotsView slotsView, GuiGraphics graphics, double mouseX, double mouseY, int index) {
+		draw(recipe, graphics, mouseX, mouseY, index);
+	}
 
 	public static class AssemblyPressing extends SequencedAssemblySubCategory {
 
@@ -44,7 +58,7 @@ public abstract class SequencedAssemblySubCategory {
 		}
 
 		@Override
-		public void draw(SequencedRecipe<?> recipe, GuiGraphics graphics, double mouseX, double mouseY, int index) {
+		public void draw(SequencedRecipe<?> recipe, IRecipeSlotsView slotsView, GuiGraphics graphics, double mouseX, double mouseY, int index) {
 			PoseStack ms = graphics.pose();
 			press.offset = index;
 			ms.pushPose();
@@ -66,25 +80,25 @@ public abstract class SequencedAssemblySubCategory {
 		}
 
 		@Override
-		public void setRecipe(IRecipeLayoutBuilder builder, SequencedRecipe<?> recipe, IFocusGroup focuses, int x) {
+		public void setRecipe(IRecipeLayoutBuilder builder, SequencedRecipe<?> recipe, IFocusGroup focuses, int x, int index) {
 			FluidIngredient fluidIngredient = recipe.getRecipe()
 					.getFluidIngredients()
 					.get(0);
 
-			CreateRecipeCategory.addFluidSlot(builder, x + 4, 15, fluidIngredient);
+			CreateRecipeCategory.addFluidSlot(builder, x + 4, 15, fluidIngredient).setSlotName("Spout" + index);
 		}
 
 		@Override
-		public void draw(SequencedRecipe<?> recipe, GuiGraphics graphics, double mouseX, double mouseY, int index) {
+		public void draw(SequencedRecipe<?> recipe, IRecipeSlotsView slotsView, GuiGraphics graphics, double mouseX, double mouseY, int index) {
 			PoseStack ms = graphics.pose();
 			spout.offset = index;
 			ms.pushPose();
 			ms.translate(-7, 50, 0);
 			ms.scale(.75f, .75f, .75f);
-			spout.withFluids(recipe.getRecipe()
-				.getFluidIngredients()
-				.get(0)
-				.getMatchingFluidStacks())
+			var fluid = slotsView.findSlotByName("Spout" + index)
+				.flatMap(slot -> slot.getDisplayedIngredient(ForgeTypes.FLUID_STACK))
+				.orElse(FluidStack.EMPTY);
+			spout.withFluid(fluid)
 				.draw(graphics, getWidth() / 2, 0);
 			ms.popPose();
 		}
@@ -101,7 +115,7 @@ public abstract class SequencedAssemblySubCategory {
 		}
 
 		@Override
-		public void setRecipe(IRecipeLayoutBuilder builder, SequencedRecipe<?> recipe, IFocusGroup focuses, int x) {
+		public void setRecipe(IRecipeLayoutBuilder builder, SequencedRecipe<?> recipe, IFocusGroup focuses, int x, int index) {
 			IRecipeSlotBuilder slot = builder
 					.addSlot(RecipeIngredientRole.INPUT, x + 4, 15)
 					.setBackground(CreateRecipeCategory.getRenderedSlot(), -1, -1)
@@ -115,7 +129,7 @@ public abstract class SequencedAssemblySubCategory {
 		}
 
 		@Override
-		public void draw(SequencedRecipe<?> recipe, GuiGraphics graphics, double mouseX, double mouseY, int index) {
+		public void draw(SequencedRecipe<?> recipe, IRecipeSlotsView slotsView, GuiGraphics graphics, double mouseX, double mouseY, int index) {
 			PoseStack ms = graphics.pose();
 			deployer.offset = index;
 			ms.pushPose();
@@ -137,7 +151,7 @@ public abstract class SequencedAssemblySubCategory {
 		}
 
 		@Override
-		public void draw(SequencedRecipe<?> recipe, GuiGraphics graphics, double mouseX, double mouseY, int index) {
+		public void draw(SequencedRecipe<?> recipe, IRecipeSlotsView slotsView, GuiGraphics graphics, double mouseX, double mouseY, int index) {
 			PoseStack ms = graphics.pose();
 			ms.pushPose();
 			ms.translate(0, 51.5f, 0);


### PR DESCRIPTION
Use the current displayed (fluid) ingredient in the spout and sandpaper's animation, where before they always uses the first of the acceptable fluid/item stack.

See https://github.com/Creators-of-Create/Create/pull/7945#issuecomment-2736934862.