### PR TITLE
Fix belt connector consumption when not having enough shafts to split the belt

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/belt/BeltSlicer.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/BeltSlicer.java
@@ -174,7 +174,7 @@ public class BeltSlicer {
 						continue;
 					int count = itemstack.getCount();
 
-					if (AllItems.BELT_CONNECTOR.isIn(itemstack)) {
+					if (AllItems.BELT_CONNECTOR.isIn(itemstack) && !beltFound) {
 						if (!world.isClientSide)
 							itemstack.shrink(1);
 						beltFound = true;
@@ -194,7 +194,7 @@ public class BeltSlicer {
 
 				if (!world.isClientSide){
 					player.getInventory().placeItemBackInInventory(AllBlocks.SHAFT.asStack(amountRetrieved));
-					player.getInventory().placeItemBackInInventory(AllItems.BELT_CONNECTOR.asStack());
+					if (beltFound) player.getInventory().placeItemBackInInventory(AllItems.BELT_CONNECTOR.asStack());
 				}
 				return InteractionResult.FAIL;
 			}

--- a/src/main/java/com/simibubi/create/content/kinetics/belt/BeltSlicer.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/BeltSlicer.java
@@ -166,17 +166,19 @@ public class BeltSlicer {
 			Search:
 			while (true) {
 				for (int i = 0; i < player.getInventory().getContainerSize(); ++i) {
-					if (amountRetrieved == requiredShafts && beltFound)
-						break Search;
-
 					ItemStack itemstack = player.getInventory().getItem(i);
+					if (amountRetrieved == requiredShafts && beltFound) {
+						if (!world.isClientSide)
+							// decrement the previous itemstack
+							player.getInventory().getItem(i - 1).shrink(1);
+						break Search;
+					}
+
 					if (itemstack.isEmpty())
 						continue;
 					int count = itemstack.getCount();
 
 					if (AllItems.BELT_CONNECTOR.isIn(itemstack)) {
-						if (!world.isClientSide)
-							itemstack.shrink(1);
 						beltFound = true;
 						continue;
 					}

--- a/src/main/java/com/simibubi/create/content/kinetics/belt/BeltSlicer.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/BeltSlicer.java
@@ -166,19 +166,17 @@ public class BeltSlicer {
 			Search:
 			while (true) {
 				for (int i = 0; i < player.getInventory().getContainerSize(); ++i) {
-					ItemStack itemstack = player.getInventory().getItem(i);
-					if (amountRetrieved == requiredShafts && beltFound) {
-						if (!world.isClientSide)
-							// decrement the previous itemstack
-							player.getInventory().getItem(i - 1).shrink(1);
+					if (amountRetrieved == requiredShafts && beltFound)
 						break Search;
-					}
 
+					ItemStack itemstack = player.getInventory().getItem(i);
 					if (itemstack.isEmpty())
 						continue;
 					int count = itemstack.getCount();
 
 					if (AllItems.BELT_CONNECTOR.isIn(itemstack)) {
+						if (!world.isClientSide)
+							itemstack.shrink(1);
 						beltFound = true;
 						continue;
 					}
@@ -194,8 +192,10 @@ public class BeltSlicer {
 					}
 				}
 
-				if (!world.isClientSide)
+				if (!world.isClientSide){
 					player.getInventory().placeItemBackInInventory(AllBlocks.SHAFT.asStack(amountRetrieved));
+					player.getInventory().placeItemBackInInventory(AllItems.BELT_CONNECTOR.asStack());
+				}
 				return InteractionResult.FAIL;
 			}
 		}


### PR DESCRIPTION
[Related issue](https://github.com/Creators-of-Create/Create/issues/7334)
This happens when you don't have at least 2 shafts in your inventory