### PR TITLE
TransformableBlockEntity implementation for DisplayLinkBlockEntity

### DIFF
--- a/src/main/java/com/simibubi/create/content/redstone/displayLink/DisplayLinkBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/redstone/displayLink/DisplayLinkBlockEntity.java
@@ -2,21 +2,16 @@ package com.simibubi.create.content.redstone.displayLink;
 
 import java.util.List;
 
-import com.simibubi.create.api.contraption.transformable.TransformableBlockEntity;
-
-import com.simibubi.create.content.contraptions.StructureTransform;
-
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.entity.BlockEntity;
-
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import com.simibubi.create.api.behaviour.display.DisplaySource;
 import com.simibubi.create.api.behaviour.display.DisplayTarget;
+import com.simibubi.create.api.contraption.transformable.TransformableBlockEntity;
 import com.simibubi.create.api.registry.CreateBuiltInRegistries;
 import com.simibubi.create.compat.computercraft.AbstractComputerBehaviour;
 import com.simibubi.create.compat.computercraft.ComputerCraftProxy;
+import com.simibubi.create.content.contraptions.StructureTransform;
 import com.simibubi.create.content.logistics.factoryBoard.FactoryPanelPosition;
 import com.simibubi.create.content.logistics.factoryBoard.FactoryPanelSupportBehaviour;
 import com.simibubi.create.foundation.advancement.AllAdvancements;
@@ -28,6 +23,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtUtils;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;

--- a/src/main/java/com/simibubi/create/content/redstone/displayLink/DisplayLinkBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/redstone/displayLink/DisplayLinkBlockEntity.java
@@ -2,6 +2,13 @@ package com.simibubi.create.content.redstone.displayLink;
 
 import java.util.List;
 
+import com.simibubi.create.api.contraption.transformable.TransformableBlockEntity;
+
+import com.simibubi.create.content.contraptions.StructureTransform;
+
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntity;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -28,7 +35,7 @@ import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.util.LazyOptional;
 
-public class DisplayLinkBlockEntity extends LinkWithBulbBlockEntity {
+public class DisplayLinkBlockEntity extends LinkWithBulbBlockEntity  implements TransformableBlockEntity {
 
 	protected BlockPos targetOffset;
 
@@ -228,6 +235,12 @@ public class DisplayLinkBlockEntity extends LinkWithBulbBlockEntity {
 		if (state.getOptionalValue(DisplayLinkBlock.FACING).orElse(Direction.UP).getAxis().isVertical())
 			return bulbOffsetVertical;
 		return bulbOffset;
+	}
+
+	@Override
+	public void transform(BlockEntity be, StructureTransform transform) {
+		targetOffset = transform.applyWithoutOffset(targetOffset);
+		notifyUpdate();
 	}
 
 }


### PR DESCRIPTION
The implementation ```TransformableBlockEntity``` for ```DisplayLinkBlockEntity``` allows for the target of the Display Link to be rotated accordingly with the rest of the contraption. Solves https://github.com/Creators-of-Create/Create/issues/6981 . I hope I didn't miss any check, I didn't do any since the target is initialized always as ```BlockPos.Zero```