### PR TITLE
Update: Dependency link of ftb mods

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,7 +132,7 @@ repositories {
     maven { url = "https://maven.squiddev.cc" } // CC: Tweaked
     maven { url = "https://www.cursemaven.com" }
     maven { url = "https://api.modrinth.com/maven" }
-    maven { url = "https://maven.saps.dev/releases" } // FTB Mods
+    maven { url = "https://maven.ftb.dev/releases" } // FTB Mods
     maven { url = "https://maven.architectury.dev" } // Arch API
     maven {
         url = "https://jm.gserv.me/repository/maven-public" // JourneyMap


### PR DESCRIPTION
https://maven.saps.dev/releases returns 404