### PR TITLE
Apify filters

### DIFF
--- a/src/main/java/com/simibubi/create/AllItems.java
+++ b/src/main/java/com/simibubi/create/AllItems.java
@@ -48,7 +48,10 @@ import com.simibubi.create.content.legacy.ShadowSteelItem;
 import com.simibubi.create.content.logistics.box.PackageItem;
 import com.simibubi.create.content.logistics.box.PackageStyles;
 import com.simibubi.create.content.logistics.box.PackageStyles.PackageStyle;
+import com.simibubi.create.content.logistics.filter.AttributeFilterItem;
 import com.simibubi.create.content.logistics.filter.FilterItem;
+import com.simibubi.create.content.logistics.filter.ListFilterItem;
+import com.simibubi.create.content.logistics.filter.PackageFilterItem;
 import com.simibubi.create.content.logistics.tableCloth.ShoppingListItem;
 import com.simibubi.create.content.materials.ExperienceNuggetItem;
 import com.simibubi.create.content.processing.burner.BlazeBurnerBlockItem;
@@ -440,14 +443,14 @@ public class AllItems {
 		}
 	}
 
-	public static final ItemEntry<FilterItem> FILTER = REGISTRATE.item("filter", FilterItem::regular)
+	public static final ItemEntry<ListFilterItem> FILTER = REGISTRATE.item("filter", FilterItem::regular)
 		.lang("List Filter")
-		.register(),
+		.register();
 
-	ATTRIBUTE_FILTER = REGISTRATE.item("attribute_filter", FilterItem::attribute)
-		.register(),
+	public static final ItemEntry<AttributeFilterItem> ATTRIBUTE_FILTER = REGISTRATE.item("attribute_filter", FilterItem::attribute)
+		.register();
 
-	PACKAGE_FILTER = REGISTRATE.item("package_filter", FilterItem::address)
+	public static final ItemEntry<PackageFilterItem> PACKAGE_FILTER = REGISTRATE.item("package_filter", FilterItem::address)
 		.register();
 
 	public static final ItemEntry<ScheduleItem> SCHEDULE = REGISTRATE.item("schedule", ScheduleItem::new)

--- a/src/main/java/com/simibubi/create/content/equipment/blueprint/BlueprintItem.java
+++ b/src/main/java/com/simibubi/create/content/equipment/blueprint/BlueprintItem.java
@@ -4,7 +4,6 @@ import java.util.Collection;
 
 import com.simibubi.create.AllItems;
 import com.simibubi.create.content.logistics.filter.AttributeFilterMenu.WhitelistMode;
-import com.simibubi.create.content.logistics.filter.FilterItem;
 import com.simibubi.create.content.logistics.item.filter.attribute.ItemAttribute;
 import com.simibubi.create.content.logistics.item.filter.attribute.attributes.InTagAttribute;
 
@@ -93,7 +92,7 @@ public class BlueprintItem extends Item {
 	}
 
 	private static ItemStack convertIngredientToFilter(Ingredient ingredient) {
-		Ingredient.Value[] acceptedItems = ingredient.values;
+		Value[] acceptedItems = ingredient.values;
 		if (acceptedItems == null || acceptedItems.length > 18)
 			return ItemStack.EMPTY;
 		if (acceptedItems.length == 0)
@@ -102,7 +101,7 @@ public class BlueprintItem extends Item {
 			return convertIItemListToFilter(acceptedItems[0]);
 
 		ItemStack result = AllItems.FILTER.asStack();
-		ItemStackHandler filterItems = FilterItem.getFilterItems(result);
+		ItemStackHandler filterItems = AllItems.FILTER.get().getFilterItemHandler(result);
 		for (int i = 0; i < acceptedItems.length; i++)
 			filterItems.setStackInSlot(i, convertIItemListToFilter(acceptedItems[i]));
 		result.getOrCreateTag()
@@ -133,7 +132,7 @@ public class BlueprintItem extends Item {
 
 		if (itemList instanceof MultiItemValue) {
 			ItemStack result = AllItems.FILTER.asStack();
-			ItemStackHandler filterItems = FilterItem.getFilterItems(result);
+			ItemStackHandler filterItems = AllItems.FILTER.get().getFilterItemHandler(result);
 			int i = 0;
 			for (ItemStack itemStack : stacks) {
 				if (i >= 18)

--- a/src/main/java/com/simibubi/create/content/equipment/blueprint/BlueprintOverlayRenderer.java
+++ b/src/main/java/com/simibubi/create/content/equipment/blueprint/BlueprintOverlayRenderer.java
@@ -12,18 +12,14 @@ import com.simibubi.create.AllItems;
 import com.simibubi.create.content.equipment.blueprint.BlueprintEntity.BlueprintCraftingInventory;
 import com.simibubi.create.content.equipment.blueprint.BlueprintEntity.BlueprintSection;
 import com.simibubi.create.content.logistics.BigItemStack;
-import com.simibubi.create.content.logistics.filter.AttributeFilterMenu.WhitelistMode;
 import com.simibubi.create.content.logistics.filter.FilterItem;
 import com.simibubi.create.content.logistics.filter.FilterItemStack;
-import com.simibubi.create.content.logistics.item.filter.attribute.ItemAttribute;
-import com.simibubi.create.content.logistics.item.filter.attribute.attributes.InTagAttribute;
 import com.simibubi.create.content.logistics.packager.InventorySummary;
 import com.simibubi.create.content.logistics.tableCloth.BlueprintOverlayShopContext;
 import com.simibubi.create.content.logistics.tableCloth.ShoppingListItem.ShoppingList;
 import com.simibubi.create.content.logistics.tableCloth.TableClothBlockEntity;
 import com.simibubi.create.content.trains.track.TrackPlacement.PlacementInfo;
 import com.simibubi.create.foundation.gui.AllGuiTextures;
-import com.simibubi.create.foundation.item.ItemHelper;
 
 import net.createmod.catnip.animation.AnimationTickHolder;
 import net.createmod.catnip.data.Couple;
@@ -35,7 +31,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.inventory.tooltip.TooltipRenderUtil;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.ListTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.CraftingContainer;
@@ -54,9 +49,6 @@ import net.minecraftforge.client.gui.overlay.ForgeGui;
 import net.minecraftforge.client.gui.overlay.IGuiOverlay;
 import net.minecraftforge.items.ItemHandlerHelper;
 import net.minecraftforge.items.ItemStackHandler;
-import net.minecraftforge.registries.ForgeRegistries;
-import net.minecraftforge.registries.tags.ITag;
-import net.minecraftforge.registries.tags.ITagManager;
 
 public class BlueprintOverlayRenderer {
 
@@ -438,34 +430,8 @@ public class BlueprintOverlayRenderer {
 
 	private static ItemStack[] getItemsMatchingFilter(ItemStack filter) {
 		return cachedRenderedFilters.computeIfAbsent(filter, itemStack -> {
-			CompoundTag tag = itemStack.getOrCreateTag();
-
-			if (AllItems.FILTER.isIn(itemStack) && !tag.getBoolean("Blacklist")) {
-				ItemStackHandler filterItems = FilterItem.getFilterItems(itemStack);
-				return ItemHelper.getNonEmptyStacks(filterItems).toArray(ItemStack[]::new);
-			}
-
-			if (AllItems.ATTRIBUTE_FILTER.isIn(itemStack)) {
-				WhitelistMode whitelistMode = WhitelistMode.values()[tag.getInt("WhitelistMode")];
-				ListTag attributes = tag.getList("MatchedAttributes", net.minecraft.nbt.Tag.TAG_COMPOUND);
-				if (whitelistMode == WhitelistMode.WHITELIST_DISJ && attributes.size() == 1) {
-					ItemAttribute fromNBT = ItemAttribute.loadStatic((CompoundTag) attributes.get(0));
-					if (fromNBT instanceof InTagAttribute inTag) {
-						ITagManager<Item> tagManager = ForgeRegistries.ITEMS.tags();
-						if (tagManager.isKnownTagName(inTag.tag)) {
-							ITag<Item> taggedItems = tagManager.getTag(inTag.tag);
-							if (!taggedItems.isEmpty()) {
-								ItemStack[] stacks = new ItemStack[taggedItems.size()];
-								int i = 0;
-								for (Item item : taggedItems) {
-									stacks[i] = new ItemStack(item);
-									i++;
-								}
-								return stacks;
-							}
-						}
-					}
-				}
+			if (itemStack.getItem() instanceof FilterItem filterItem) {
+				return filterItem.getFilterItems(itemStack);
 			}
 
 			return new ItemStack[0];

--- a/src/main/java/com/simibubi/create/content/logistics/filter/AbstractFilterScreen.java
+++ b/src/main/java/com/simibubi/create/content/logistics/filter/AbstractFilterScreen.java
@@ -6,7 +6,6 @@ import java.util.Collections;
 import java.util.List;
 
 import com.google.common.collect.ImmutableList;
-import com.simibubi.create.AllItems;
 import com.simibubi.create.AllPackets;
 import com.simibubi.create.content.logistics.filter.FilterScreenPacket.Option;
 import com.simibubi.create.foundation.gui.AllGuiTextures;
@@ -73,14 +72,16 @@ public abstract class AbstractFilterScreen<F extends AbstractFilterMenu> extends
 
 		background.render(graphics, x, y);
 		graphics.drawString(font, title, x + (background.getWidth() - 8) / 2 - font.width(title) / 2, y + 4,
-			AllItems.PACKAGE_FILTER.isIn(menu.contentHolder) ? 0x3D3C48
-				: AllItems.FILTER.isIn(menu.contentHolder) ? 0x303030 : 0x592424,
-			false);
+			getTitleColor(), false);
 
 		GuiGameElement.of(menu.contentHolder).<GuiGameElement
 			.GuiRenderBuilder>at(x + background.getWidth() + 8, y + background.getHeight() - 52, -200)
 			.scale(4)
 			.render(graphics);
+	}
+
+	protected int getTitleColor() {
+		return 0x592424;
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/logistics/filter/AttributeFilterItem.java
+++ b/src/main/java/com/simibubi/create/content/logistics/filter/AttributeFilterItem.java
@@ -1,0 +1,109 @@
+package com.simibubi.create.content.logistics.filter;
+
+import com.simibubi.create.content.logistics.filter.AttributeFilterMenu.WhitelistMode;
+import com.simibubi.create.content.logistics.filter.FilterItemStack.AttributeFilterItemStack;
+import com.simibubi.create.content.logistics.item.filter.attribute.ItemAttribute;
+import com.simibubi.create.content.logistics.item.filter.attribute.attributes.InTagAttribute;
+import com.simibubi.create.foundation.utility.CreateLang;
+
+import net.minecraft.ChatFormatting;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.tags.ITag;
+import net.minecraftforge.registries.tags.ITagManager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class AttributeFilterItem extends FilterItem {
+	protected AttributeFilterItem(Properties properties) {
+		super(properties);
+	}
+
+	@Override
+	protected List<Component> makeSummary(ItemStack filter) {
+		if (!filter.hasTag()) return Collections.emptyList();
+
+		List<Component> list = new ArrayList<>();
+
+		WhitelistMode whitelistMode = WhitelistMode.values()[filter.getOrCreateTag()
+			.getInt("WhitelistMode")];
+		list.add((whitelistMode == WhitelistMode.WHITELIST_CONJ
+			? CreateLang.translateDirect("gui.attribute_filter.allow_list_conjunctive")
+			: whitelistMode == WhitelistMode.WHITELIST_DISJ
+			? CreateLang.translateDirect("gui.attribute_filter.allow_list_disjunctive")
+			: CreateLang.translateDirect("gui.attribute_filter.deny_list")).withStyle(ChatFormatting.GOLD));
+
+		int count = 0;
+		ListTag attributes = filter.getOrCreateTag()
+			.getList("MatchedAttributes", Tag.TAG_COMPOUND);
+		for (Tag inbt : attributes) {
+			CompoundTag compound = (CompoundTag) inbt;
+			ItemAttribute attribute = ItemAttribute.loadStatic(compound);
+			if (attribute == null)
+				continue;
+			boolean inverted = compound.getBoolean("Inverted");
+			if (count > 3) {
+				list.add(Component.literal("- ...")
+					.withStyle(ChatFormatting.DARK_GRAY));
+				break;
+			}
+			list.add(Component.literal("- ")
+				.append(attribute.format(inverted)));
+			count++;
+		}
+
+		if (count == 0)
+			return Collections.emptyList();
+
+		return list;
+	}
+
+	@Override
+	public AbstractContainerMenu createMenu(int id, Inventory inv, Player player) {
+		return AttributeFilterMenu.create(id, inv, player.getMainHandItem());
+	}
+
+	@Override
+	public FilterItemStack makeStackWrapper(ItemStack filter) {
+		return new AttributeFilterItemStack(filter);
+	}
+
+	@Override
+	public ItemStack[] getFilterItems(ItemStack itemStack) {
+		CompoundTag tag = itemStack.getOrCreateTag();
+
+		WhitelistMode whitelistMode = WhitelistMode.values()[tag.getInt("WhitelistMode")];
+		ListTag attributes = tag.getList("MatchedAttributes", net.minecraft.nbt.Tag.TAG_COMPOUND);
+
+		if (whitelistMode == WhitelistMode.WHITELIST_DISJ && attributes.size() == 1) {
+			ItemAttribute fromNBT = ItemAttribute.loadStatic((CompoundTag) attributes.get(0));
+			if (fromNBT instanceof InTagAttribute inTag) {
+				ITagManager<Item> tagManager = ForgeRegistries.ITEMS.tags();
+				if (tagManager.isKnownTagName(inTag.tag)) {
+					ITag<Item> taggedItems = tagManager.getTag(inTag.tag);
+					if (!taggedItems.isEmpty()) {
+						ItemStack[] stacks = new ItemStack[taggedItems.size()];
+						int i = 0;
+						for (Item item : taggedItems) {
+							stacks[i] = new ItemStack(item);
+							i++;
+						}
+						return stacks;
+					}
+				}
+			}
+		}
+		return new ItemStack[0];
+	}
+}

--- a/src/main/java/com/simibubi/create/content/logistics/filter/AttributeFilterItem.java
+++ b/src/main/java/com/simibubi/create/content/logistics/filter/AttributeFilterItem.java
@@ -31,7 +31,7 @@ public class AttributeFilterItem extends FilterItem {
 	}
 
 	@Override
-	protected List<Component> makeSummary(ItemStack filter) {
+	public List<Component> makeSummary(ItemStack filter) {
 		if (!filter.hasTag()) return Collections.emptyList();
 
 		List<Component> list = new ArrayList<>();

--- a/src/main/java/com/simibubi/create/content/logistics/filter/FilterItem.java
+++ b/src/main/java/com/simibubi/create/content/logistics/filter/FilterItem.java
@@ -71,7 +71,7 @@ public abstract class FilterItem extends Item implements MenuProvider, SupportsI
 		tooltip.addAll(makeSummary);
 	}
 
-	protected abstract List<Component> makeSummary(ItemStack filter);
+	public abstract List<Component> makeSummary(ItemStack filter);
 
 	@Override
 	public InteractionResultHolder<ItemStack> use(Level world, Player player, InteractionHand hand) {

--- a/src/main/java/com/simibubi/create/content/logistics/filter/FilterItem.java
+++ b/src/main/java/com/simibubi/create/content/logistics/filter/FilterItem.java
@@ -1,7 +1,5 @@
 package com.simibubi.create.content.logistics.filter;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -9,19 +7,11 @@ import javax.annotation.Nonnull;
 
 import org.jetbrains.annotations.NotNull;
 
-import com.simibubi.create.AllItems;
 import com.simibubi.create.AllKeys;
 import com.simibubi.create.content.logistics.box.PackageItem;
-import com.simibubi.create.content.logistics.filter.AttributeFilterMenu.WhitelistMode;
-import com.simibubi.create.content.logistics.item.filter.attribute.ItemAttribute;
 import com.simibubi.create.foundation.item.ItemHelper;
 import com.simibubi.create.foundation.recipe.ItemCopyingRecipe.SupportsItemCopying;
-import com.simibubi.create.foundation.utility.CreateLang;
 
-import net.minecraft.ChatFormatting;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.ListTag;
-import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
@@ -41,32 +31,24 @@ import net.minecraft.world.level.Level;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.items.ItemHandlerHelper;
-import net.minecraftforge.items.ItemStackHandler;
 import net.minecraftforge.network.NetworkHooks;
 
-public class FilterItem extends Item implements MenuProvider, SupportsItemCopying {
+public abstract class FilterItem extends Item implements MenuProvider, SupportsItemCopying {
 
-	private FilterType type;
-
-	private enum FilterType {
-		REGULAR, ATTRIBUTE, PACKAGE;
+	public static ListFilterItem regular(Properties properties) {
+		return new ListFilterItem(properties);
 	}
 
-	public static FilterItem regular(Properties properties) {
-		return new FilterItem(FilterType.REGULAR, properties);
+	public static AttributeFilterItem attribute(Properties properties) {
+		return new AttributeFilterItem(properties);
 	}
 
-	public static FilterItem attribute(Properties properties) {
-		return new FilterItem(FilterType.ATTRIBUTE, properties);
+	public static PackageFilterItem address(Properties properties) {
+		return new PackageFilterItem(properties);
 	}
 
-	public static FilterItem address(Properties properties) {
-		return new FilterItem(FilterType.PACKAGE, properties);
-	}
-
-	private FilterItem(FilterType type, Properties properties) {
+	protected FilterItem(Properties properties) {
 		super(properties);
-		this.type = type;
 	}
 
 	@Nonnull
@@ -89,84 +71,7 @@ public class FilterItem extends Item implements MenuProvider, SupportsItemCopyin
 		tooltip.addAll(makeSummary);
 	}
 
-	private List<Component> makeSummary(ItemStack filter) {
-		List<Component> list = new ArrayList<>();
-		if (!filter.hasTag())
-			return list;
-
-		if (type == FilterType.REGULAR) {
-			ItemStackHandler filterItems = getFilterItems(filter);
-			boolean blacklist = filter.getOrCreateTag()
-				.getBoolean("Blacklist");
-
-			list.add((blacklist ? CreateLang.translateDirect("gui.filter.deny_list")
-				: CreateLang.translateDirect("gui.filter.allow_list")).withStyle(ChatFormatting.GOLD));
-			int count = 0;
-			for (int i = 0; i < filterItems.getSlots(); i++) {
-				if (count > 3) {
-					list.add(Component.literal("- ...")
-						.withStyle(ChatFormatting.DARK_GRAY));
-					break;
-				}
-
-				ItemStack filterStack = filterItems.getStackInSlot(i);
-				if (filterStack.isEmpty())
-					continue;
-				list.add(Component.literal("- ")
-					.append(filterStack.getHoverName())
-					.withStyle(ChatFormatting.GRAY));
-				count++;
-			}
-
-			if (count == 0)
-				return Collections.emptyList();
-		}
-
-		if (type == FilterType.ATTRIBUTE) {
-			WhitelistMode whitelistMode = WhitelistMode.values()[filter.getOrCreateTag()
-				.getInt("WhitelistMode")];
-			list.add((whitelistMode == WhitelistMode.WHITELIST_CONJ
-				? CreateLang.translateDirect("gui.attribute_filter.allow_list_conjunctive")
-				: whitelistMode == WhitelistMode.WHITELIST_DISJ
-				? CreateLang.translateDirect("gui.attribute_filter.allow_list_disjunctive")
-				: CreateLang.translateDirect("gui.attribute_filter.deny_list")).withStyle(ChatFormatting.GOLD));
-
-			int count = 0;
-			ListTag attributes = filter.getOrCreateTag()
-				.getList("MatchedAttributes", Tag.TAG_COMPOUND);
-			for (Tag inbt : attributes) {
-				CompoundTag compound = (CompoundTag) inbt;
-				ItemAttribute attribute = ItemAttribute.loadStatic(compound);
-				if (attribute == null)
-					continue;
-				boolean inverted = compound.getBoolean("Inverted");
-				if (count > 3) {
-					list.add(Component.literal("- ...")
-						.withStyle(ChatFormatting.DARK_GRAY));
-					break;
-				}
-				list.add(Component.literal("- ")
-					.append(attribute.format(inverted)));
-				count++;
-			}
-
-			if (count == 0)
-				return Collections.emptyList();
-		}
-
-		if (type == FilterType.PACKAGE) {
-			String address = filter.getOrCreateTag()
-				.getString("Address");
-			if (!address.isBlank())
-				list.add(CreateLang.text("-> ")
-					.style(ChatFormatting.GRAY)
-					.add(CreateLang.text(address)
-						.style(ChatFormatting.GOLD))
-					.component());
-		}
-
-		return list;
-	}
+	protected abstract List<Component> makeSummary(ItemStack filter);
 
 	@Override
 	public InteractionResultHolder<ItemStack> use(Level world, Player player, InteractionHand hand) {
@@ -183,32 +88,11 @@ public class FilterItem extends Item implements MenuProvider, SupportsItemCopyin
 	}
 
 	@Override
-	public AbstractContainerMenu createMenu(int id, Inventory inv, Player player) {
-		ItemStack heldItem = player.getMainHandItem();
-		if (type == FilterType.REGULAR)
-			return FilterMenu.create(id, inv, heldItem);
-		if (type == FilterType.ATTRIBUTE)
-			return AttributeFilterMenu.create(id, inv, heldItem);
-		if (type == FilterType.PACKAGE)
-			return PackageFilterMenu.create(id, inv, heldItem);
-		return null;
-	}
+	public abstract AbstractContainerMenu createMenu(int id, Inventory inv, Player player);
 
 	@Override
 	public Component getDisplayName() {
 		return getDescription();
-	}
-
-	public static ItemStackHandler getFilterItems(ItemStack stack) {
-		ItemStackHandler newInv = new ItemStackHandler(18);
-		if (AllItems.FILTER.get() != stack.getItem())
-			throw new IllegalArgumentException("Cannot get filter items from non-filter: " + stack);
-		if (!stack.hasTag())
-			return newInv;
-		CompoundTag invNBT = stack.getOrCreateTagElement("Items");
-		if (!invNBT.isEmpty())
-			newInv.deserializeNBT(invNBT);
-		return newInv;
 	}
 
 	public static boolean testDirect(ItemStack filter, ItemStack stack, boolean matchNBT) {
@@ -245,4 +129,7 @@ public class FilterItem extends Item implements MenuProvider, SupportsItemCopyin
 		return true;
 	}
 
+	public abstract FilterItemStack makeStackWrapper(ItemStack filter);
+
+	public abstract ItemStack[] getFilterItems(ItemStack itemStack);
 }

--- a/src/main/java/com/simibubi/create/content/logistics/filter/FilterItemStack.java
+++ b/src/main/java/com/simibubi/create/content/logistics/filter/FilterItemStack.java
@@ -3,7 +3,6 @@ package com.simibubi.create.content.logistics.filter;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.simibubi.create.AllItems;
 import com.simibubi.create.content.fluids.transfer.GenericItemEmptying;
 import com.simibubi.create.content.logistics.box.PackageItem;
 import com.simibubi.create.content.logistics.item.filter.attribute.ItemAttribute;
@@ -25,19 +24,9 @@ public class FilterItemStack {
 	private FluidStack filterFluidStack;
 
 	public static FilterItemStack of(ItemStack filter) {
-		if (filter.hasTag()) {
-			if (AllItems.FILTER.isIn(filter)) {
-				trimFilterTag(filter);
-				return new ListFilterItemStack(filter);
-			}
-			if (AllItems.ATTRIBUTE_FILTER.isIn(filter)) {
-				trimFilterTag(filter);
-				return new AttributeFilterItemStack(filter);
-			}
-			if (AllItems.PACKAGE_FILTER.isIn(filter)) {
-				trimFilterTag(filter);
-				return new PackageFilterItemStack(filter);
-			}
+		if (filter.hasTag() && filter.getItem() instanceof FilterItem item) {
+			trimFilterTag(filter);
+			return item.makeStackWrapper(filter);
 		}
 
 		return new FilterItemStack(filter);
@@ -133,12 +122,12 @@ public class FilterItemStack {
 		public boolean shouldRespectNBT;
 		public boolean isBlacklist;
 
-		protected ListFilterItemStack(ItemStack filter) {
+		public ListFilterItemStack(ItemStack filter) {
 			super(filter);
 			boolean defaults = !filter.hasTag();
 
 			containedItems = new ArrayList<>();
-			ItemStackHandler items = FilterItem.getFilterItems(filter);
+			ItemStackHandler items = ((ListFilterItem) filter.getItem()).getFilterItemHandler(filter);
 			for (int i = 0; i < items.getSlots(); i++) {
 				ItemStack stackInSlot = items.getStackInSlot(i);
 				if (!stackInSlot.isEmpty())
@@ -182,7 +171,7 @@ public class FilterItemStack {
 		public WhitelistMode whitelistMode;
 		public List<Pair<ItemAttribute, Boolean>> attributeTests;
 
-		protected AttributeFilterItemStack(ItemStack filter) {
+		public AttributeFilterItemStack(ItemStack filter) {
 			super(filter);
 			boolean defaults = !filter.hasTag();
 
@@ -253,7 +242,7 @@ public class FilterItemStack {
 
 		public String filterString;
 
-		protected PackageFilterItemStack(ItemStack filter) {
+		public PackageFilterItemStack(ItemStack filter) {
 			super(filter);
 			filterString = filter.getOrCreateTag()
 				.getString("Address");

--- a/src/main/java/com/simibubi/create/content/logistics/filter/FilterMenu.java
+++ b/src/main/java/com/simibubi/create/content/logistics/filter/FilterMenu.java
@@ -1,5 +1,6 @@
 package com.simibubi.create.content.logistics.filter;
 
+import com.simibubi.create.AllItems;
 import com.simibubi.create.AllMenuTypes;
 
 import net.minecraft.nbt.CompoundTag;
@@ -48,7 +49,7 @@ public class FilterMenu extends AbstractFilterMenu {
 
 	@Override
 	protected ItemStackHandler createGhostInventory() {
-		return FilterItem.getFilterItems(contentHolder);
+		return AllItems.FILTER.get().getFilterItemHandler(contentHolder);
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/logistics/filter/FilterScreen.java
+++ b/src/main/java/com/simibubi/create/content/logistics/filter/FilterScreen.java
@@ -96,4 +96,8 @@ public class FilterScreen extends AbstractFilterScreen<FilterMenu> {
 		return true;
 	}
 
+	@Override
+	protected int getTitleColor() {
+		return 0x303030;
+	}
 }

--- a/src/main/java/com/simibubi/create/content/logistics/filter/ListFilterItem.java
+++ b/src/main/java/com/simibubi/create/content/logistics/filter/ListFilterItem.java
@@ -1,0 +1,85 @@
+package com.simibubi.create.content.logistics.filter;
+
+import com.simibubi.create.content.logistics.filter.FilterItemStack.ListFilterItemStack;
+import com.simibubi.create.foundation.item.ItemHelper;
+import com.simibubi.create.foundation.utility.CreateLang;
+
+import net.minecraft.ChatFormatting;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.item.ItemStack;
+
+import net.minecraftforge.items.ItemStackHandler;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ListFilterItem extends FilterItem {
+	protected ListFilterItem(Properties properties) {
+		super(properties);
+	}
+
+	@Override
+	protected List<Component> makeSummary(ItemStack filter) {
+		if (!filter.hasTag()) return Collections.emptyList();
+
+		List<Component> list = new ArrayList<>();
+
+		ItemStackHandler filterItems = getFilterItemHandler(filter);
+		boolean blacklist = filter.getOrCreateTag()
+			.getBoolean("Blacklist");
+
+		list.add((blacklist ? CreateLang.translateDirect("gui.filter.deny_list")
+			: CreateLang.translateDirect("gui.filter.allow_list")).withStyle(ChatFormatting.GOLD));
+		int count = 0;
+		for (int i = 0; i < filterItems.getSlots(); i++) {
+			if (count > 3) {
+				list.add(Component.literal("- ...")
+					.withStyle(ChatFormatting.DARK_GRAY));
+				break;
+			}
+
+			ItemStack filterStack = filterItems.getStackInSlot(i);
+			if (filterStack.isEmpty())
+				continue;
+			list.add(Component.literal("- ")
+				.append(filterStack.getHoverName())
+				.withStyle(ChatFormatting.GRAY));
+			count++;
+		}
+
+		if (count == 0)
+			return Collections.emptyList();
+
+		return list;
+	}
+
+	@Override
+	public AbstractContainerMenu createMenu(int id, Inventory inv, Player player) {
+		return FilterMenu.create(id, inv, player.getMainHandItem());
+	}
+
+	@Override
+	public FilterItemStack makeStackWrapper(ItemStack filter) {
+		return new ListFilterItemStack(filter);
+	}
+
+	public ItemStackHandler getFilterItemHandler(ItemStack stack) {
+		ItemStackHandler newInv = new ItemStackHandler(18);
+		CompoundTag invNBT = stack.getOrCreateTagElement("Items");
+		if (!invNBT.isEmpty())
+			newInv.deserializeNBT(invNBT);
+		return newInv;
+	}
+
+	@Override
+	public ItemStack[] getFilterItems(ItemStack itemStack) {
+		if (itemStack.hasTag() && itemStack.getOrCreateTag().getBoolean("Blacklist"))
+			return new ItemStack[0];
+		return ItemHelper.getNonEmptyStacks(getFilterItemHandler(itemStack)).toArray(ItemStack[]::new);
+	}
+}

--- a/src/main/java/com/simibubi/create/content/logistics/filter/ListFilterItem.java
+++ b/src/main/java/com/simibubi/create/content/logistics/filter/ListFilterItem.java
@@ -24,7 +24,7 @@ public class ListFilterItem extends FilterItem {
 	}
 
 	@Override
-	protected List<Component> makeSummary(ItemStack filter) {
+	public List<Component> makeSummary(ItemStack filter) {
 		if (!filter.hasTag()) return Collections.emptyList();
 
 		List<Component> list = new ArrayList<>();

--- a/src/main/java/com/simibubi/create/content/logistics/filter/PackageFilterItem.java
+++ b/src/main/java/com/simibubi/create/content/logistics/filter/PackageFilterItem.java
@@ -1,0 +1,50 @@
+package com.simibubi.create.content.logistics.filter;
+
+import com.simibubi.create.content.logistics.filter.FilterItemStack.PackageFilterItemStack;
+import com.simibubi.create.foundation.utility.CreateLang;
+
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.Collections;
+import java.util.List;
+
+public class PackageFilterItem extends FilterItem{
+	protected PackageFilterItem(Properties properties) {
+		super(properties);
+	}
+
+	@Override
+	protected List<Component> makeSummary(ItemStack filter) {
+		if (!filter.hasTag()) return Collections.emptyList();
+
+		String address = filter.getOrCreateTag()
+			.getString("Address");
+		if (address.isBlank()) return Collections.emptyList();
+
+		return List.of(CreateLang.text("-> ")
+			.style(ChatFormatting.GRAY)
+			.add(CreateLang.text(address)
+				.style(ChatFormatting.GOLD))
+			.component());
+	}
+
+	@Override
+	public AbstractContainerMenu createMenu(int id, Inventory inv, Player player) {
+		return PackageFilterMenu.create(id, inv, player.getMainHandItem());
+	}
+
+	@Override
+	public FilterItemStack makeStackWrapper(ItemStack filter) {
+		return new PackageFilterItemStack(filter);
+	}
+
+	@Override
+	public ItemStack[] getFilterItems(ItemStack itemStack) {
+		return new ItemStack[0];
+	}
+}

--- a/src/main/java/com/simibubi/create/content/logistics/filter/PackageFilterItem.java
+++ b/src/main/java/com/simibubi/create/content/logistics/filter/PackageFilterItem.java
@@ -19,7 +19,7 @@ public class PackageFilterItem extends FilterItem{
 	}
 
 	@Override
-	protected List<Component> makeSummary(ItemStack filter) {
+	public List<Component> makeSummary(ItemStack filter) {
 		if (!filter.hasTag()) return Collections.emptyList();
 
 		String address = filter.getOrCreateTag()

--- a/src/main/java/com/simibubi/create/content/logistics/filter/PackageFilterScreen.java
+++ b/src/main/java/com/simibubi/create/content/logistics/filter/PackageFilterScreen.java
@@ -77,7 +77,7 @@ public class PackageFilterScreen extends AbstractFilterScreen<PackageFilterMenu>
 	public boolean mouseClicked(double pMouseX, double pMouseY, int pButton) {
 		return super.mouseClicked(pMouseX, pMouseY, pButton);
 	}
-	
+
 	@Override
 	public boolean mouseScrolled(double mouseX, double mouseY, double delta) {
 		if (addressBox.mouseScrolled(mouseX, mouseY, delta))
@@ -108,4 +108,8 @@ public class PackageFilterScreen extends AbstractFilterScreen<PackageFilterMenu>
 		return false;
 	}
 
+	@Override
+	protected int getTitleColor() {
+		return 0x3D3C48;
+	}
 }


### PR DESCRIPTION
Fixes #7706 
There was A LOT of hardcoding there, wow.

Splits FilterItem and its mixed usage of the `FilterType` enum and `/AllItems\.[A-Z]_?FILTER\.isIn/` method into four classes. `FilterItem` itself retains most of the logic, and it has three subclasses for `ListFilterItem`, `AttributeFilterItem` and `PackgeFilterItem`. This makes filters so much more extensible for addons, ie they can actually extend it and should be able to implement custom filtering behavior without requiring mixins.

I have tested this and it still works, including basic filter behavior and blueprints (overlay rendering and jei-autofilling).

## WAIFU Analysis:
I have only looked at classes that have changes to existing methods, not just new methods.
- Two mods mixin to `FilterItem`:
  - [CreateBigCannons](https://github.com/Cannoneers-of-Create/CreateBigCannons/blob/multiversion/src/main/java/rbasamoyai/createbigcannons/mixin/compat/create/FilterItemMixin.java) - The target method did not get modified, so this mixin will not break.
  - [Jade Addons](https://github.com/Snownee/JadeAddons/blob/1.20-forge/src/main/java/snownee/jade/addon/mixin/create/FilterItemAccess.java) - The target method was made public, so this mixin will no longer be needed. In the meanwhile, it won't break because the signature did not change.
- No mixins to `BlueprintItem`
- One mixin to `BlueprintOverlayRenderer`:
  - [Jade Addons](https://github.com/Snownee/JadeAddons/blob/1.20-forge/src/main/java/snownee/jade/addon/mixin/create/BlueprintOverlayRendererAccess.java) - The field this makes a getter for was not modified in any way.
- No mixins to `AbstractFilterScreen`
- Two mixins to `FilterItemStack`:
  - [Destroy](https://github.com/petrolpark/Destroy/blob/1.20.1/src/main/java/com/petrolpark/destroy/mixin/FilterItemStackMixin.java) - The method and field this uses was not touched.
  - [CogsOfCarmite](https://github.com/TeamTwilight/CogsOfCarminite/blob/main/src/main/java/com/cogsofcarminite/mixin/FilterItemStackMixin.java) - The target method and instruction still exist, and their filter item does not extend FilterItem (that was actually impossible, the constructor was private) so it will not enter the if statement.
- No mixins to `FilterMenu`


**Therefore while this changes a lot it should not break addons at all, meaning it can be merged safely.**

I would also like to get @jodlodi and @sashafiesta's opinions on this as you are the ones going to use it.
