### PR TITLE
Allow conditions on retrieve package instruction

### DIFF
--- a/src/main/java/com/simibubi/create/content/trains/schedule/destination/FetchPackagesInstruction.java
+++ b/src/main/java/com/simibubi/create/content/trains/schedule/destination/FetchPackagesInstruction.java
@@ -93,7 +93,7 @@ public class FetchPackagesInstruction extends TextScheduleInstruction {
 
 	@Override
 	public boolean supportsConditions() {
-		return false;
+		return true;
 	}
 
 	@Override


### PR DESCRIPTION
Having zero delay for "Retrieve package" looks unusual, in my opinion. It would be nice to be able to customize this, in the same way we can for "Deliver package".

From some light testing it seems that just enabling `supportsConditions` is enough for all the usual conditions to work.

Was there a reason why this was left disabled?