### PR TITLE
Fix Printing Plackard

### DIFF
--- a/src/generated/resources/data/create/tags/blocks/safe_nbt.json
+++ b/src/generated/resources/data/create/tags/blocks/safe_nbt.json
@@ -20,6 +20,7 @@
     "create:brass_belt_funnel",
     "create:redstone_link",
     "create:analog_lever",
+    "create:placard",
     "create:pulse_repeater",
     "create:pulse_extender",
     "create:pulse_timer",

--- a/src/main/java/com/simibubi/create/AllBlocks.java
+++ b/src/main/java/com/simibubi/create/AllBlocks.java
@@ -2110,6 +2110,7 @@ public class AllBlocks {
 		.initialProperties(SharedProperties::copperMetal)
 		.properties(p -> p.forceSolidOn())
 		.transform(pickaxeOnly())
+		.tag(AllBlockTags.SAFE_NBT.tag)
 		.blockstate((c, p) -> p.horizontalFaceBlock(c.get(), AssetLookup.standardModel(c, p)))
 		.simpleItem()
 		.register();


### PR DESCRIPTION
Fix for #7342 (now properly done), it adds the PlacardBlock to safe_nbt tag , not sure why it was not in it. PlacardBlock.getRequiredItems requires the holding item with it's nbt data, so it should be safe for printing. Maybe there is some past issue im not aware of.