### PR TITLE
Prevent item frame transmutation

### DIFF
--- a/src/main/java/com/simibubi/create/content/schematics/requirement/ItemRequirement.java
+++ b/src/main/java/com/simibubi/create/content/schematics/requirement/ItemRequirement.java
@@ -14,6 +14,7 @@ import com.simibubi.create.api.schematic.requirement.SpecialBlockItemRequirement
 import com.simibubi.create.api.schematic.requirement.SpecialEntityItemRequirement;
 import com.simibubi.create.compat.framedblocks.FramedBlocksInSchematics;
 import com.simibubi.create.foundation.data.recipe.Mods;
+import com.simibubi.create.foundation.mixin.accessor.ItemFrameAccessor;
 
 import net.createmod.catnip.nbt.NBTProcessors;
 import net.minecraft.world.entity.Entity;
@@ -141,10 +142,10 @@ public class ItemRequirement {
 		}
 
 		if (entity instanceof ItemFrame itemFrame) {
-			ItemStack frame = new ItemStack(Items.ITEM_FRAME);
+			ItemStack frame = ((ItemFrameAccessor) itemFrame).create$getFrameItemStack();
 			ItemStack displayedItem = NBTProcessors.withUnsafeNBTDiscarded(itemFrame.getItem());
 			if (displayedItem.isEmpty())
-				return new ItemRequirement(ItemUseType.CONSUME, Items.ITEM_FRAME);
+				return new ItemRequirement(ItemUseType.CONSUME, frame);
 			return new ItemRequirement(List.of(new ItemRequirement.StackRequirement(frame, ItemUseType.CONSUME),
 				new ItemRequirement.StrictNbtStackRequirement(displayedItem, ItemUseType.CONSUME)));
 		}

--- a/src/main/java/com/simibubi/create/foundation/mixin/accessor/ItemFrameAccessor.java
+++ b/src/main/java/com/simibubi/create/foundation/mixin/accessor/ItemFrameAccessor.java
@@ -1,0 +1,13 @@
+package com.simibubi.create.foundation.mixin.accessor;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+import net.minecraft.world.entity.decoration.ItemFrame;
+import net.minecraft.world.item.ItemStack;
+
+@Mixin(ItemFrame.class)
+public interface ItemFrameAccessor {
+	@Invoker("getFrameItemStack")
+	ItemStack create$getFrameItemStack();
+}

--- a/src/main/resources/create.mixins.json
+++ b/src/main/resources/create.mixins.json
@@ -34,6 +34,7 @@
     "accessor.FlowingFluidAccessor",
     "accessor.FluidInteractionRegistryAccessor",
     "accessor.GameTestHelperAccessor",
+    "accessor.ItemFrameAccessor",
     "accessor.ItemModelGeneratorsAccessor",
     "accessor.LivingEntityAccessor",
     "accessor.MobEffectInstanceAccessor",


### PR DESCRIPTION
Fixes schematicannon consuming an item frame when printing a glow item frame. didn't find a open or close issue about it.