### PR TITLE
Add ComputerCraft Lua functions to retrieve train information from the station

### DIFF
--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/StationPeripheral.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/StationPeripheral.java
@@ -4,6 +4,8 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 
+import com.simibubi.create.content.trains.graph.DimensionPalette;
+
 import org.jetbrains.annotations.NotNull;
 
 import com.simibubi.create.AllPackets;
@@ -103,6 +105,20 @@ public class StationPeripheral extends SyncedPeripheral<StationBlockEntity> {
 	}
 
 	@LuaFunction
+	public final CreateLuaTable getPresentTrain() throws LuaException {
+		GlobalStation station = blockEntity.getStation();
+		if (station == null)
+			throw new LuaException("station is not connected to a track");
+
+		if (station.getPresentTrain() == null) {
+			return null;
+		}
+
+		DimensionPalette dimensions = new DimensionPalette();
+		return fromCompoundTag(station.getPresentTrain().write(dimensions));
+	}
+
+	@LuaFunction
 	public final boolean isTrainImminent() throws LuaException {
 		GlobalStation station = blockEntity.getStation();
 		if (station == null)
@@ -112,12 +128,40 @@ public class StationPeripheral extends SyncedPeripheral<StationBlockEntity> {
 	}
 
 	@LuaFunction
+	public final CreateLuaTable getImminentTrain() throws LuaException {
+		GlobalStation station = blockEntity.getStation();
+		if (station == null)
+			throw new LuaException("station is not connected to a track");
+
+		if (station.getPresentTrain() == null) {
+			return null;
+		}
+
+		DimensionPalette dimensions = new DimensionPalette();
+		return fromCompoundTag(station.getPresentTrain().write(dimensions));
+	}
+
+	@LuaFunction
 	public final boolean isTrainEnroute() throws LuaException {
 		GlobalStation station = blockEntity.getStation();
 		if (station == null)
 			throw new LuaException("station is not connected to a track");
 
 		return station.getNearestTrain() != null;
+	}
+
+	@LuaFunction
+	public final CreateLuaTable getEnrouteTrain() throws LuaException {
+		GlobalStation station = blockEntity.getStation();
+		if (station == null)
+			throw new LuaException("station is not connected to a track");
+
+		if (station.getPresentTrain() == null) {
+			return null;
+		}
+
+		DimensionPalette dimensions = new DimensionPalette();
+		return fromCompoundTag(station.getPresentTrain().write(dimensions));
 	}
 
 	@LuaFunction

--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/StationPeripheral.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/StationPeripheral.java
@@ -110,9 +110,8 @@ public class StationPeripheral extends SyncedPeripheral<StationBlockEntity> {
 		if (station == null)
 			throw new LuaException("station is not connected to a track");
 
-		if (station.getPresentTrain() == null) {
+		if (station.getPresentTrain() == null)
 			return null;
-		}
 
 		DimensionPalette dimensions = new DimensionPalette();
 		return fromCompoundTag(station.getPresentTrain().write(dimensions));
@@ -133,12 +132,11 @@ public class StationPeripheral extends SyncedPeripheral<StationBlockEntity> {
 		if (station == null)
 			throw new LuaException("station is not connected to a track");
 
-		if (station.getPresentTrain() == null) {
+		if (station.getImminentTrain() == null)
 			return null;
-		}
 
 		DimensionPalette dimensions = new DimensionPalette();
-		return fromCompoundTag(station.getPresentTrain().write(dimensions));
+		return fromCompoundTag(station.getImminentTrain().write(dimensions));
 	}
 
 	@LuaFunction
@@ -156,12 +154,11 @@ public class StationPeripheral extends SyncedPeripheral<StationBlockEntity> {
 		if (station == null)
 			throw new LuaException("station is not connected to a track");
 
-		if (station.getPresentTrain() == null) {
+		if (station.getNearestTrain() == null)
 			return null;
-		}
 
 		DimensionPalette dimensions = new DimensionPalette();
-		return fromCompoundTag(station.getPresentTrain().write(dimensions));
+		return fromCompoundTag(station.getNearestTrain().write(dimensions));
 	}
 
 	@LuaFunction


### PR DESCRIPTION
This PR adds new functions to the Train Station Peripheral including:
- `getPresentTrain()`
- `getImminentTrain()`
- `getEnrouteTrain()`

These functions returns the full train information inside a Lua table, or `nill` if a train is not found.

This would be usefull to create custom displays using CC monitors, announcements using CC's speakers, or a custom train tracking app on a Pocket Computer.

Related discussion: https://github.com/Creators-of-Create/Create/pull/7453#issuecomment-2718108459 https://github.com/Creators-of-Create/Create/pull/7453#issuecomment-2718443267 https://github.com/Creators-of-Create/Create/pull/7453#issuecomment-2718451361