### PR TITLE
BeltFunnelBlock are brittle?

### DIFF
--- a/src/main/java/com/simibubi/create/impl/contraption/BlockMovementChecksImpl.java
+++ b/src/main/java/com/simibubi/create/impl/contraption/BlockMovementChecksImpl.java
@@ -35,6 +35,7 @@ import com.simibubi.create.content.decoration.steamWhistle.WhistleExtenderBlock;
 import com.simibubi.create.content.fluids.tank.FluidTankBlock;
 import com.simibubi.create.content.kinetics.crank.HandCrankBlock;
 import com.simibubi.create.content.kinetics.fan.NozzleBlock;
+import com.simibubi.create.content.logistics.funnel.BeltFunnelBlock;
 import com.simibubi.create.content.logistics.packagerLink.PackagerLinkBlock;
 import com.simibubi.create.content.logistics.vault.ItemVaultBlock;
 import com.simibubi.create.content.redstone.link.RedstoneLinkBlock;
@@ -242,6 +243,8 @@ public class BlockMovementChecksImpl {
 		if (block instanceof WhistleBlock)
 			return true;
 		if (block instanceof WhistleExtenderBlock)
+			return true;
+		if (block instanceof BeltFunnelBlock)
 			return true;
 		return AllBlockTags.BRITTLE.matches(state);
 	}


### PR DESCRIPTION
this fixes #6985 by considering BeltFunnelBlock as brittle because their state is dependant on the existence of the belt under them. That way they are always placed after the belts.