### PR TITLE
fix the blueprint printing command bug for the sign (1.20.1)

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/CreateNBTProcessors.java
+++ b/src/main/java/com/simibubi/create/foundation/CreateNBTProcessors.java
@@ -21,8 +21,7 @@ import net.minecraftforge.registries.ForgeRegistries;
 
 public class CreateNBTProcessors {
 	public static void register() {
-		// Remove the first layer of commands while preserving the styles.
-		// Since recursive commands won't be executed, there's no need to handle them.
+		// Remove commands while preserving the styles.
 		NBTProcessors.addProcessor(BlockEntityType.SIGN, data -> {
 			var front_text = data.getCompound("front_text").getList("messages", Tag.TAG_STRING);
 			var back_text = data.getCompound("back_text").getList("messages", Tag.TAG_STRING);
@@ -90,18 +89,6 @@ public class CreateNBTProcessors {
 				removeCommand(textComponent2);
 		}
 		return textComponent;
-	}
-	private static void tryRemovingCommand(ListTag front_text, int i) {
-		if(NBTProcessors.textComponentHasClickEvent(front_text.get(i).getAsString()))
-		{
-			var text =
-				Component.Serializer.fromJson(front_text.get(i).getAsString());
-			if (text != null) {
-				text.setStyle(text.getStyle().withClickEvent(null));
-				front_text.remove(i);
-				front_text.add(i,StringTag.valueOf(Component.Serializer.toJson(text)));
-			}
-		}
 	}
 
 	public static CompoundTag clipboardProcessor(CompoundTag data) {

--- a/src/main/java/com/simibubi/create/foundation/CreateNBTProcessors.java
+++ b/src/main/java/com/simibubi/create/foundation/CreateNBTProcessors.java
@@ -9,6 +9,7 @@ import net.createmod.catnip.nbt.NBTProcessors;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
+import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.entity.BlockEntityType;
@@ -17,11 +18,14 @@ import net.minecraftforge.registries.ForgeRegistries;
 
 public class CreateNBTProcessors {
 	public static void register() {
-
+		// Remove the first layer of commands while preserving the styles.
+		// Since recursive commands won't be executed, there's no need to handle them.
 		NBTProcessors.addProcessor(BlockEntityType.SIGN, data -> {
+			var front_text = data.getCompound("front_text").getList("messages", Tag.TAG_STRING);
+			var back_text = data.getCompound("back_text").getList("messages", Tag.TAG_STRING);
 			for (int i = 0; i < 4; ++i) {
-				if (NBTProcessors.textComponentHasClickEvent(data.getString("Text" + (i + 1))))
-					return null;
+				tryRemovingCommand(front_text, i);
+				tryRemovingCommand(back_text, i);
 			}
 			return data;
 		});
@@ -55,6 +59,19 @@ public class CreateNBTProcessors {
 
 		NBTProcessors.addProcessor(AllBlockEntityTypes.CREATIVE_CRATE.get(), NBTProcessors.itemProcessor("Filter"));
 		NBTProcessors.addProcessor(AllBlockEntityTypes.PLACARD.get(), NBTProcessors.itemProcessor("Item"));
+	}
+
+	private static void tryRemovingCommand(ListTag front_text, int i) {
+		if(NBTProcessors.textComponentHasClickEvent(front_text.get(i).getAsString()))
+		{
+			var text =
+				Component.Serializer.fromJson(front_text.get(i).getAsString());
+			if (text != null) {
+				text.setStyle(text.getStyle().withClickEvent(null));
+				front_text.remove(i);
+				front_text.add(i,net.minecraft.nbt.StringTag.valueOf(Component.Serializer.toJson(text)));
+			}
+		}
 	}
 
 	public static CompoundTag clipboardProcessor(CompoundTag data) {

--- a/src/main/java/com/simibubi/create/foundation/CreateNBTProcessors.java
+++ b/src/main/java/com/simibubi/create/foundation/CreateNBTProcessors.java
@@ -9,52 +9,36 @@ import net.createmod.catnip.nbt.NBTProcessors;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.item.Items;
+import net.minecraft.network.chat.Component;
 import net.minecraft.world.level.block.entity.BlockEntityType;
-
-import net.minecraftforge.registries.ForgeRegistries;
 
 public class CreateNBTProcessors {
 	public static void register() {
-
+		// Remove the first layer of commands while preserving the styles.
+		// Since recursive commands won't be executed, there's no need to handle them.
 		NBTProcessors.addProcessor(BlockEntityType.SIGN, data -> {
+			var front_text = data.getCompound("front_text").getList("messages", Tag.TAG_STRING);
+			var back_text = data.getCompound("back_text").getList("messages", Tag.TAG_STRING);
 			for (int i = 0; i < 4; ++i) {
-				if (NBTProcessors.textComponentHasClickEvent(data.getString("Text" + (i + 1))))
-					return null;
+				tryRemovingCommand(front_text, i);
+				tryRemovingCommand(back_text, i);
 			}
 			return data;
 		});
-
-		NBTProcessors.addProcessor(BlockEntityType.LECTERN, data -> {
-			if (!data.contains("Book", Tag.TAG_COMPOUND))
-				return data;
-			CompoundTag book = data.getCompound("Book");
-
-			// Writable books can't have click events, so they're safe to keep
-			ResourceLocation writableBookResource = ForgeRegistries.ITEMS.getKey(Items.WRITABLE_BOOK);
-			if (writableBookResource != null && book.getString("id").equals(writableBookResource.toString()))
-				return data;
-
-			if (!book.contains("tag", Tag.TAG_COMPOUND))
-				return data;
-			CompoundTag tag = book.getCompound("tag");
-
-			if (!tag.contains("pages", Tag.TAG_LIST))
-				return data;
-			ListTag pages = tag.getList("pages", Tag.TAG_STRING);
-
-			for (Tag inbt : pages) {
-				if (NBTProcessors.textComponentHasClickEvent(inbt.getAsString()))
-					return null;
-			}
-			return data;
-		});
-
-		NBTProcessors.addProcessor(AllBlockEntityTypes.CLIPBOARD.get(), CreateNBTProcessors::clipboardProcessor);
-
-		NBTProcessors.addProcessor(AllBlockEntityTypes.CREATIVE_CRATE.get(), NBTProcessors.itemProcessor("Filter"));
 		NBTProcessors.addProcessor(AllBlockEntityTypes.PLACARD.get(), NBTProcessors.itemProcessor("Item"));
+	}
+
+	private static void tryRemovingCommand(ListTag front_text, int i) {
+		if(NBTProcessors.textComponentHasClickEvent(front_text.get(i).getAsString()))
+		{
+			var text =
+				Component.Serializer.fromJson(front_text.get(i).getAsString());
+			if (text != null) {
+				text.setStyle(text.getStyle().withClickEvent(null));
+				front_text.remove(i);
+				front_text.add(i,net.minecraft.nbt.StringTag.valueOf(Component.Serializer.toJson(text)));
+			}
+		}
 	}
 
 	public static CompoundTag clipboardProcessor(CompoundTag data) {

--- a/src/main/java/com/simibubi/create/foundation/CreateNBTProcessors.java
+++ b/src/main/java/com/simibubi/create/foundation/CreateNBTProcessors.java
@@ -9,7 +9,10 @@ import net.createmod.catnip.nbt.NBTProcessors;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
+import net.minecraft.nbt.StringTag;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.Component.Serializer;
+import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.entity.BlockEntityType;
@@ -23,10 +26,10 @@ public class CreateNBTProcessors {
 		NBTProcessors.addProcessor(BlockEntityType.SIGN, data -> {
 			var front_text = data.getCompound("front_text").getList("messages", Tag.TAG_STRING);
 			var back_text = data.getCompound("back_text").getList("messages", Tag.TAG_STRING);
-			for (int i = 0; i < 4; ++i) {
-				tryRemovingCommand(front_text, i);
-				tryRemovingCommand(back_text, i);
-			}
+			ListTag front_text2 = removeCommands(front_text);
+			ListTag back_text2 = removeCommands(back_text);
+			data.getCompound("front_text").put("messages",front_text2);
+			data.getCompound("back_text").put("messages",back_text2);
 			return data;
 		});
 
@@ -61,6 +64,33 @@ public class CreateNBTProcessors {
 		NBTProcessors.addProcessor(AllBlockEntityTypes.PLACARD.get(), NBTProcessors.itemProcessor("Item"));
 	}
 
+	private static ListTag removeCommands(ListTag inList) {
+		ListTag result = new ListTag();
+		inList.stream()
+			.map(t->
+				{
+					var component = Serializer.fromJson(t.getAsString());
+					if(component != null) {
+						return StringTag.valueOf(Serializer.toJson(
+							removeCommand(component)
+						));
+					}
+					return StringTag.valueOf("");
+				}
+			)
+			.forEach(result::add);
+		return result;
+	}
+
+	private static MutableComponent removeCommand(MutableComponent textComponent){
+		textComponent.setStyle(textComponent.getStyle().withClickEvent(null));
+		for(Component component : textComponent.getSiblings())
+		{
+			if(component instanceof MutableComponent textComponent2)
+				removeCommand(textComponent2);
+		}
+		return textComponent;
+	}
 	private static void tryRemovingCommand(ListTag front_text, int i) {
 		if(NBTProcessors.textComponentHasClickEvent(front_text.get(i).getAsString()))
 		{
@@ -69,7 +99,7 @@ public class CreateNBTProcessors {
 			if (text != null) {
 				text.setStyle(text.getStyle().withClickEvent(null));
 				front_text.remove(i);
-				front_text.add(i,net.minecraft.nbt.StringTag.valueOf(Component.Serializer.toJson(text)));
+				front_text.add(i,StringTag.valueOf(Component.Serializer.toJson(text)));
 			}
 		}
 	}


### PR DESCRIPTION
Fixed the dangerous operation where signs with command would be fully printed and preserve the styles.
from: #8103 