### PR TITLE
[1.21.1] Fix #8194. Fix FlowSource.FluidHandler always have EMPTY fluidHandlerCache in ponder world

### DIFF
--- a/src/main/java/com/simibubi/create/content/fluids/FlowSource.java
+++ b/src/main/java/com/simibubi/create/content/fluids/FlowSource.java
@@ -3,6 +3,8 @@ package com.simibubi.create.content.fluids;
 import java.lang.ref.WeakReference;
 import java.util.function.Predicate;
 
+import net.createmod.ponder.api.level.PonderLevel;
+
 import org.jetbrains.annotations.Nullable;
 
 import com.simibubi.create.foundation.ICapabilityProvider;
@@ -89,6 +91,9 @@ public abstract class FlowSource {
 						() -> !networkBE.isRemoved(),
 						() -> fluidHandlerCache = EMPTY
 					));
+				else if (blockEntity != null && world instanceof PonderLevel ponderLevel) {
+					fluidHandlerCache = ICapabilityProvider.of(()->ponderLevel.getCapability(Capabilities.FluidHandler.BLOCK, blockEntity.getBlockPos(), location.getOppositeFace()));
+				}
 			}
 		}
 


### PR DESCRIPTION
This is a 1.21.1 specific bug. This bug together with #8316  , make PonderScene of pipes hardly working as expect.

Pump that connects with pipe cannot work properly since codes below don't consider 'world is PonderLevel' situation and then there is no fluidHandlerCache when in Ponder.
https://github.com/Creators-of-Create/Create/blob/4cd14682d14e7789090d6be6abd68a589a517fc9/src/main/java/com/simibubi/create/content/fluids/FlowSource.java#L83-L91



