### PR TITLE
Fix crash with null level during world gen (from third party mods)

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/tunnel/BeltTunnelBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/tunnel/BeltTunnelBlockEntity.java
@@ -138,6 +138,8 @@ public class BeltTunnelBlockEntity extends SmartBlockEntity {
 			sides.add(direction);
 
 			// Flap might be occluded
+			if (level == null)
+				continue;
 			BlockState nextState = level.getBlockState(worldPosition.relative(direction));
 			if (nextState.getBlock() instanceof BeltTunnelBlock)
 				continue;


### PR DESCRIPTION
Hi, I'm using Create with a bunch of other mods and datapacks, and one of them generates Belt Tunnel blocks in structures, sometimes causing crashes during world gen.

The crashes happened during the feature placement phase, so probably because of that the "level" variable in the Block Entity was null (or maybe Chunky was the culprit, I don't know), causing a crash when accessing a blockState in updateTunnelConnections.

I don't have the stack of the crash to show you, but after adding this null check the crash went away and the worldgen could contiune its job. Probably the generated blocks are forming a broken/non-functional machine, but it probably doesn't matter in this case (this is my first time using Create, so I don't know what those "flaps" are haha).