### PR TITLE
[1.21.1] Fix Potato Cannon doesn't playing the proper animation when fired

### DIFF
--- a/src/main/java/com/simibubi/create/content/equipment/potatoCannon/PotatoCannonItem.java
+++ b/src/main/java/com/simibubi/create/content/equipment/potatoCannon/PotatoCannonItem.java
@@ -272,7 +272,7 @@ public class PotatoCannonItem extends ProjectileWeaponItem implements CustomArmP
 
 	@Override
 	public boolean onEntitySwing(ItemStack stack, LivingEntity entity, InteractionHand hand) {
-		return false;
+		return true;
 	}
 
 	@Override


### PR DESCRIPTION
This PR fix #7966 

On 1.21.1, the basic item interaction animation is played in addition of the Potato Cannon shooting animation, as described in #7966 . However #7966 doesn't occure in 1.20.1, making it specific to 1.21.1.

This is my first PR, so apologies if my wording aren't clear