### PR TITLE
Fix belt stack sizes getting reduced in ponder

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/belt/BeltRenderer.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/BeltRenderer.java
@@ -26,6 +26,7 @@ import net.createmod.catnip.render.SuperByteBuffer;
 import net.createmod.catnip.data.Iterate;
 import net.createmod.catnip.levelWrappers.WrappedLevel;
 import net.createmod.catnip.math.AngleHelper;
+import net.createmod.ponder.api.level.PonderLevel;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.client.renderer.MultiBufferSource;
@@ -287,7 +288,7 @@ public class BeltRenderer extends SafeBlockEntityRenderer<BeltBlockEntity> {
 		boolean blockItem = bakedModel.isGui3d();
 
 		int count = 0;
-		if (mc.player.getEyePosition(1.0F).distanceTo(itemPos) < 16)
+		if (be.getLevel() instanceof PonderLevel || mc.player.getEyePosition(1.0F).distanceTo(itemPos) < 16)
 			count = (int) (Mth.log2((int) (transported.stack.getCount()))) / 2;
 
 		Random r = new Random(transported.angle);


### PR DESCRIPTION
Stack size reduction optimization added in #6677, but that also reduced it in ponders and wasn't caught in #6898
Before: 
![image](https://github.com/user-attachments/assets/3dae7846-5ec0-4795-81b1-4d8d962c5fb1)

After:
![image](https://github.com/user-attachments/assets/5d6bc472-895b-4216-948a-29b2605d60c0)
