### PR TITLE
Fix blaze burners not overriding animate tick

### DIFF
--- a/src/main/java/com/simibubi/create/content/processing/burner/BlazeBurnerBlock.java
+++ b/src/main/java/com/simibubi/create/content/processing/burner/BlazeBurnerBlock.java
@@ -1,7 +1,5 @@
 package com.simibubi.create.content.processing.burner;
 
-import java.util.Random;
-
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -21,6 +19,7 @@ import net.minecraft.advancements.critereon.StatePropertiesPredicate;
 import net.minecraft.core.BlockPos;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
+import net.minecraft.util.RandomSource;
 import net.minecraft.util.StringRepresentable;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
@@ -235,7 +234,7 @@ public class BlazeBurnerBlock extends HorizontalDirectionalBlock implements IBE<
 	}
 
 	@OnlyIn(Dist.CLIENT)
-	public void animateTick(BlockState state, Level world, BlockPos pos, Random random) {
+	public void animateTick(BlockState state, Level world, BlockPos pos, RandomSource random) {
 		if (random.nextInt(10) != 0)
 			return;
 		if (!state.getValue(HEAT_LEVEL)

--- a/src/main/java/com/simibubi/create/content/processing/burner/BlazeBurnerBlock.java
+++ b/src/main/java/com/simibubi/create/content/processing/burner/BlazeBurnerBlock.java
@@ -233,6 +233,7 @@ public class BlazeBurnerBlock extends HorizontalDirectionalBlock implements IBE<
 		return false;
 	}
 
+	@Override
 	@OnlyIn(Dist.CLIENT)
 	public void animateTick(BlockState state, Level world, BlockPos pos, RandomSource random) {
 		if (random.nextInt(10) != 0)

--- a/src/main/java/com/simibubi/create/content/processing/burner/LitBlazeBurnerBlock.java
+++ b/src/main/java/com/simibubi/create/content/processing/burner/LitBlazeBurnerBlock.java
@@ -89,6 +89,7 @@ public class LitBlazeBurnerBlock extends Block implements IWrenchable {
 		return AllItems.EMPTY_BLAZE_BURNER.asStack();
 	}
 
+	@Override
 	@OnlyIn(Dist.CLIENT)
 	public void animateTick(BlockState state, Level world, BlockPos pos, RandomSource random) {
 		world.addAlwaysVisibleParticle(ParticleTypes.LARGE_SMOKE, true,

--- a/src/main/java/com/simibubi/create/content/processing/burner/LitBlazeBurnerBlock.java
+++ b/src/main/java/com/simibubi/create/content/processing/burner/LitBlazeBurnerBlock.java
@@ -1,7 +1,5 @@
 package com.simibubi.create.content.processing.burner;
 
-import java.util.Random;
-
 import com.simibubi.create.AllBlocks;
 import com.simibubi.create.AllItems;
 import com.simibubi.create.Create;
@@ -13,6 +11,7 @@ import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.tags.ItemTags;
+import net.minecraft.util.RandomSource;
 import net.minecraft.util.StringRepresentable;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
@@ -91,7 +90,7 @@ public class LitBlazeBurnerBlock extends Block implements IWrenchable {
 	}
 
 	@OnlyIn(Dist.CLIENT)
-	public void animateTick(BlockState state, Level world, BlockPos pos, Random random) {
+	public void animateTick(BlockState state, Level world, BlockPos pos, RandomSource random) {
 		world.addAlwaysVisibleParticle(ParticleTypes.LARGE_SMOKE, true,
 			(double) pos.getX() + 0.5D + random.nextDouble() / 3.0D * (double) (random.nextBoolean() ? 1 : -1),
 			(double) pos.getY() + random.nextDouble() + random.nextDouble(),


### PR DESCRIPTION
Fixes #8068.

Simple fix. Updates method signature of animateTick to use RandomSource so now it overrides the vanilla method. Also added Override annotation to methods.
