### PR TITLE
[1.21.1] Fix #8194 and fix block setting methods of WorldInstructions do not make SmartBlockEntity virtual

### DIFF
--- a/src/main/java/com/simibubi/create/content/fluids/FlowSource.java
+++ b/src/main/java/com/simibubi/create/content/fluids/FlowSource.java
@@ -3,6 +3,8 @@ package com.simibubi.create.content.fluids;
 import java.lang.ref.WeakReference;
 import java.util.function.Predicate;
 
+import net.createmod.ponder.api.level.PonderLevel;
+
 import org.jetbrains.annotations.Nullable;
 
 import com.simibubi.create.foundation.ICapabilityProvider;
@@ -89,6 +91,9 @@ public abstract class FlowSource {
 						() -> !networkBE.isRemoved(),
 						() -> fluidHandlerCache = EMPTY
 					));
+				else if (blockEntity != null && world instanceof PonderLevel ponderLevel) {
+					fluidHandlerCache = ICapabilityProvider.of(()->ponderLevel.getCapability(Capabilities.FluidHandler.BLOCK, blockEntity.getBlockPos(), location.getOppositeFace()));
+				}
 			}
 		}
 

--- a/src/main/java/com/simibubi/create/foundation/ponder/CreateSceneBuilder.java
+++ b/src/main/java/com/simibubi/create/foundation/ponder/CreateSceneBuilder.java
@@ -304,6 +304,53 @@ public class CreateSceneBuilder extends PonderSceneBuilder {
 				linkBlockEntity -> linkBlockEntity.pulse());
 		}
 
+		@Override
+		public void restoreBlocks(Selection selection) {
+			super.restoreBlocks(selection);
+			markSmartBlockEntityVirtual(selection);
+		}
+
+		@Override
+		public void setBlocks(Selection selection, BlockState state, boolean spawnParticles) {
+			super.setBlocks(selection, state, spawnParticles);
+			markSmartBlockEntityVirtual(selection);
+		}
+
+		@Override
+		public void setBlock(BlockPos pos, BlockState state, boolean spawnParticles) {
+			super.setBlock(pos, state, spawnParticles);
+			markSmartBlockEntityVirtual(pos);
+		}
+
+		@Override
+		public void replaceBlocks(Selection selection, BlockState state, boolean spawnParticles) {
+			super.replaceBlocks(selection, state, spawnParticles);
+			markSmartBlockEntityVirtual(selection);
+		}
+
+		@Override
+		public void modifyBlock(BlockPos pos, UnaryOperator<BlockState> stateFunc, boolean spawnParticles) {
+			super.modifyBlock(pos, stateFunc, spawnParticles);
+			markSmartBlockEntityVirtual(pos);
+		}
+
+		@Override
+		public void modifyBlocks(Selection selection, UnaryOperator<BlockState> stateFunc, boolean spawnParticles) {
+			super.modifyBlocks(selection, stateFunc, spawnParticles);
+			markSmartBlockEntityVirtual(selection);
+		}
+
+		private void markSmartBlockEntityVirtual(BlockPos pos) {
+			addInstruction(scene -> {
+				if(scene.getWorld().getBlockEntity(pos) instanceof SmartBlockEntity smartBlockEntity) smartBlockEntity.markVirtual();
+			});
+		}
+
+		private void markSmartBlockEntityVirtual(Selection selection) {
+			addInstruction(scene -> selection.forEach(pos->{
+				if(scene.getWorld().getBlockEntity(pos) instanceof SmartBlockEntity smartBlockEntity) smartBlockEntity.markVirtual();
+			}));
+		}
 	}
 
 	public class SpecialInstructions extends PonderSpecialInstructions {


### PR DESCRIPTION
As title described, this PR fixes 2 bugs. Fixes #8194 
These 2 bugs make PonderScene of pipes hardly working as expect.

Pump that connects with pipe cannot work properly since codes below do not consider 'world is PonderLevel' situation and then there is no fluidHandlerCache when in Ponder.
https://github.com/Creators-of-Create/Create/blob/4cd14682d14e7789090d6be6abd68a589a517fc9/src/main/java/com/simibubi/create/content/fluids/FlowSource.java#L83-L91

And these block setting methods of WorldInstructions do not make SmartBlockEntity virtual, which leads to `WorldInstructions#propagatePipeChange` -> `PumpBlockEntity#onSpeedChanged` -> `PumpBlockEntity#updatePressureChange`  call chain break.
https://github.com/Creators-of-Create/Create/blob/4cd14682d14e7789090d6be6abd68a589a517fc9/src/main/java/com/simibubi/create/content/fluids/pump/PumpBlockEntity.java#L93-L96
