### PR TITLE
Fixed the TrainCargoManager's initilization of the allItems variable

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/MountedStorageManager.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/MountedStorageManager.java
@@ -97,9 +97,7 @@ public class MountedStorageManager {
 
 		this.allItemStorages = ImmutableMap.copyOf(this.itemsBuilder);
 
-		this.items = new MountedItemStorageWrapper(subMap(this.allItemStorages, this::isExposed));
-
-		this.allItems = this.items;
+        this.initializeManagerItems(new MountedItemStorageWrapper(subMap(this.allItemStorages, this::isExposed)));
 		this.itemsBuilder = null;
 
 		ImmutableMap<BlockPos, MountedItemStorage> fuelMap = subMap(this.allItemStorages, this::canUseForFuel);
@@ -114,6 +112,11 @@ public class MountedStorageManager {
 		this.syncedFluids = ImmutableMap.copyOf(this.syncedFluidsBuilder);
 		this.syncedFluidsBuilder = null;
 	}
+
+    protected void initializeManagerItems(MountedItemStorageWrapper items) {
+        this.items = items;
+        this.allItems = this.items;
+    }
 
 	private boolean isExposed(MountedItemStorage storage) {
 		return !AllMountedItemStorageTypeTags.INTERNAL.matches(storage);

--- a/src/main/java/com/simibubi/create/content/contraptions/minecart/TrainCargoManager.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/minecart/TrainCargoManager.java
@@ -27,7 +27,7 @@ public class TrainCargoManager extends MountedStorageManager {
 	@Override
 	public void initialize() {
 		super.initialize();
-		this.items = new CargoInvWrapper(this.items);
+        this.initializeManagerItems(new CargoInvWrapper(this.items));
 		if (this.fuelItems != null) {
 			this.fuelItems = new CargoInvWrapper(this.fuelItems);
 		}


### PR DESCRIPTION
This pull request addresses issue #7609, which concerns the train schedule logic specific to the "Cargo idle" condition. Previously, the train's idle timer only waited the specified amount of time upon arriving at a station, instead of waiting until no cargo changes occurred for the given duration.

Upon investigation, I found that during the initialization of the TrainCargoManager, a CargoInvWrapper subobject is created using the MountedItemStorageWrapper's constructor and set within the MountedStorageManager's `item` variable. **HOWEVER**, the MountedStorageManager's/TrainCargoManager's `allItems` variable, which is used to interact with and fetch the collective contraption's item inventories, remains set to the original MountedItemStorageWrapper class. This prevents the CargoInvWrapper's overwritten methods from being invoked, as a result the changeDetected method, responsible for resetting the train's idle timer whenever an update to the cargo occurs, is never called, causing the train to leave after the set time of "inactivity"

This fix ensures that the `allItems` variable is correctly updated during initialization to a CargoInvWrapper class and allows the changeDetected method to function as intended to restore the proper behavior of the train's idle timer within the "Cargo idle" condition.