### PR TITLE
bugfix: format reversed when "_" at end of line

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/item/TooltipHelper.java
+++ b/src/main/java/com/simibubi/create/foundation/item/TooltipHelper.java
@@ -124,7 +124,7 @@ public class TooltipHelper {
 		boolean currentlyHighlighted = false;
 		for (String string : lines) {
 			MutableComponent currentComponent = lineStart.plainCopy();
-			String[] split = string.split("_");
+			String[] split = string.split("_", -1);
 			for (String part : split) {
                 currentComponent.append(Component.literal(part).withStyle(styles.get(currentlyHighlighted)));
 				currentlyHighlighted = !currentlyHighlighted;


### PR DESCRIPTION
> when handling long tooltips with lots of ""s, and one "" at the end of one of splitted lines, String.split(int) trims all empty strings, making the highlight format not intended  

sry for spamming, I didn't know a pr's dead after I force-push the branch `_(:з」∠)_`