### PR TITLE
ComputerCraft Update

### DIFF
--- a/src/main/java/com/simibubi/create/compat/computercraft/AbstractComputerBehaviour.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/AbstractComputerBehaviour.java
@@ -48,6 +48,8 @@ public class AbstractComputerBehaviour extends BlockEntityBehaviour {
 	public boolean hasAttachedComputer() {
 		return hasAttachedComputer;
 	}
+  
+  public void sendEvent(String eventName, Object... args) {}
 
 	@Override
 	public BehaviourType<?> getType() {

--- a/src/main/java/com/simibubi/create/compat/computercraft/ComputerCraftProxy.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/ComputerCraftProxy.java
@@ -16,6 +16,8 @@ public class ComputerCraftProxy {
 	private static void registerWithDependency() {
 		/* Comment if computercraft.implementation is not in the source set */
 		 computerFactory = ComputerBehaviour::new;
+
+		ComputerBehaviour.registerItemDetailProviders();
 	}
 
 	private static Function<SmartBlockEntity, ? extends AbstractComputerBehaviour> fallbackFactory;

--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/ComputerBehaviour.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/ComputerBehaviour.java
@@ -86,4 +86,8 @@ public class ComputerBehaviour extends AbstractComputerBehaviour {
     });
   }
 
+  public void registerItemDetailProviders() {
+    PackagerPeripheral.registerItemDetailProviders();
+  }
+
 }

--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/ComputerBehaviour.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/ComputerBehaviour.java
@@ -8,6 +8,7 @@ import com.simibubi.create.compat.computercraft.implementation.peripherals.Speed
 import com.simibubi.create.compat.computercraft.implementation.peripherals.SpeedGaugePeripheral;
 import com.simibubi.create.compat.computercraft.implementation.peripherals.StationPeripheral;
 import com.simibubi.create.compat.computercraft.implementation.peripherals.StressGaugePeripheral;
+import com.simibubi.create.compat.computercraft.implementation.peripherals.SyncedPeripheral;
 import com.simibubi.create.content.kinetics.gauge.SpeedGaugeBlockEntity;
 import com.simibubi.create.content.kinetics.gauge.StressGaugeBlockEntity;
 import com.simibubi.create.content.kinetics.speedController.SpeedControllerBlockEntity;
@@ -75,5 +76,14 @@ public class ComputerBehaviour extends AbstractComputerBehaviour {
 		if (peripheral != null)
 			peripheral.invalidate();
 	}
+
+  @Override
+  public void sendEvent(String eventName, Object... args) {
+    getPeripheralCapability().ifPresent(cap -> {
+      if (cap instanceof SyncedPeripheral<?> peripheral) {
+        peripheral.sendEvent(eventName, args);
+      }
+    });
+  }
 
 }

--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/ComputerBehaviour.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/ComputerBehaviour.java
@@ -2,6 +2,7 @@ package com.simibubi.create.compat.computercraft.implementation;
 
 import com.simibubi.create.compat.computercraft.AbstractComputerBehaviour;
 import com.simibubi.create.compat.computercraft.implementation.peripherals.DisplayLinkPeripheral;
+import com.simibubi.create.compat.computercraft.implementation.peripherals.PackagerPeripheral;
 import com.simibubi.create.compat.computercraft.implementation.peripherals.SequencedGearshiftPeripheral;
 import com.simibubi.create.compat.computercraft.implementation.peripherals.SpeedControllerPeripheral;
 import com.simibubi.create.compat.computercraft.implementation.peripherals.SpeedGaugePeripheral;
@@ -11,6 +12,7 @@ import com.simibubi.create.content.kinetics.gauge.SpeedGaugeBlockEntity;
 import com.simibubi.create.content.kinetics.gauge.StressGaugeBlockEntity;
 import com.simibubi.create.content.kinetics.speedController.SpeedControllerBlockEntity;
 import com.simibubi.create.content.kinetics.transmission.sequencer.SequencedGearshiftBlockEntity;
+import com.simibubi.create.content.logistics.packager.PackagerBlockEntity;
 import com.simibubi.create.content.redstone.displayLink.DisplayLinkBlockEntity;
 import com.simibubi.create.content.trains.station.StationBlockEntity;
 import com.simibubi.create.foundation.blockEntity.SmartBlockEntity;
@@ -49,6 +51,8 @@ public class ComputerBehaviour extends AbstractComputerBehaviour {
 			return () -> new StressGaugePeripheral(sgbe);
 		if (be instanceof StationBlockEntity sbe)
 			return () -> new StationPeripheral(sbe);
+    if (be instanceof PackagerBlockEntity pbe)
+      return () -> new PackagerPeripheral(pbe);
 
 		throw new IllegalArgumentException(
 			"No peripheral available for " + ForgeRegistries.BLOCK_ENTITY_TYPES.getKey(be.getType()));

--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/ComputerBehaviour.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/ComputerBehaviour.java
@@ -86,7 +86,7 @@ public class ComputerBehaviour extends AbstractComputerBehaviour {
     });
   }
 
-  public void registerItemDetailProviders() {
+  public static void registerItemDetailProviders() {
     PackagerPeripheral.registerItemDetailProviders();
   }
 

--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/PackagerPeripheral.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/PackagerPeripheral.java
@@ -1,12 +1,17 @@
 package com.simibubi.create.compat.computercraft.implementation.peripherals;
 
+import java.util.List;
+
 import org.jetbrains.annotations.NotNull;
 
+import com.simibubi.create.compat.computercraft.implementation.CreateLuaTable;
 import com.simibubi.create.content.logistics.box.PackageItem;
 import com.simibubi.create.content.logistics.packager.PackagerBlockEntity;
+import com.simibubi.create.content.logistics.stockTicker.PackageOrderWithCrafts;
 
 import dan200.computercraft.api.lua.LuaException;
 import dan200.computercraft.api.lua.LuaFunction;
+import dan200.computercraft.api.detail.VanillaDetailRegistries;
 import net.minecraft.world.item.ItemStack;
 
 public class PackagerPeripheral extends SyncedPeripheral<PackagerBlockEntity> {
@@ -15,23 +20,84 @@ public class PackagerPeripheral extends SyncedPeripheral<PackagerBlockEntity> {
     super(blockEntity);
   }
 
+  @LuaFunction
+  public final String getHeldAddress() throws LuaException {
+    ItemStack stack = getHeldStack();
+    
+    return PackageItem.getAddress(stack);
+  }
+
   @LuaFunction(mainThread = true)
-  public final void setAddress(String newAddress) throws LuaException {
-    ItemStack stack = this.blockEntity.inventory.getStackInSlot(1);
-    if (stack.isEmpty())
-      throw new LuaException("No package in packager");
+  public final void setHeldAddress(String newAddress) throws LuaException {
+    ItemStack stack = getHeldStack();
+    
     PackageItem.addAddress(stack, newAddress);
   }
 
   @LuaFunction
-  public final String getAddress() throws LuaException {
+  public final int getHeldOrderID() throws LuaException {
+    ItemStack stack = getHeldStack();
+    
+    return PackageItem.getOrderId(stack);
+  }
+
+  @LuaFunction
+  public final CreateLuaTable getHeldContext() throws LuaException {
+    return getHeldContextTable(getHeldStack());
+  }
+
+  @LuaFunction
+  public final CreateLuaTable getHeldItems() throws LuaException {
+    ItemStack stack = getHeldStack();
+    
+    return fromCompoundTag(PackageItem.getContents(stack).serializeNBT());
+  }
+
+  protected static CreateLuaTable getHeldContextTable(ItemStack stack) {
+    PackageOrderWithCrafts context = PackageItem.getOrderContext(stack);
+    if (context == null)
+      return new CreateLuaTable();
+
+    try {
+      return fromCompoundTag(context.write());
+    } catch (LuaException e) {
+      return new CreateLuaTable();
+    }
+  }
+  
+  protected static CreateLuaTable getHeldItemsTable(ItemStack stack) {
+    try {
+      return fromCompoundTag(PackageItem.getContents(stack).serializeNBT());
+    } catch (LuaException e) {
+      return new CreateLuaTable();
+    }
+  }
+
+  // return Address, OrderID, Items, Context as a list
+  public static List<Object> getPackageItemDetails(ItemStack stack) {
+    return List.of(PackageItem.getAddress(stack), PackageItem.getOrderId(stack), getHeldItemsTable(stack), getHeldContextTable(stack));
+  }
+
+  protected final ItemStack getHeldStack() throws LuaException {
     ItemStack stack = this.blockEntity.inventory.getStackInSlot(1);
     if (stack.isEmpty())
       throw new LuaException("No package in packager");
-    return PackageItem.getAddress(stack);
+    return stack;
+  }
+  
+  public static void registerItemDetailProviders() {
+    VanillaDetailRegistries.ITEM_STACK.addProvider((out, stack) -> {
+      if (!PackageItem.isPackage(stack))
+        return;
+      
+      List<Object> details = getPackageItemDetails(stack);
+      out.put("address", details.get(0));
+      out.put("orderID", details.get(1));
+      out.put("items", details.get(2));
+      out.put("orderContext", details.get(3));
+    });
   }
 
-  
 	@NotNull
 	@Override
 	public String getType() {

--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/PackagerPeripheral.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/PackagerPeripheral.java
@@ -1,0 +1,41 @@
+package com.simibubi.create.compat.computercraft.implementation.peripherals;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.simibubi.create.content.logistics.packager.PackagerBlockEntity;
+
+import dan200.computercraft.api.lua.LuaException;
+import dan200.computercraft.api.lua.LuaFunction;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.item.ItemStack;
+
+public class PackagerPeripheral extends SyncedPeripheral<PackagerBlockEntity> {
+
+  public PackagerPeripheral(PackagerBlockEntity blockEntity) {
+    super(blockEntity);
+  }
+
+  @LuaFunction(mainThread = true)
+  public final void setAddress(String newAddress) throws LuaException {
+    ItemStack stack = this.blockEntity.inventory.getStackInSlot(1);
+    CompoundTag tags = stack.getTag();
+    tags.putString("Address", newAddress);
+  }
+
+  @LuaFunction
+  public final String getAddress() throws LuaException {
+    ItemStack stack = this.blockEntity.inventory.getStackInSlot(1);
+    if (stack.isEmpty())
+      throw new LuaException("no package in packager");
+    CompoundTag tags = stack.getTag();
+    // Get the address Tag
+    return tags.getString("Address");
+  }
+
+  
+	@NotNull
+	@Override
+	public String getType() {
+		return "Create_Packager";
+	}
+}

--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/PackagerPeripheral.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/PackagerPeripheral.java
@@ -12,12 +12,20 @@ import com.simibubi.create.content.logistics.stockTicker.PackageOrderWithCrafts;
 import dan200.computercraft.api.lua.LuaException;
 import dan200.computercraft.api.lua.LuaFunction;
 import dan200.computercraft.api.detail.VanillaDetailRegistries;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.item.ItemStack;
 
 public class PackagerPeripheral extends SyncedPeripheral<PackagerBlockEntity> {
 
   public PackagerPeripheral(PackagerBlockEntity blockEntity) {
     super(blockEntity);
+  }
+
+  protected final ItemStack getHeldStack() throws LuaException {
+    ItemStack stack = this.blockEntity.inventory.getStackInSlot(1);
+    if (stack.isEmpty())
+      throw new LuaException("No package in packager");
+    return stack;
   }
 
   @LuaFunction
@@ -48,9 +56,7 @@ public class PackagerPeripheral extends SyncedPeripheral<PackagerBlockEntity> {
 
   @LuaFunction
   public final CreateLuaTable getHeldItems() throws LuaException {
-    ItemStack stack = getHeldStack();
-    
-    return fromCompoundTag(PackageItem.getContents(stack).serializeNBT());
+    return getHeldItemsTable(getHeldStack());
   }
 
   protected static CreateLuaTable getHeldContextTable(ItemStack stack) {
@@ -67,7 +73,7 @@ public class PackagerPeripheral extends SyncedPeripheral<PackagerBlockEntity> {
   
   protected static CreateLuaTable getHeldItemsTable(ItemStack stack) {
     try {
-      return fromCompoundTag(PackageItem.getContents(stack).serializeNBT());
+      return fromCompoundTag(PackageItem.getContents(stack).serializeNBT()).getTable("items");
     } catch (LuaException e) {
       return new CreateLuaTable();
     }
@@ -77,13 +83,6 @@ public class PackagerPeripheral extends SyncedPeripheral<PackagerBlockEntity> {
   public static List<Object> getPackageItemDetails(ItemStack stack) {
     return List.of(PackageItem.getAddress(stack), PackageItem.getOrderId(stack), getHeldItemsTable(stack), getHeldContextTable(stack));
   }
-
-  protected final ItemStack getHeldStack() throws LuaException {
-    ItemStack stack = this.blockEntity.inventory.getStackInSlot(1);
-    if (stack.isEmpty())
-      throw new LuaException("No package in packager");
-    return stack;
-  }
   
   public static void registerItemDetailProviders() {
     VanillaDetailRegistries.ITEM_STACK.addProvider((out, stack) -> {
@@ -91,10 +90,10 @@ public class PackagerPeripheral extends SyncedPeripheral<PackagerBlockEntity> {
         return;
       
       List<Object> details = getPackageItemDetails(stack);
-      out.put("address", details.get(0));
-      out.put("orderID", details.get(1));
-      out.put("items", details.get(2));
-      out.put("orderContext", details.get(3));
+      out.put("package_address", details.get(0));
+      out.put("package_orderID", details.get(1));
+      out.put("package_items", details.get(2));
+      out.put("package_orderContext", details.get(3));
     });
   }
 

--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/PackagerPeripheral.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/PackagerPeripheral.java
@@ -2,11 +2,11 @@ package com.simibubi.create.compat.computercraft.implementation.peripherals;
 
 import org.jetbrains.annotations.NotNull;
 
+import com.simibubi.create.content.logistics.box.PackageItem;
 import com.simibubi.create.content.logistics.packager.PackagerBlockEntity;
 
 import dan200.computercraft.api.lua.LuaException;
 import dan200.computercraft.api.lua.LuaFunction;
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.item.ItemStack;
 
 public class PackagerPeripheral extends SyncedPeripheral<PackagerBlockEntity> {
@@ -18,18 +18,17 @@ public class PackagerPeripheral extends SyncedPeripheral<PackagerBlockEntity> {
   @LuaFunction(mainThread = true)
   public final void setAddress(String newAddress) throws LuaException {
     ItemStack stack = this.blockEntity.inventory.getStackInSlot(1);
-    CompoundTag tags = stack.getTag();
-    tags.putString("Address", newAddress);
+    if (stack.isEmpty())
+      throw new LuaException("No package in packager");
+    PackageItem.addAddress(stack, newAddress);
   }
 
   @LuaFunction
   public final String getAddress() throws LuaException {
     ItemStack stack = this.blockEntity.inventory.getStackInSlot(1);
     if (stack.isEmpty())
-      throw new LuaException("no package in packager");
-    CompoundTag tags = stack.getTag();
-    // Get the address Tag
-    return tags.getString("Address");
+      throw new LuaException("No package in packager");
+    return PackageItem.getAddress(stack);
   }
 
   

--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/StationPeripheral.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/StationPeripheral.java
@@ -13,20 +13,10 @@ import com.simibubi.create.content.trains.schedule.Schedule;
 import com.simibubi.create.content.trains.station.GlobalStation;
 import com.simibubi.create.content.trains.station.StationBlockEntity;
 import com.simibubi.create.content.trains.station.TrainEditPacket;
-import com.simibubi.create.foundation.utility.StringHelper;
 
 import dan200.computercraft.api.lua.IArguments;
 import dan200.computercraft.api.lua.LuaException;
 import dan200.computercraft.api.lua.LuaFunction;
-import net.minecraft.nbt.ByteTag;
-import net.minecraft.nbt.CollectionTag;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.DoubleTag;
-import net.minecraft.nbt.IntTag;
-import net.minecraft.nbt.ListTag;
-import net.minecraft.nbt.NumericTag;
-import net.minecraft.nbt.StringTag;
-import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
 
 import net.minecraftforge.network.PacketDistributor;
@@ -175,98 +165,6 @@ public class StationPeripheral extends SyncedPeripheral<StationBlockEntity> {
 			throw new LuaException("there is no train present");
 
 		return train;
-	}
-
-	private static @NotNull CreateLuaTable fromCompoundTag(CompoundTag tag) throws LuaException {
-		return (CreateLuaTable) fromNBTTag(null, tag);
-	}
-
-	private static @NotNull Object fromNBTTag(@Nullable String key, Tag tag) throws LuaException {
-		byte type = tag.getId();
-
-		if (type == Tag.TAG_BYTE && key != null && key.equals("Count"))
-			return ((NumericTag) tag).getAsByte();
-		else if (type == Tag.TAG_BYTE)
-			return ((NumericTag) tag).getAsByte() != 0;
-		else if (type == Tag.TAG_SHORT || type == Tag.TAG_INT || type == Tag.TAG_LONG)
-			return ((NumericTag) tag).getAsLong();
-		else if (type == Tag.TAG_FLOAT || type == Tag.TAG_DOUBLE)
-			return ((NumericTag) tag).getAsDouble();
-		else if (type == Tag.TAG_STRING)
-			return tag.getAsString();
-		else if (type == Tag.TAG_LIST || type == Tag.TAG_BYTE_ARRAY || type == Tag.TAG_INT_ARRAY || type == Tag.TAG_LONG_ARRAY) {
-			CreateLuaTable list = new CreateLuaTable();
-			CollectionTag<?> listTag = (CollectionTag<?>) tag;
-
-			for (int i = 0; i < listTag.size(); i++) {
-				list.put(i + 1, fromNBTTag(null, listTag.get(i)));
-			}
-
-			return list;
-
-		} else if (type == Tag.TAG_COMPOUND) {
-			CreateLuaTable table = new CreateLuaTable();
-			CompoundTag compoundTag = (CompoundTag) tag;
-
-			for (String compoundKey : compoundTag.getAllKeys()) {
-				table.put(
-					StringHelper.camelCaseToSnakeCase(compoundKey),
-					fromNBTTag(compoundKey, compoundTag.get(compoundKey))
-				);
-			}
-
-			return table;
-		}
-
-		throw new LuaException("unknown tag type " + tag.getType().getName());
-	}
-
-	private static @NotNull CompoundTag toCompoundTag(CreateLuaTable table) throws LuaException {
-		return (CompoundTag) toNBTTag(null, table.getMap());
-	}
-
-	private static @NotNull Tag toNBTTag(@Nullable String key, Object value) throws LuaException {
-		if (value instanceof Boolean v)
-			return ByteTag.valueOf(v);
-		else if (value instanceof Byte || (key != null && key.equals("count")))
-			return ByteTag.valueOf(((Number) value).byteValue());
-		else if (value instanceof Number v) {
-			// If number is numerical integer
-			if (v.intValue() == v.doubleValue())
-				return IntTag.valueOf(v.intValue());
-			else
-				return DoubleTag.valueOf(v.doubleValue());
-
-		} else if (value instanceof String v)
-			return StringTag.valueOf(v);
-		else if (value instanceof Map<?, ?> v && v.containsKey(1.0)) { // List
-			ListTag list = new ListTag();
-			for (double i = 1; i <= v.size(); i++) {
-				if (v.get(i) != null)
-					list.add(toNBTTag(null, v.get(i)));
-			}
-
-			return list;
-
-		} else if (value instanceof Map<?, ?> v) { // Table/Map
-			CompoundTag compound = new CompoundTag();
-			for (Object objectKey : v.keySet()) {
-				if (!(objectKey instanceof String compoundKey))
-					throw new LuaException("table key is not of type string");
-
-				compound.put(
-					// Items serialize their resource location as "id" and not as "Id".
-					// This check is needed to see if the 'i' should be left lowercase or not.
-					// Items store "count" in the same compound tag, so we can check for its presence to see if this is a serialized item
-					compoundKey.equals("id") && v.containsKey("count") ? "id" : StringHelper.snakeCaseToCamelCase(compoundKey),
-					toNBTTag(compoundKey, v.get(compoundKey))
-				);
-			}
-
-			return compound;
-		}
-
-		throw new LuaException("unknown object type " + value.getClass().getName());
 	}
 
 	@NotNull

--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/SyncedPeripheral.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/SyncedPeripheral.java
@@ -58,7 +58,11 @@ public abstract class SyncedPeripheral<T extends SmartBlockEntity> implements IP
   
 	public void sendEvent(String eventName, Object... args) {
 		for (IComputerAccess computer : computerAccesses) {
-			computer.queueEvent(eventName, args);
+			String side = computer.getAttachmentName();
+      Object[] fullArgs = new Object[args.length + 1];
+      fullArgs[0] = side;
+      System.arraycopy(args, 0, fullArgs, 1, args.length);
+      computer.queueEvent(eventName, fullArgs);
 		}
 	}
 

--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/SyncedPeripheral.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/SyncedPeripheral.java
@@ -1,5 +1,6 @@
 package com.simibubi.create.compat.computercraft.implementation.peripherals;
 
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -9,10 +10,22 @@ import org.jetbrains.annotations.Nullable;
 import com.simibubi.create.AllPackets;
 import com.simibubi.create.compat.computercraft.AttachedComputerPacket;
 import com.simibubi.create.compat.computercraft.implementation.ComputerBehaviour;
+import com.simibubi.create.compat.computercraft.implementation.CreateLuaTable;
 import com.simibubi.create.foundation.blockEntity.SmartBlockEntity;
+import com.simibubi.create.foundation.utility.StringHelper;
 
+import dan200.computercraft.api.lua.LuaException;
 import dan200.computercraft.api.peripheral.IComputerAccess;
 import dan200.computercraft.api.peripheral.IPeripheral;
+import net.minecraft.nbt.ByteTag;
+import net.minecraft.nbt.CollectionTag;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.DoubleTag;
+import net.minecraft.nbt.IntTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.NumericTag;
+import net.minecraft.nbt.StringTag;
+import net.minecraft.nbt.Tag;
 import net.minecraftforge.network.PacketDistributor;
 
 public abstract class SyncedPeripheral<T extends SmartBlockEntity> implements IPeripheral {
@@ -52,6 +65,98 @@ public abstract class SyncedPeripheral<T extends SmartBlockEntity> implements IP
 	@Override
 	public boolean equals(@Nullable IPeripheral other) {
 		return this == other;
+	}
+
+	protected static @NotNull CreateLuaTable fromCompoundTag(CompoundTag tag) throws LuaException {
+		return (CreateLuaTable) fromNBTTag(null, tag);
+	}
+
+	protected static @NotNull Object fromNBTTag(@Nullable String key, Tag tag) throws LuaException {
+		byte type = tag.getId();
+
+		if (type == Tag.TAG_BYTE && key != null && key.equals("Count"))
+			return ((NumericTag) tag).getAsByte();
+		else if (type == Tag.TAG_BYTE)
+			return ((NumericTag) tag).getAsByte() != 0;
+		else if (type == Tag.TAG_SHORT || type == Tag.TAG_INT || type == Tag.TAG_LONG)
+			return ((NumericTag) tag).getAsLong();
+		else if (type == Tag.TAG_FLOAT || type == Tag.TAG_DOUBLE)
+			return ((NumericTag) tag).getAsDouble();
+		else if (type == Tag.TAG_STRING)
+			return tag.getAsString();
+		else if (type == Tag.TAG_LIST || type == Tag.TAG_BYTE_ARRAY || type == Tag.TAG_INT_ARRAY || type == Tag.TAG_LONG_ARRAY) {
+			CreateLuaTable list = new CreateLuaTable();
+			CollectionTag<?> listTag = (CollectionTag<?>) tag;
+
+			for (int i = 0; i < listTag.size(); i++) {
+				list.put(i + 1, fromNBTTag(null, listTag.get(i)));
+			}
+
+			return list;
+
+		} else if (type == Tag.TAG_COMPOUND) {
+			CreateLuaTable table = new CreateLuaTable();
+			CompoundTag compoundTag = (CompoundTag) tag;
+
+			for (String compoundKey : compoundTag.getAllKeys()) {
+				table.put(
+					StringHelper.camelCaseToSnakeCase(compoundKey),
+					fromNBTTag(compoundKey, compoundTag.get(compoundKey))
+				);
+			}
+
+			return table;
+		}
+
+		throw new LuaException("unknown tag type " + tag.getType().getName());
+	}
+
+	protected static @NotNull CompoundTag toCompoundTag(CreateLuaTable table) throws LuaException {
+		return (CompoundTag) toNBTTag(null, table.getMap());
+	}
+
+	protected static @NotNull Tag toNBTTag(@Nullable String key, Object value) throws LuaException {
+		if (value instanceof Boolean v)
+			return ByteTag.valueOf(v);
+		else if (value instanceof Byte || (key != null && key.equals("count")))
+			return ByteTag.valueOf(((Number) value).byteValue());
+		else if (value instanceof Number v) {
+			// If number is numerical integer
+			if (v.intValue() == v.doubleValue())
+				return IntTag.valueOf(v.intValue());
+			else
+				return DoubleTag.valueOf(v.doubleValue());
+
+		} else if (value instanceof String v)
+			return StringTag.valueOf(v);
+		else if (value instanceof Map<?, ?> v && v.containsKey(1.0)) { // List
+			ListTag list = new ListTag();
+			for (double i = 1; i <= v.size(); i++) {
+				if (v.get(i) != null)
+					list.add(toNBTTag(null, v.get(i)));
+			}
+
+			return list;
+
+		} else if (value instanceof Map<?, ?> v) { // Table/Map
+			CompoundTag compound = new CompoundTag();
+			for (Object objectKey : v.keySet()) {
+				if (!(objectKey instanceof String compoundKey))
+					throw new LuaException("table key is not of type string");
+
+				compound.put(
+					// Items serialize their resource location as "id" and not as "Id".
+					// This check is needed to see if the 'i' should be left lowercase or not.
+					// Items store "count" in the same compound tag, so we can check for its presence to see if this is a serialized item
+					compoundKey.equals("id") && v.containsKey("count") ? "id" : StringHelper.snakeCaseToCamelCase(compoundKey),
+					toNBTTag(compoundKey, v.get(compoundKey))
+				);
+			}
+
+			return compound;
+		}
+
+		throw new LuaException("unknown object type " + value.getClass().getName());
 	}
 
 }

--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/SyncedPeripheral.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/SyncedPeripheral.java
@@ -1,6 +1,7 @@
 package com.simibubi.create.compat.computercraft.implementation.peripherals;
 
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -17,7 +18,7 @@ import net.minecraftforge.network.PacketDistributor;
 public abstract class SyncedPeripheral<T extends SmartBlockEntity> implements IPeripheral {
 
 	protected final T blockEntity;
-	private final AtomicInteger computers = new AtomicInteger();
+	private final Set<IComputerAccess> computerAccesses = ConcurrentHashMap.newKeySet();
 
 	public SyncedPeripheral(T blockEntity) {
 		this.blockEntity = blockEntity;
@@ -25,21 +26,27 @@ public abstract class SyncedPeripheral<T extends SmartBlockEntity> implements IP
 
 	@Override
 	public void attach(@NotNull IComputerAccess computer) {
-		computers.incrementAndGet();
+		computerAccesses.add(computer);
 		updateBlockEntity();
 	}
 
 	@Override
 	public void detach(@NotNull IComputerAccess computer) {
-		computers.decrementAndGet();
+		computerAccesses.remove(computer);
 		updateBlockEntity();
 	}
 
 	private void updateBlockEntity() {
-		boolean hasAttachedComputer = computers.get() > 0;
+		boolean hasAttachedComputer = computerAccesses.size() > 0;
 
 		blockEntity.getBehaviour(ComputerBehaviour.TYPE).setHasAttachedComputer(hasAttachedComputer);
 		AllPackets.getChannel().send(PacketDistributor.ALL.noArg(), new AttachedComputerPacket(blockEntity.getBlockPos(), hasAttachedComputer));
+	}
+  
+	public void sendEvent(String eventName, Object... args) {
+		for (IComputerAccess computer : computerAccesses) {
+			computer.queueEvent(eventName, args);
+		}
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/logistics/packager/PackagerBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/packager/PackagerBlockEntity.java
@@ -7,12 +7,15 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import com.simibubi.create.AllBlocks;
 import com.simibubi.create.AllSoundEvents;
 import com.simibubi.create.Create;
 import com.simibubi.create.api.packager.unpacking.UnpackingHandler;
+import com.simibubi.create.compat.computercraft.AbstractComputerBehaviour;
+import com.simibubi.create.compat.computercraft.ComputerCraftProxy;
 import com.simibubi.create.content.contraptions.actors.psi.PortableStorageInterfaceBlockEntity;
 import com.simibubi.create.content.logistics.BigItemStack;
 import com.simibubi.create.content.logistics.box.PackageItem;
@@ -85,6 +88,8 @@ public class PackagerBlockEntity extends SmartBlockEntity {
 
 	private AdvancementBehaviour advancements;
 
+	public AbstractComputerBehaviour computerBehaviour;
+  
 	//
 
 	public PackagerBlockEntity(BlockEntityType<?> typeIn, BlockPos pos, BlockState state) {
@@ -108,6 +113,7 @@ public class PackagerBlockEntity extends SmartBlockEntity {
 			.withFilter(this::supportsBlockEntity));
 		behaviours.add(invVersionTracker = new VersionedInventoryTrackerBehaviour(this));
 		behaviours.add(advancements = new AdvancementBehaviour(this, AllAdvancements.PACKAGER));
+		behaviours.add(computerBehaviour = ComputerCraftProxy.behaviour(this));
 	}
 
 	private boolean supportsBlockEntity(BlockEntity target) {
@@ -584,11 +590,20 @@ public class PackagerBlockEntity extends SmartBlockEntity {
 		queuedExitingPackages.clear();
 	}
 
+	@NotNull
 	@Override
-	public <T> LazyOptional<T> getCapability(Capability<T> cap, Direction side) {
+	public <T> LazyOptional<T> getCapability(@NotNull Capability<T> cap, @Nullable Direction side) {
 		if (cap == ForgeCapabilities.ITEM_HANDLER)
 			return invProvider.cast();
+		if (computerBehaviour.isPeripheralCap(cap))
+			return computerBehaviour.getPeripheralCapability();
 		return super.getCapability(cap, side);
+	}
+
+	@Override
+	public void invalidateCaps() {
+		super.invalidateCaps();
+		computerBehaviour.removePeripheral();
 	}
 
 	public float getTrayOffset(float partialTicks) {

--- a/src/main/java/com/simibubi/create/content/logistics/packager/PackagerBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/packager/PackagerBlockEntity.java
@@ -16,6 +16,7 @@ import com.simibubi.create.Create;
 import com.simibubi.create.api.packager.unpacking.UnpackingHandler;
 import com.simibubi.create.compat.computercraft.AbstractComputerBehaviour;
 import com.simibubi.create.compat.computercraft.ComputerCraftProxy;
+import com.simibubi.create.compat.computercraft.implementation.peripherals.PackagerPeripheral;
 import com.simibubi.create.content.contraptions.actors.psi.PortableStorageInterfaceBlockEntity;
 import com.simibubi.create.content.logistics.BigItemStack;
 import com.simibubi.create.content.logistics.box.PackageItem;
@@ -139,6 +140,8 @@ public class PackagerBlockEntity extends SmartBlockEntity {
 			if (!level.isClientSide() && !queuedExitingPackages.isEmpty() && heldBox.isEmpty()) {
 				BigItemStack entry = queuedExitingPackages.get(0);
 				heldBox = entry.stack.copy();
+        computerBehaviour.sendEvent("Create_Packager_Send", PackageItem.getAddress(heldBox));
+        
 				
 				entry.count--;
 				if (entry.count <= 0)
@@ -358,6 +361,9 @@ public class PackagerBlockEntity extends SmartBlockEntity {
 
 		if (unpacked && !simulate) {
 			previouslyUnwrapped = box;
+
+      computerBehaviour.sendEvent("Create_Packager_Receive", PackageItem.getAddress(box));
+      
 			animationInward = true;
 			animationTicks = CYCLE;
 			notifyUpdate();
@@ -499,6 +505,7 @@ public class PackagerBlockEntity extends SmartBlockEntity {
 		}
 
 		heldBox = createdBox;
+    computerBehaviour.sendEvent("Create_Packager_Send", PackageItem.getAddress(heldBox));
 		animationInward = false;
 		animationTicks = CYCLE;
 

--- a/src/main/java/com/simibubi/create/content/logistics/packager/PackagerBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/packager/PackagerBlockEntity.java
@@ -48,6 +48,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
+import net.minecraft.server.packs.repository.Pack;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.util.Mth;
@@ -140,8 +141,9 @@ public class PackagerBlockEntity extends SmartBlockEntity {
 			if (!level.isClientSide() && !queuedExitingPackages.isEmpty() && heldBox.isEmpty()) {
 				BigItemStack entry = queuedExitingPackages.get(0);
 				heldBox = entry.stack.copy();
-        computerBehaviour.sendEvent("Create_Packager_Send", PackageItem.getAddress(heldBox));
-        
+
+        List<Object> details = PackagerPeripheral.getPackageItemDetails(heldBox);
+        computerBehaviour.sendEvent("Create_Packager_Holding_Package", details.get(0), details.get(1), details.get(2), details.get(3));
 				
 				entry.count--;
 				if (entry.count <= 0)
@@ -362,7 +364,8 @@ public class PackagerBlockEntity extends SmartBlockEntity {
 		if (unpacked && !simulate) {
 			previouslyUnwrapped = box;
 
-      computerBehaviour.sendEvent("Create_Packager_Receive", PackageItem.getAddress(box));
+      List<Object> details = PackagerPeripheral.getPackageItemDetails(heldBox);
+      computerBehaviour.sendEvent("Create_Packager_Receive", details.get(0), details.get(1), details.get(2), details.get(3));
       
 			animationInward = true;
 			animationTicks = CYCLE;
@@ -505,8 +508,11 @@ public class PackagerBlockEntity extends SmartBlockEntity {
 		}
 
 		heldBox = createdBox;
-    computerBehaviour.sendEvent("Create_Packager_Send", PackageItem.getAddress(heldBox));
-		animationInward = false;
+
+    List<Object> details = PackagerPeripheral.getPackageItemDetails(heldBox);
+    computerBehaviour.sendEvent("Create_Packager_Holding_Package", details.get(0), details.get(1), details.get(2), details.get(3));
+		
+    animationInward = false;
 		animationTicks = CYCLE;
 
 		advancements.awardPlayer(AllAdvancements.PACKAGER);

--- a/src/main/java/com/simibubi/create/content/logistics/packager/PackagerBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/packager/PackagerBlockEntity.java
@@ -364,7 +364,7 @@ public class PackagerBlockEntity extends SmartBlockEntity {
 		if (unpacked && !simulate) {
 			previouslyUnwrapped = box;
 
-      List<Object> details = PackagerPeripheral.getPackageItemDetails(heldBox);
+      List<Object> details = PackagerPeripheral.getPackageItemDetails(box);
       computerBehaviour.sendEvent("Create_Packager_Receive", details.get(0), details.get(1), details.get(2), details.get(3));
       
 			animationInward = true;

--- a/wiki/Lua-Packager-Items.md
+++ b/wiki/Lua-Packager-Items.md
@@ -1,0 +1,8 @@
+The package item list is represented by a table in Lua. The table contains a list of the item stacks in the package.
+
+```lua
+items = { -- List of item stacks in the package
+  { id = "minecraft:oak_log",    count = 24, slot = 0 },
+  { id = "minecraft:oak_planks", count = 12, slot = 1 },
+}
+```

--- a/wiki/Lua-Packager-Order-Context.md
+++ b/wiki/Lua-Packager-Order-Context.md
@@ -1,0 +1,91 @@
+This table contains the data for the order of a package. If it returns an empty table then the package context was not in this package it is in another package with the same order ID. The order context is used to determine what items are needed for the order and how many crafts of each recipe there are.
+
+```lua
+orderContext = {
+  ordered_crafts = {
+    { -- Requests 5 Oak Fences
+      pattern = {
+        entries = { -- Each entry represents a slot in the crafting grid
+          {
+            item = {
+              count = 1, -- Items required for the recipe in this slot
+              id = "minecraft:oak_planks", -- Registry name of required item
+            },
+            amount = 1, -- Always 1
+          },
+          { item = { count = 1, id = "minecraft:stick" }, amount = 1 },
+          { item = { count = 1, id = "minecraft:oak_planks" }, amount = 1 },
+          { item = { count = 1, id = "minecraft:oak_planks" }, amount = 1 },
+          { item = { count = 1, id = "minecraft:stick" }, amount = 1 },
+          { item = { count = 1, id = "minecraft:oak_planks" }, amount = 1 },
+          { item = { count = 1, id = "minecraft:air" }, amount = 1 },
+          { item = { count = 1, id = "minecraft:air" }, amount = 1 },
+          { item = { count = 1, id = "minecraft:air" }, amount = 1 },
+        },
+      },
+      count = 5,
+    },
+    { -- Requests 4 Oak Doors
+      pattern = {
+        entries = {
+          { item = { count = 1, id = "minecraft:oak_planks" }, amount = 1 },
+          { item = { count = 1, id = "minecraft:oak_planks" }, amount = 1 },
+          { item = { count = 1, id = "minecraft:air"        }, amount = 1 },
+          { item = { count = 1, id = "minecraft:oak_planks" }, amount = 1 },
+          { item = { count = 1, id = "minecraft:oak_planks" }, amount = 1 },
+          { item = { count = 1, id = "minecraft:air"        }, amount = 1 },
+          { item = { count = 1, id = "minecraft:oak_planks" }, amount = 1 },
+          { item = { count = 1, id = "minecraft:oak_planks" }, amount = 1 },
+          { item = { count = 1, id = "minecraft:air"        }, amount = 1 },
+        },
+      },
+      count = 4,
+    },
+  },
+  ordered_stacks = {
+    entries = { -- Required items for the order
+      {
+        item = {
+          count = 1, -- Should be 1 for each item type
+          id = "minecraft:oak_planks",
+        },
+        amount = 44, -- Total count needed for the order
+      },
+      {
+        item = {
+          count = 1,
+          id = "minecraft:stick",
+        },
+        amount = 10,
+      },
+    },
+  },
+}
+```
+
+---
+## Order Context
+
+| Field            | Description                |
+|------------------|----------------------------|
+| `ordered_crafts` | Lists crafting entries     |
+| `ordered_stacks` | Order required item counts |
+
+### `ordered_crafts`
+List of crafting entries
+
+Each entry:
+- `pattern.entries` (table list): Slots in the crafting grid. Will be empty if not a crafting request.
+  - Each entry:
+    - `item.id` (`string`): Registry name of required item.
+    - `item.count` (`number`): Items required for the recipe in this slot (usually 1).
+    - `amount` (`number`): Always 1.
+- `count` (`number`): Number of recipe crafts to perform.
+
+### `ordered_stacks`
+Order required item counts
+
+- `entries` (table list): each entry:
+  - `item.id` (`string`): Registry name of required item.
+  - `item.count` (`number`): Always 1.
+  - `amount` (`number`): Total count of items needed for order.

--- a/wiki/Lua-Packager.md
+++ b/wiki/Lua-Packager.md
@@ -1,0 +1,105 @@
+## Methods
+
+| Method                                               | Description                                               |
+|------------------------------------------------------|-----------------------------------------------------------|
+| [`getHeldAddress()`](#getheldaddress)                | Gets the address of the held package.                     |
+| [`setHeldAddress(address)`](#setheldaddressaddress)  | Sets the address of the held package.                     |
+| [`getHeldOrderID()`](#getheldorderid)                | Gets the order ID of the held package.                    |
+| [`getHeldItems()`](#gethelditems)                    | Gets the table of item stacks in the held package.        |
+| [`getHeldContext()`](#getheldcontext)                | Gets the table of the order context for the held package. |
+
+---
+### `getHeldAddress()`
+Gets the address of the package that is about to be taken out of it's inventory.
+
+**Returns**
+- `string`: The address of the held package.
+
+**Throws**
+- If no package is currently held.
+
+---
+### `setHeldAddress(address)`
+Sets the address of the package that is about to be taken out of it's inventory. Even if the address is changed repackaging will still combine them. The resulting address will be the same as the last package address.
+
+**Parameters**
+- `address` (`string`): The address of the package to hold.
+
+**Throws**
+- If no package is currently held.
+
+---
+### `getHeldOrderID()`
+Gets the ID of the order. Requests that are split into multiple packages will have the same order ID. If the order ID isn't set it will return -1.
+
+**Returns**
+- `number` The order ID 
+
+**Throws**
+- If no package is currently held.
+
+---
+### `getHeldItems()`
+Gets the Lua table of item stacks in the held package.
+
+**Returns**
+- `table` The items in the held package.
+
+**Throws**
+- If no package is currently held.
+
+**See also**
+- [Lua Package Items](#Lua-Packager-Items) How package items are represented in Lua.
+
+---
+### `getHeldContext()`
+Gets a Lua table of the order context stored in the held package. If empty then the package context is in another package with the same order ID. The order context is used to determine what items are needed for the order and how many crafts of each recipe there are.
+
+**Returns**
+- `table`: The order context table.
+
+**Throws**
+- If no package is currently held.
+
+**See also**
+- [Lua Order Context](#Lua-Packager-Order-Context) How order context is represented in Lua.
+
+
+---
+## Events
+
+| Event                                                  | Description                                                           |
+|--------------------------------------------------------|-----------------------------------------------------------------------|
+| [`Create_Packager_Holding_Package`](#create_packager_holding_package) | Fired when the packager is about to send out a package |
+| [`Create_Packager_Receive`](#create_packager_receive)  | Fired when a package is unpacked into it's inventory.                 |
+
+---
+### `Create_Packager_Holding_Package`
+**Arguments**
+1. `event`         (`string`)
+2. `side`          (`string`)
+3. `address`       (`string` or `nil`)
+4. `orderID`       (`number`)
+5. `items`         ([`table`](#Lua-Packager-Items))
+6. `orderContext`  ([`table`](#Lua-Packager-Order-Context))
+
+---
+### `Create_Packager_Receive`
+**Arguments**
+1. `event`         (`string`)
+2. `side`          (`string`)
+3. `address`       (`string` or `nil`)
+4. `orderID`       (`number`)
+5. `items`         ([`table`](#Lua-Packager-Items))
+6. `orderContext`  ([`table`](#Lua-Packager-Order-Context))
+
+---
+
+
+## Item Detail Provider
+
+Calling `getItemDetails` On a package will include the following extra information about the package.
+- `package_address`       (`string` or `nil`)
+- `package_orderID`       (`number`)
+- `package_items`         ([`table`](#Lua-Packager-Items))
+- `package_orderContext`  ([`table`](#Lua-Packager-Order-Context))

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -1,0 +1,1 @@
+Just before this PR is about to be merged this /wiki folder should be removed from the PR and the pages should be added to the wiki


### PR DESCRIPTION
### Adding integration for CC: Tweaked
- Added Packager as a peripheral
- Added ways to get a Package's Address, OrderID, Items, and OrderContext through Packager events and getItemDetails
- A Package's Address can be changed with a computer
- Packagers will send events when sending and receiving packages

Documentation for the added peripherals is [here](https://github.com/MaxOrtGit/Create/tree/ComputerCraftFor0.6/wiki)

### Implementation Updates
- You can now send Events through `SyncedPeripheral`s 
- Changed `SyncedPeripheral` from using a counter to a set of `IComputerAccess`s
- Moved toNBTTag/fromNBTTag from `StationPeripheral` to `SyncedPeripheral`
- Added Event pushes on receive/send to `PackagerBlockEntity`
