### PR TITLE
#6984 Fix Proposal

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/funnel/BeltFunnelBlock.java
+++ b/src/main/java/com/simibubi/create/content/logistics/funnel/BeltFunnelBlock.java
@@ -2,11 +2,9 @@ package com.simibubi.create.content.logistics.funnel;
 
 import com.simibubi.create.AllBlocks;
 import com.simibubi.create.AllShapes;
-import com.simibubi.create.api.schematic.requirement.SpecialBlockItemRequirement;
 import com.simibubi.create.content.kinetics.belt.BeltBlock;
 import com.simibubi.create.content.kinetics.belt.BeltSlope;
 import com.simibubi.create.content.kinetics.belt.behaviour.DirectBeltInputBehaviour;
-import com.simibubi.create.content.schematics.requirement.ItemRequirement;
 import com.simibubi.create.foundation.advancement.AllAdvancements;
 import com.simibubi.create.foundation.block.ProperWaterloggedBlock;
 import com.simibubi.create.foundation.blockEntity.behaviour.BlockEntityBehaviour;
@@ -20,6 +18,7 @@ import net.minecraft.util.StringRepresentable;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.item.context.UseOnContext;
@@ -28,7 +27,6 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition.Builder;
 import net.minecraft.world.level.block.state.properties.EnumProperty;
@@ -37,7 +35,7 @@ import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.EntityCollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
 
-public class BeltFunnelBlock extends AbstractHorizontalFunnelBlock implements SpecialBlockItemRequirement {
+public class BeltFunnelBlock extends AbstractHorizontalFunnelBlock {
 
 	private BlockEntry<? extends FunnelBlock> parent;
 
@@ -209,8 +207,8 @@ public class BeltFunnelBlock extends AbstractHorizontalFunnelBlock implements Sp
 	}
 
 	@Override
-	public ItemRequirement getRequiredItems(BlockState state, BlockEntity be) {
-		return ItemRequirement.of(parent.getDefaultState(), be);
+	public Item asItem() {
+		return this.parent.asItem();
 	}
 
 }


### PR DESCRIPTION
This changes allows for filters not to be counted twice on brass belt funnels by https://github.com/Creators-of-Create/Create/blob/55a0c577668e2e76217176bf685aeba5846dd871/src/main/java/com/simibubi/create/content/schematics/requirement/ItemRequirement.java#L69 

¿is ok to override  asItem() to make ItemRequirement.defaultOf() work properly?