### PR TITLE
Send edge points in the same packet as their edges

### DIFF
--- a/src/main/java/com/simibubi/create/content/trains/graph/TrackGraphSync.java
+++ b/src/main/java/com/simibubi/create/content/trains/graph/TrackGraphSync.java
@@ -9,7 +9,6 @@ import java.util.UUID;
 import java.util.Map.Entry;
 
 import javax.annotation.Nullable;
-import javax.sound.midi.Track;
 
 import com.google.common.collect.ImmutableList;
 import com.simibubi.create.AllPackets;

--- a/src/main/java/com/simibubi/create/content/trains/graph/TrackGraphSync.java
+++ b/src/main/java/com/simibubi/create/content/trains/graph/TrackGraphSync.java
@@ -2,11 +2,14 @@ package com.simibubi.create.content.trains.graph;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.Map.Entry;
 
 import javax.annotation.Nullable;
+import javax.sound.midi.Track;
 
 import com.google.common.collect.ImmutableList;
 import com.simibubi.create.AllPackets;
@@ -138,6 +141,8 @@ public class TrackGraphSync {
 		packet.fullWipe = true;
 		int sent = 0;
 
+		Set<TrackEdgePoint> sentPoints = new HashSet<>();
+
 		for (TrackNode node : graph.nodes.values()) {
 			TrackGraphSyncPacket currentPacket = packet;
 			currentPacket.addedNodes.put(node.getNetId(), Pair.of(node.getLocation(), node.getNormal()));
@@ -152,12 +157,24 @@ public class TrackGraphSync {
 			TrackGraphSyncPacket currentPacket = packet;
 			if (!graph.connectionsByNode.containsKey(node))
 				continue;
-			graph.connectionsByNode.get(node)
-				.forEach((node2, edge) -> {
-					Couple<Integer> key = Couple.create(node.getNetId(), node2.getNetId());
-					currentPacket.addedEdges.add(Pair.of(Pair.of(key, edge.getTrackMaterial()), edge.getTurn()));
-					currentPacket.syncEdgeData(node, node2, edge);
-				});
+
+			for (Entry<TrackNode,TrackEdge> entry : graph.connectionsByNode.get(node).entrySet()) {
+				TrackNode node2 = entry.getKey();
+				TrackEdge edge = entry.getValue();
+
+				Couple<Integer> key = Couple.create(node.getNetId(), node2.getNetId());
+				currentPacket.addedEdges.add(Pair.of(Pair.of(key, edge.getTrackMaterial()), edge.getTurn()));
+				currentPacket.syncEdgeData(node, node2, edge);
+
+				for (TrackEdgePoint point : edge.edgeData.getPoints()) {
+					if (sentPoints.contains(point))
+						continue;
+
+					sentPoints.add(point);
+					currentPacket.addedEdgePoints.add(point);
+					sent++;
+				}
+			}
 
 			if (sent++ < 1000)
 				continue;
@@ -168,6 +185,10 @@ public class TrackGraphSync {
 
 		for (EdgePointType<?> type : EdgePointType.TYPES.values()) {
 			for (TrackEdgePoint point : graph.getPoints(type)) {
+				if (sentPoints.contains(point))
+					continue;
+
+				sentPoints.add(point);
 				packet.addedEdgePoints.add(point);
 
 				if (sent++ < 1000)


### PR DESCRIPTION
Fixes #8425 by sending an edge along with it's edge points in the same packet, so that when sending a large graph to a joining player their client doesn't delete points on edges because they don't have the point in the graph yet.