### PR TITLE
Add Clipboard support for Stock Ticker categories

### DIFF
--- a/src/generated/resources/assets/create/lang/en_us.json
+++ b/src/generated/resources/assets/create/lang/en_us.json
@@ -1556,6 +1556,7 @@
   "create.logistics.recipe_filter": "Recipe Filter",
   "create.logistics.redstone_interval": "Redstone Interval",
   "create.logistics.secondFrequency": "Frequency #2",
+  "create.logistics.stock_ticker.requires_items_in_inventory": "Not enough %1$s items in Inventory",
   "create.logistics.train_observer.cargo_filter": "Cargo Filter",
   "create.logistics.when_multiple_outputs_available": "Distribution Method",
   "create.materialChecklist": "Material Checklist",

--- a/src/main/java/com/simibubi/create/content/logistics/stockTicker/StockTickerBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/stockTicker/StockTickerBlockEntity.java
@@ -15,6 +15,7 @@ import com.simibubi.create.compat.Mods;
 import com.simibubi.create.compat.computercraft.AbstractComputerBehaviour;
 import com.simibubi.create.compat.computercraft.ComputerCraftProxy;
 import com.simibubi.create.content.contraptions.actors.seat.SeatEntity;
+import com.simibubi.create.content.equipment.clipboard.ClipboardCloneable;
 import com.simibubi.create.content.logistics.BigItemStack;
 import com.simibubi.create.content.logistics.filter.FilterItem;
 import com.simibubi.create.content.logistics.filter.FilterItemStack;
@@ -45,6 +46,7 @@ import net.minecraft.world.MenuProvider;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
@@ -57,7 +59,7 @@ import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
 import net.neoforged.neoforge.items.IItemHandler;
 
-public class StockTickerBlockEntity extends StockCheckingBlockEntity implements IHaveHoveringInformation, Clearable {
+public class StockTickerBlockEntity extends StockCheckingBlockEntity implements IHaveHoveringInformation, Clearable, ClipboardCloneable {
 	public AbstractComputerBehaviour computerBehaviour;
 
 	// Player-interface Feature
@@ -315,5 +317,91 @@ public class StockTickerBlockEntity extends StockCheckingBlockEntity implements 
 		public Component getDisplayName() {
 			return Component.empty();
 		}
+	}
+
+	@Override
+	public String getClipboardKey() {
+		return "StockTicker";
+	}
+
+  
+	@Override
+	public boolean writeToClipboard(CompoundTag tag, Direction side) {
+		tag.put("Categories", NBTHelper.writeItemList(categories));
+		return true;
+	}
+
+  
+	@Override
+	public boolean readFromClipboard(CompoundTag tag, Player player, Direction side, boolean simulate) {
+		if (!tag.contains("Categories"))
+			return false;
+		if (simulate)
+			return true;
+
+    // Read categories from the tag
+    List<ItemStack> newCategories = NBTHelper.readItemList(tag.getList("Categories", Tag.TAG_COMPOUND));
+
+    // Apply the new categories if the player is in creative mode
+    if (player.isCreative()) {
+      categories = newCategories;
+      hiddenCategoriesByPlayer.clear();
+      notifyUpdate();
+      return true;
+    }
+
+    // Diff the new categories with the existing ones
+    Map<Item, Integer> counts = new HashMap<>();
+    newCategories.forEach(s -> counts.merge(s.getItem(),  s.getCount(), Integer::sum));
+    categories   .forEach(s -> counts.merge(s.getItem(), -s.getCount(), Integer::sum));
+
+    // Check if the player has enough items in their inventory to cover the new categories
+    InvWrapper inv = new InvWrapper(player.getInventory());
+    
+    for (Map.Entry<Item,Integer> e : counts.entrySet()) {
+      if (e.getValue() <= 0) continue;
+
+      if (!ItemHelper.extract(inv, inv_stack -> inv_stack.getItem() == e.getKey(),
+          e.getValue(), true).isEmpty())
+        continue;
+
+      player.displayClientMessage(CreateLang
+        .translate("logistics.stock_ticker.requires_items_in_inventory", e.getKey().getDescription()
+          .copy()
+          .withStyle(ChatFormatting.WHITE))
+        .style(ChatFormatting.RED)
+        .component(), true);
+      AllSoundEvents.DENY.playOnServer(player.level(), player.blockPosition(), 1, 1);
+      return false;
+    }
+
+    // Take the items from the player's inventory
+    for (Map.Entry<Item,Integer> e : counts.entrySet()) {
+      for (boolean preferStacksWithoutData : Iterate.trueAndFalse) {
+        while (e.getValue() > 0) {
+          if (ItemHelper.extract(inv, stack -> stack.getItem() == e.getKey() && preferStacksWithoutData != stack.hasTag(),
+              1, false)
+            .isEmpty())
+            break; 
+          e.setValue(e.getValue() - 1);
+        }
+      }
+    }
+    
+    // Add extra items to the player's inventory
+    for (Map.Entry<Item,Integer> e : counts.entrySet()) {
+      if (e.getValue() < 0) {
+        player.getInventory()
+          .placeItemBackInInventory(new ItemStack(e.getKey(), -e.getValue()));
+        continue;
+      }
+    }
+    
+    // Apply the new categories and clear hidden categories
+    categories = newCategories;
+    hiddenCategoriesByPlayer.clear();
+    notifyUpdate();
+
+    return true;
 	}
 }

--- a/src/main/java/com/simibubi/create/content/logistics/stockTicker/StockTickerBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/stockTicker/StockTickerBlockEntity.java
@@ -58,6 +58,7 @@ import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
 import net.neoforged.neoforge.items.IItemHandler;
+import net.neoforged.neoforge.items.wrapper.InvWrapper;
 
 public class StockTickerBlockEntity extends StockCheckingBlockEntity implements IHaveHoveringInformation, Clearable, ClipboardCloneable {
 	public AbstractComputerBehaviour computerBehaviour;
@@ -326,21 +327,21 @@ public class StockTickerBlockEntity extends StockCheckingBlockEntity implements 
 
   
 	@Override
-	public boolean writeToClipboard(CompoundTag tag, Direction side) {
-		tag.put("Categories", NBTHelper.writeItemList(categories));
+	public boolean writeToClipboard(HolderLookup.Provider registries, CompoundTag tag, Direction side) {
+		tag.put("Categories", NBTHelper.writeItemList(categories, registries));
 		return true;
 	}
 
   
 	@Override
-	public boolean readFromClipboard(CompoundTag tag, Player player, Direction side, boolean simulate) {
+	public boolean readFromClipboard(HolderLookup.Provider registries, CompoundTag tag, Player player, Direction side, boolean simulate) {
 		if (!tag.contains("Categories"))
 			return false;
 		if (simulate)
 			return true;
 
     // Read categories from the tag
-    List<ItemStack> newCategories = NBTHelper.readItemList(tag.getList("Categories", Tag.TAG_COMPOUND));
+    List<ItemStack> newCategories = NBTHelper.readItemList(tag.getList("Categories", Tag.TAG_COMPOUND), registries);
 
     // Apply the new categories if the player is in creative mode
     if (player.isCreative()) {
@@ -379,7 +380,7 @@ public class StockTickerBlockEntity extends StockCheckingBlockEntity implements 
     for (Map.Entry<Item,Integer> e : counts.entrySet()) {
       for (boolean preferStacksWithoutData : Iterate.trueAndFalse) {
         while (e.getValue() > 0) {
-          if (ItemHelper.extract(inv, stack -> stack.getItem() == e.getKey() && preferStacksWithoutData != stack.hasTag(),
+          if (ItemHelper.extract(inv, stack -> stack.getItem() == e.getKey() && preferStacksWithoutData == stack.isComponentsPatchEmpty(),
               1, false)
             .isEmpty())
             break; 

--- a/src/main/resources/assets/create/lang/default/interface.json
+++ b/src/main/resources/assets/create/lang/default/interface.json
@@ -224,6 +224,8 @@
 	"create.logistics.filter.up_to": "Up to",
 	"create.logistics.filter.exactly": "Exactly",
 	"create.logistics.filter.requires_item_in_inventory": "Requires %1$s item in Inventory",
+  
+  "create.logistics.stock_ticker.requires_items_in_inventory": "Not enough %1$s items in Inventory",
 
 	"create.logistics.creative_crate.supply": "Infinite Supply",
 	"create.logistics.train_observer.cargo_filter": "Cargo Filter",


### PR DESCRIPTION
Implements #8239

It allows for copying filters (not networks) across Stock Tickers. It properly takes/refunds items to the player's inventory with their tags cleared. It also gives a warning if the player doesn't have enough of a given filter.