### PR TITLE
Fix block setting methods of WorldInstructions do not make SmartBlockEntity virtual

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/ponder/CreateSceneBuilder.java
+++ b/src/main/java/com/simibubi/create/foundation/ponder/CreateSceneBuilder.java
@@ -305,6 +305,53 @@ public class CreateSceneBuilder extends PonderSceneBuilder {
 				linkBlockEntity -> linkBlockEntity.pulse());
 		}
 
+		@Override
+		public void restoreBlocks(Selection selection) {
+			super.restoreBlocks(selection);
+			markSmartBlockEntityVirtual(selection);
+		}
+
+		@Override
+		public void setBlocks(Selection selection, BlockState state, boolean spawnParticles) {
+			super.setBlocks(selection, state, spawnParticles);
+			markSmartBlockEntityVirtual(selection);
+		}
+
+		@Override
+		public void setBlock(BlockPos pos, BlockState state, boolean spawnParticles) {
+			super.setBlock(pos, state, spawnParticles);
+			markSmartBlockEntityVirtual(pos);
+		}
+
+		@Override
+		public void replaceBlocks(Selection selection, BlockState state, boolean spawnParticles) {
+			super.replaceBlocks(selection, state, spawnParticles);
+			markSmartBlockEntityVirtual(selection);
+		}
+
+		@Override
+		public void modifyBlock(BlockPos pos, UnaryOperator<BlockState> stateFunc, boolean spawnParticles) {
+			super.modifyBlock(pos, stateFunc, spawnParticles);
+			markSmartBlockEntityVirtual(pos);
+		}
+
+		@Override
+		public void modifyBlocks(Selection selection, UnaryOperator<BlockState> stateFunc, boolean spawnParticles) {
+			super.modifyBlocks(selection, stateFunc, spawnParticles);
+			markSmartBlockEntityVirtual(selection);
+		}
+
+		private void markSmartBlockEntityVirtual(BlockPos pos) {
+			addInstruction(scene -> {
+				if(scene.getWorld().getBlockEntity(pos) instanceof SmartBlockEntity smartBlockEntity) smartBlockEntity.markVirtual();
+			});
+		}
+
+		private void markSmartBlockEntityVirtual(Selection selection) {
+			addInstruction(scene -> selection.forEach(pos->{
+				if(scene.getWorld().getBlockEntity(pos) instanceof SmartBlockEntity smartBlockEntity) smartBlockEntity.markVirtual();
+			}));
+		}
 	}
 
 	public class SpecialInstructions extends PonderSpecialInstructions {


### PR DESCRIPTION
Block setting methods of WorldInstructions do not make SmartBlockEntity virtual, which leads to `WorldInstructions#propagatePipeChange` -> `PumpBlockEntity#onSpeedChanged` -> `PumpBlockEntity#updatePressureChange`  call chain break.
https://github.com/Creators-of-Create/Create/blob/7d91f416b45962b4d56674f9399df0b88bf716a4/src/main/java/com/simibubi/create/content/fluids/pump/PumpBlockEntity.java#L92-L95

And this bug could potentially lead to more problems.
