### PR TITLE
Fix GenericItemEmptying#emptyItem doesn't return correct resultingItem when Item is BucketItem, has no emptying recipe and in simulating

### DIFF
--- a/src/main/java/com/simibubi/create/content/fluids/transfer/GenericItemEmptying.java
+++ b/src/main/java/com/simibubi/create/content/fluids/transfer/GenericItemEmptying.java
@@ -73,7 +73,7 @@ public class GenericItemEmptying {
 			return Pair.of(resultingFluid, resultingItem);
 		resultingFluid = tank.drain(1000, simulate? FluidAction.SIMULATE: FluidAction.EXECUTE);
 		if (tank instanceof FluidBucketWrapper){
-			resultingItem = tank.getContainer().copy().getCraftingRemainingItem();
+			resultingItem = simulate? tank.getContainer().copy().getCraftingRemainingItem() : tank.getContainer().copy();
 		} else
 			resultingItem = tank.getContainer().copy();
 		if (!simulate)

--- a/src/main/java/com/simibubi/create/content/fluids/transfer/GenericItemEmptying.java
+++ b/src/main/java/com/simibubi/create/content/fluids/transfer/GenericItemEmptying.java
@@ -70,9 +70,8 @@ public class GenericItemEmptying {
 		IFluidHandlerItem tank = capability.orElse(null);
 		if (tank == null)
 			return Pair.of(resultingFluid, resultingItem);
-		resultingFluid = tank.drain(1000, simulate ? FluidAction.SIMULATE : FluidAction.EXECUTE);
-		resultingItem = tank.getContainer()
-			.copy();
+		resultingFluid = tank.drain(1000, FluidAction.EXECUTE);
+		resultingItem = tank.getContainer().copy();
 		if (!simulate)
 			stack.shrink(1);
 

--- a/src/main/java/com/simibubi/create/content/fluids/transfer/GenericItemEmptying.java
+++ b/src/main/java/com/simibubi/create/content/fluids/transfer/GenericItemEmptying.java
@@ -15,6 +15,7 @@ import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler.FluidAction;
 import net.minecraftforge.fluids.capability.IFluidHandlerItem;
+import net.minecraftforge.fluids.capability.wrappers.FluidBucketWrapper;
 import net.minecraftforge.items.ItemStackHandler;
 import net.minecraftforge.items.wrapper.RecipeWrapper;
 
@@ -70,8 +71,11 @@ public class GenericItemEmptying {
 		IFluidHandlerItem tank = capability.orElse(null);
 		if (tank == null)
 			return Pair.of(resultingFluid, resultingItem);
-		resultingFluid = tank.drain(1000, FluidAction.EXECUTE);
-		resultingItem = tank.getContainer().copy();
+		resultingFluid = tank.drain(1000, simulate? FluidAction.SIMULATE: FluidAction.EXECUTE);
+		if (tank instanceof FluidBucketWrapper){
+			resultingItem = tank.getContainer().copy().getCraftingRemainingItem();
+		} else
+			resultingItem = tank.getContainer().copy();
 		if (!simulate)
 			stack.shrink(1);
 


### PR DESCRIPTION
Just found this bug when investigating strange behavior of [this issue](https://github.com/DragonsPlusMinecraft/CreateEnchantmentIndustry/issues/253).

When a Item has no emptying recipe and also has `ForgeCapabilities.FLUID_HANDLER_ITEM/Capabilities.FluidHandler.ITEM`, `GenericItemEmptying#emptyItem` will get capability to obtain result. The key problem is: You cannot obtain correct result from `IFluidHandlerItem#getContainer` when `IFluidHandlerItem#drain` pass-in FluidAction parameter is `FluidAction.SIMULATE`.

So here is the fix: always pass in `FluidAction.EXECUTE`. It's OK to always pass in `FluidAction.EXECUTE` even when simulating, since we have copied the original ItemStack.
```
ItemStack split = stack.copy();
IFluidHandlerItem capability = split.getCapability(Capabilities.FluidHandler.ITEM);
resultingFluid = capability.drain(...
```