### PR TITLE
Fix Harvester not handle CropBlock with additional properties properly

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/actors/harvester/HarvesterMovementBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/actors/harvester/HarvesterMovementBehaviour.java
@@ -172,7 +172,13 @@ public class HarvesterMovementBehaviour implements MovementBehaviour {
 
 		Block block = state.getBlock();
 		if (block instanceof CropBlock crop) {
-			return state.setValue(((CropBlockAccessor) crop).create$callGetAgeProperty(), 0);
+			BlockState newState = crop.getStateForAge(0);
+			// Different block indicates an intentional override that converts the crop another block.
+			// In that case, the returned state should be respected.
+			// Not very likely for age 0, but it's safer to check it anyway.
+			return newState.is(block)
+				? state.setValue(((CropBlockAccessor) crop).create$callGetAgeProperty(), 0)
+				: newState;
 		}
 		if (block == Blocks.SWEET_BERRY_BUSH) {
 			return state.setValue(BlockStateProperties.AGE_3, Integer.valueOf(1));

--- a/src/main/java/com/simibubi/create/content/contraptions/actors/harvester/HarvesterMovementBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/actors/harvester/HarvesterMovementBehaviour.java
@@ -2,6 +2,8 @@ package com.simibubi.create.content.contraptions.actors.harvester;
 
 import javax.annotation.Nullable;
 
+import com.simibubi.create.foundation.mixin.accessor.CropBlockAccessor;
+
 import org.apache.commons.lang3.mutable.MutableBoolean;
 
 import com.simibubi.create.AllTags.AllBlockTags;
@@ -170,7 +172,7 @@ public class HarvesterMovementBehaviour implements MovementBehaviour {
 
 		Block block = state.getBlock();
 		if (block instanceof CropBlock crop) {
-			return crop.getStateForAge(0);
+			return state.setValue(((CropBlockAccessor) crop).create$callGetAgeProperty(), 0);
 		}
 		if (block == Blocks.SWEET_BERRY_BUSH) {
 			return state.setValue(BlockStateProperties.AGE_3, Integer.valueOf(1));

--- a/src/main/java/com/simibubi/create/foundation/mixin/accessor/CropBlockAccessor.java
+++ b/src/main/java/com/simibubi/create/foundation/mixin/accessor/CropBlockAccessor.java
@@ -1,0 +1,14 @@
+package com.simibubi.create.foundation.mixin.accessor;
+
+import net.minecraft.world.level.block.CropBlock;
+
+import net.minecraft.world.level.block.state.properties.IntegerProperty;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(CropBlock.class)
+public interface CropBlockAccessor {
+	@Invoker("getAgeProperty")
+	IntegerProperty create$callGetAgeProperty();
+}

--- a/src/main/resources/create.mixins.json
+++ b/src/main/resources/create.mixins.json
@@ -24,6 +24,7 @@
     "WaterWheelFluidSpreadMixin",
     "accessor.AbstractProjectileDispenseBehaviorAccessor",
     "accessor.BuiltInRegistriesAccessor",
+    "accessor.CropBlockAccessor",
     "accessor.DispenserBlockAccessor",
     "accessor.FallingBlockEntityAccessor",
     "accessor.FlowingFluidAccessor",


### PR DESCRIPTION
It's well known that the Harvester incompatible with crops that has additional properties other than age, like the Tomato in Farmer's Delight that can be rope logged.

The reason behind is that Create calls the `CropBlock#getStateForAge()` for new state, the method does not have a block state context and thus could only return a state derived from the default state with age altered.

This PR fixes the problem so that a state derived from the original state is returned instead, with exceptions that respects `CropBlock#getStateForAge()` if it returns a different block (indicating an intentional override converting the block on certain age).

Do note that this does not completely fix interaction with Farmer's Delight's Tomato, when replant config is off, the broken rope is still not accounted for since it's not handled by loot table. This is beyond the scope of this PR and likely only fixable by addons that depends on both (which I am currently working on).