### PR TITLE
Fix item duplication on belts

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/belt/transport/BeltCrusherInteractionHandler.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/transport/BeltCrusherInteractionHandler.java
@@ -63,7 +63,7 @@ public class BeltCrusherInteractionHandler {
 				remainder = ItemHandlerHelper.copyStackWithSize(currentItem.stack, notFilled);
 
 			currentItem.stack = remainder;
-			beltInventory.belt.sendData();
+			beltInventory.belt.notifyUpdate();
 			return true;
 		}
 

--- a/src/main/java/com/simibubi/create/content/kinetics/belt/transport/BeltFunnelInteractionHandler.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/transport/BeltFunnelInteractionHandler.java
@@ -116,7 +116,7 @@ public class BeltFunnelInteractionHandler {
 			funnelBE.flap(true);
 			funnelBE.onTransfer(toInsert);
 			currentItem.stack = remainder;
-			beltInventory.belt.sendData();
+			beltInventory.belt.notifyUpdate();
 			if (blocking)
 				return true;
 		}

--- a/src/main/java/com/simibubi/create/content/kinetics/belt/transport/BeltInventory.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/transport/BeltInventory.java
@@ -68,8 +68,7 @@ public class BeltInventory {
 			toInsert.clear();
 			items.removeAll(toRemove);
 			toRemove.clear();
-			belt.setChanged();
-			belt.sendData();
+			belt.notifyUpdate();
 		}
 
 		if (belt.getSpeed() == 0)
@@ -79,8 +78,7 @@ public class BeltInventory {
 		if (beltMovementPositive != belt.getDirectionAwareBeltMovementSpeed() > 0) {
 			beltMovementPositive = !beltMovementPositive;
 			Collections.reverse(items);
-			belt.setChanged();
-			belt.sendData();
+			belt.notifyUpdate();
 		}
 
 		// Assuming the first entry is furthest on the belt
@@ -154,11 +152,11 @@ public class BeltInventory {
 				ItemStack item = currentItem.stack;
 				if (handleBeltProcessingAndCheckIfRemoved(currentItem, nextOffset, noMovement)) {
 					iterator.remove();
-					belt.sendData();
+					belt.notifyUpdate();
 					continue;
 				}
 				if (item != currentItem.stack)
-					belt.sendData();
+					belt.notifyUpdate();
 				if (currentItem.locked)
 					continue;
 			}
@@ -217,7 +215,7 @@ public class BeltInventory {
 					currentItem.stack = remainder;
 
 				flapTunnel(this, lastOffset, movementFacing, false);
-				belt.sendData();
+				belt.notifyUpdate();
 				continue;
 			}
 
@@ -228,7 +226,7 @@ public class BeltInventory {
 				eject(currentItem);
 				iterator.remove();
 				flapTunnel(this, lastOffset, movementFacing, false);
-				belt.sendData();
+				belt.notifyUpdate();
 				continue;
 			}
 		}
@@ -248,7 +246,7 @@ public class BeltInventory {
 				return false;
 			if (processingBehaviour == null) {
 				currentItem.locked = false;
-				belt.sendData();
+				belt.notifyUpdate();
 				return false;
 			}
 
@@ -259,7 +257,7 @@ public class BeltInventory {
 				return false;
 
 			currentItem.locked = false;
-			belt.sendData();
+			belt.notifyUpdate();
 			return false;
 		}
 
@@ -292,7 +290,7 @@ public class BeltInventory {
 				if (result == ProcessingResult.HOLD) {
 					currentItem.beltPosition = segment + .5f + (beltMovementPositive ? 1 / 512f : -1 / 512f);
 					currentItem.locked = true;
-					belt.sendData();
+					belt.notifyUpdate();
 					return false;
 				}
 			}
@@ -471,8 +469,7 @@ public class BeltInventory {
 			toRemove.add(transported);
 		}
 		if (dirty) {
-			belt.setChanged();
-			belt.sendData();
+			belt.notifyUpdate();
 		}
 	}
 

--- a/src/main/java/com/simibubi/create/content/kinetics/belt/transport/BeltTunnelInteractionHandler.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/transport/BeltTunnelInteractionHandler.java
@@ -56,8 +56,7 @@ public class BeltTunnelInteractionHandler {
 				if (onServer) {
 					brassTunnel.setStackToDistribute(current.stack, movementFacing.getOpposite());
 					current.stack = ItemStack.EMPTY;
-					beltInventory.belt.sendData();
-					beltInventory.belt.setChanged();
+					beltInventory.belt.notifyUpdate();
 				}
 				removed = true;
 			}
@@ -92,7 +91,7 @@ public class BeltTunnelInteractionHandler {
 						flapTunnel(beltInventory, upcomingSegment, d, false);
 
 					current.stack.shrink(1);
-					beltInventory.belt.sendData();
+					beltInventory.belt.notifyUpdate();
 					if (current.stack.getCount() <= 1)
 						break;
 				}


### PR DESCRIPTION
When a belt points directly into another belt, the last item to cross the boundary may be duplicated when the chunk is unloaded. I believe this happens because the ending doesn't mark the inventory as changed after removing the item.

This is my first time contributing to a Minecraft mod, so please double check that I'm correct before merging.

Fixes #7242
Fixes #4526