### PR TITLE
Add config option to prevent block dropping when contraption is replacing blocks

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/Contraption.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/Contraption.java
@@ -1168,7 +1168,9 @@ public abstract class Contraption {
 					if (targetPos.getY() == world.getMinBuildHeight())
 						targetPos = targetPos.above();
 					world.levelEvent(2001, targetPos, Block.getId(state));
-					Block.dropResources(state, world, targetPos, null);
+					if (!AllConfigs.server().kinetics.noDropWhenContraptionReplaceBlocks.get()) {
+						Block.dropResources(state, world, targetPos, null);
+					}
 					continue;
 				}
 				if (state.getBlock() instanceof SimpleWaterloggedBlock
@@ -1177,7 +1179,7 @@ public abstract class Contraption {
 					state = state.setValue(BlockStateProperties.WATERLOGGED, FluidState.getType() == Fluids.WATER);
 				}
 
-				world.destroyBlock(targetPos, true);
+				world.destroyBlock(targetPos, !AllConfigs.server().kinetics.noDropWhenContraptionReplaceBlocks.get());
 
 				if (AllBlocks.SHAFT.has(state))
 					state = ShaftBlock.pickCorrectShaftType(state, world, targetPos);
@@ -1196,7 +1198,7 @@ public abstract class Contraption {
 				if (verticalRotation) {
 					if (state.getBlock() instanceof RopeBlock || state.getBlock() instanceof MagnetBlock
 						|| state.getBlock() instanceof DoorBlock)
-						world.destroyBlock(targetPos, true);
+						world.destroyBlock(targetPos, !AllConfigs.server().kinetics.noDropWhenContraptionReplaceBlocks.get());
 				}
 
 				BlockEntity blockEntity = world.getBlockEntity(targetPos);

--- a/src/main/java/com/simibubi/create/content/contraptions/Contraption.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/Contraption.java
@@ -1142,6 +1142,8 @@ public abstract class Contraption {
 			return;
 		disassembled = true;
 
+		boolean shouldDropBlocks = !AllConfigs.server().kinetics.noDropWhenContraptionReplaceBlocks.get();
+
 		translateMultiblockControllers(transform);
 
 		for (boolean nonBrittles : Iterate.trueAndFalse) {
@@ -1168,7 +1170,7 @@ public abstract class Contraption {
 					if (targetPos.getY() == world.getMinBuildHeight())
 						targetPos = targetPos.above();
 					world.levelEvent(2001, targetPos, Block.getId(state));
-					if (!AllConfigs.server().kinetics.noDropWhenContraptionReplaceBlocks.get()) {
+					if (shouldDropBlocks) {
 						Block.dropResources(state, world, targetPos, null);
 					}
 					continue;
@@ -1179,7 +1181,7 @@ public abstract class Contraption {
 					state = state.setValue(BlockStateProperties.WATERLOGGED, FluidState.getType() == Fluids.WATER);
 				}
 
-				world.destroyBlock(targetPos, !AllConfigs.server().kinetics.noDropWhenContraptionReplaceBlocks.get());
+				world.destroyBlock(targetPos, shouldDropBlocks);
 
 				if (AllBlocks.SHAFT.has(state))
 					state = ShaftBlock.pickCorrectShaftType(state, world, targetPos);
@@ -1198,7 +1200,7 @@ public abstract class Contraption {
 				if (verticalRotation) {
 					if (state.getBlock() instanceof RopeBlock || state.getBlock() instanceof MagnetBlock
 						|| state.getBlock() instanceof DoorBlock)
-						world.destroyBlock(targetPos, !AllConfigs.server().kinetics.noDropWhenContraptionReplaceBlocks.get());
+						world.destroyBlock(targetPos, shouldDropBlocks);
 				}
 
 				BlockEntity blockEntity = world.getBlockEntity(targetPos);

--- a/src/main/java/com/simibubi/create/infrastructure/config/CKinetics.java
+++ b/src/main/java/com/simibubi/create/infrastructure/config/CKinetics.java
@@ -52,6 +52,7 @@ public class CKinetics extends ConfigBase {
 		b(false, "minecartContraptionInContainers", Comments.minecartContraptionInContainers);
 	public final ConfigBool stabiliseStableContraptions = b(false, "stabiliseStableContraptions", Comments.stabiliseStableContraptions, "[Technical]");
 	public final ConfigBool syncPlayerPickupHitboxWithContraptionHitbox = b(false, "syncPlayerPickupHitboxWithContraptionHitbox", Comments.syncPlayerPickupHitboxWithContraptionHitbox, "[Technical]");
+	public final ConfigBool noDropWhenContraptionReplaceBlocks = b(false, "noDropWhenContraptionReplaceBlocks", Comments.noDropWhenContraptionReplaceBlocks);
 
 	public final ConfigGroup stats = group(1, "stats", Comments.stats);
 	public final ConfigFloat mediumSpeed = f(30, 0, 4096, "mediumSpeed", Comments.rpm, Comments.mediumSpeed);
@@ -122,6 +123,8 @@ public class CKinetics extends ConfigBase {
 		static String minecartContraptionInContainers = "Whether minecart contraptions can be placed into container items.";
 		static String stabiliseStableContraptions = "Whether stabilised bearings create a separated entity even on non-rotating contraptions.";
 		static String syncPlayerPickupHitboxWithContraptionHitbox = "Whether the players hitbox should be expanded to the size of the contraption hitbox.";
+		static String noDropWhenContraptionReplaceBlocks = "Whether to prevent block dropping when contraption is placed inside in-world blocks.";
+
 	}
 
 	public enum DeployerAggroSetting {


### PR DESCRIPTION
Same PR for #8453 but targeting 1.20.1 branch.

---
Original PR message for reference:

This PR adds a config to allow user to control whether block drops should be spawned when the contraption disassembles. When the `noDropWhenContraptionReplaceBlocks` is `true`, contraptions will only replace in-world blocks when stopped, without adding drops. The default value is `false` to keep consistent behavior.

![image](https://github.com/user-attachments/assets/08dbe48b-9273-4f69-9491-371fc161502c)

This is a feature probably wanted by many people, so I think it would be good to have one.