### PR TITLE
Fix #7476: Crushing Wheel loss of efficiency on powers of 2

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/crusher/CrushingWheelControllerBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/crusher/CrushingWheelControllerBlockEntity.java
@@ -125,8 +125,8 @@ public class CrushingWheelControllerBlockEntity extends SmartBlockEntity {
 		if (!hasEntity()) {
 
 			float processingSpeed =
-				Mth.clamp((speed) / (!inventory.appliedRecipe ? Mth.log2(inventory.getStackInSlot(0)
-					.getCount()) : 1), .25f, 20);
+				Mth.clamp((speed) / (!inventory.appliedRecipe ? (float) Math.log(inventory.getStackInSlot(0)
+					.getCount())/(float) Math.log(2) : 1), .25f, 20);
 			inventory.remainingTime -= processingSpeed;
 			spawnParticles(inventory.getStackInSlot(0));
 


### PR DESCRIPTION
Minecraft log2 function returned integer instead of float, messing up the calculation of the processingSpeed. Fixed by using log function from Java library.