### PR TITLE
Fix Self-Driving Cart achievement being very obtuse to obtain

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/deployer/DeployerHandler.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/deployer/DeployerHandler.java
@@ -319,7 +319,7 @@ public class DeployerHandler {
 		// 'Inert' item use behaviour & block placement
 		InteractionResult onItemUse = stack.useOn(itemusecontext);
 		if (onItemUse.consumesAction()) {
-			if (stack.getItem() instanceof BlockItem bi
+			if (item instanceof BlockItem bi
 				&& (bi.getBlock() instanceof IForgeBaseRailBlock || bi.getBlock() instanceof ITrackBlock))
 				player.placedTracks = true;
 			return;

--- a/src/main/java/com/simibubi/create/content/kinetics/deployer/DeployerMovementBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/deployer/DeployerMovementBehaviour.java
@@ -6,6 +6,10 @@ import java.util.UUID;
 
 import javax.annotation.Nullable;
 
+import com.simibubi.create.content.trains.track.ITrackBlock;
+
+import net.minecraftforge.common.extensions.IForgeBaseRailBlock;
+
 import org.apache.commons.lang3.tuple.Pair;
 
 import com.simibubi.create.AllBlocks;
@@ -164,7 +168,7 @@ public class DeployerMovementBehaviour implements MovementBehaviour {
 
 		if (ForgeEventFactory.onBlockPlace(player, blocksnapshot, Direction.UP))
 			blocksnapshot.restore(true, false);
-		else if (AllBlocks.TRACK.has(blockState))
+		else if (blockState.getBlock() instanceof IForgeBaseRailBlock || blockState.getBlock() instanceof ITrackBlock)
 			player.placedTracks = true;
 	}
 


### PR DESCRIPTION
Fixes #4058

The main method for setting the `placedTracks` field of a `DeployerFakePlayer` was comparing the item from the stack after using it, by which time it had become air. We were already getting the actual item (far) before calling useOn so just compare against that instead.
The method via schematic printing was very restrictive compared to the main method.