### PR TITLE
[1.21.1] Large Waterwheel using Archwood Planks, defaults to Blue Archwood

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/waterwheel/WaterWheelRenderer.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/waterwheel/WaterWheelRenderer.java
@@ -110,7 +110,7 @@ public class WaterWheelRenderer<T extends WaterWheelBlockEntity> extends Kinetic
 		String path = id.getPath();
 
 		if (path.endsWith("_planks")) // Covers most wood types
-			return path.substring(0, path.length() - 7);
+			return (path.startsWith("archwood") ? "blue_" : "") + path.substring(0, path.length() - 7);
 
 		if (path.contains("wood/planks/")) // TerraFirmaCraft
 			return path.substring(12);


### PR DESCRIPTION
would be better if this would be changable by adding a subMaterial or something like that

but this just fixes #8384 in regards to having a mismatched logtype

![{D1C277A9-59E8-4C2E-9B82-658BD39A2C23}](https://github.com/user-attachments/assets/9751eca3-6abf-45e4-9836-b33947b254e6)

