### PR TITLE
Fix all recipe types to respect crafting remaining items

### DIFF
--- a/src/main/java/com/simibubi/create/content/equipment/sandPaper/SandPaperItem.java
+++ b/src/main/java/com/simibubi/create/content/equipment/sandPaper/SandPaperItem.java
@@ -142,6 +142,14 @@ public class SandPaperItem extends Item implements CustomUseEffectsItem {
 						.placeItemBackInInventory(polished);
 				}
 			}
+			if (!toPolish.isEmpty() && toPolish.hasCraftingRemainingItem()) {
+				if (player instanceof FakePlayer) {
+					player.drop(toPolish.getCraftingRemainingItem(), false, false);
+				} else {
+					player.getInventory()
+						.placeItemBackInInventory(toPolish.getCraftingRemainingItem());
+				}
+			}
 			tag.remove("Polishing");
 			stack.hurtAndBreak(1, entityLiving, p -> p.broadcastBreakEvent(p.getUsedItemHand()));
 		}

--- a/src/main/java/com/simibubi/create/content/kinetics/crusher/CrushingWheelControllerBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/crusher/CrushingWheelControllerBlockEntity.java
@@ -126,7 +126,7 @@ public class CrushingWheelControllerBlockEntity extends SmartBlockEntity {
 
 			float processingSpeed =
 				Mth.clamp((speed) / (!inventory.appliedRecipe ? (float) Math.log(inventory.getStackInSlot(0)
-					.getCount())/(float) Math.log(2) : 1), .25f, 20);
+					.getCount()) / (float) Math.log(2) : 1), .25f, 20);
 			inventory.remainingTime -= processingSpeed;
 			spawnParticles(inventory.getStackInSlot(0));
 
@@ -296,14 +296,17 @@ public class CrushingWheelControllerBlockEntity extends SmartBlockEntity {
 
 		List<ItemStack> list = new ArrayList<>();
 		if (recipe.isPresent()) {
-			int rolls = inventory.getStackInSlot(0)
-				.getCount();
+			ItemStack input = inventory.getStackInSlot(0);
+			int rolls = input.getCount();
 			inventory.clear();
 			for (int roll = 0; roll < rolls; roll++) {
 				List<ItemStack> rolledResults = recipe.get()
 					.rollResults();
 				for (ItemStack stack : rolledResults) {
 					ItemHelper.addToList(stack, list);
+				}
+				if (input.hasCraftingRemainingItem()) {
+					ItemHelper.addToList(input.getCraftingRemainingItem(), list);
 				}
 			}
 			for (int slot = 0; slot < list.size() && slot + 1 < inventory.getSlots(); slot++)

--- a/src/main/java/com/simibubi/create/content/kinetics/deployer/BeltDeployerCallbacks.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/deployer/BeltDeployerCallbacks.java
@@ -25,6 +25,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.level.Level;
@@ -135,11 +136,23 @@ public class BeltDeployerCallbacks {
 			recipe instanceof ItemApplicationRecipe && ((ItemApplicationRecipe) recipe).shouldKeepHeldItem();
 
 		if (!keepHeld) {
-			if (heldItem.isDamageableItem())
+			if (heldItem.isDamageableItem()) {
 				heldItem.hurtAndBreak(1, blockEntity.player,
 					s -> s.broadcastBreakEvent(InteractionHand.MAIN_HAND));
-			else
+			} else {
+				Player player = blockEntity.player;
+				ItemStack leftover = heldItem.hasCraftingRemainingItem() ? heldItem.getCraftingRemainingItem() : ItemStack.EMPTY;
+
 				heldItem.shrink(1);
+
+				if (heldItem.isEmpty()) {
+					player.setItemInHand(InteractionHand.MAIN_HAND, leftover);
+				} else {
+					if (!player.getInventory().add(leftover)) {
+						player.drop(leftover, false);
+					}
+				}
+			}
 		}
 
 		if (resultItem != null && !resultItem.isEmpty())

--- a/src/main/java/com/simibubi/create/content/kinetics/deployer/BeltDeployerCallbacks.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/deployer/BeltDeployerCallbacks.java
@@ -98,7 +98,7 @@ public class BeltDeployerCallbacks {
 								DeployerBlockEntity blockEntity, Recipe<?> recipe) {
 
 		List<TransportedItemStack> collect =
-			RecipeApplier.applyRecipeOn(blockEntity.getLevel(), ItemHandlerHelper.copyStackWithSize(transported.stack, 1), recipe)
+			RecipeApplier.applyRecipeOn(blockEntity.getLevel(), ItemHandlerHelper.copyStackWithSize(transported.stack, 1), recipe, true)
 				.stream()
 				.map(stack -> {
 					TransportedItemStack copy = transported.copy();

--- a/src/main/java/com/simibubi/create/content/kinetics/deployer/ManualApplicationRecipe.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/deployer/ManualApplicationRecipe.java
@@ -84,10 +84,23 @@ public class ManualApplicationRecipe extends ItemApplicationRecipe {
 		boolean keepHeld = recipe.shouldKeepHeldItem() || creative;
 
 		if (!keepHeld) {
-			if (heldItem.isDamageableItem())
+			if (heldItem.isDamageableItem()) {
 				heldItem.hurtAndBreak(1, event.getEntity(), s -> s.broadcastBreakEvent(InteractionHand.MAIN_HAND));
-			else
+			} else {
+				Player player = event.getEntity();
+				InteractionHand hand = event.getHand();
+				ItemStack leftover = heldItem.hasCraftingRemainingItem() ? heldItem.getCraftingRemainingItem() : ItemStack.EMPTY;
+
 				heldItem.shrink(1);
+
+				if (heldItem.isEmpty()) {
+					player.setItemInHand(hand, leftover);
+				} else {
+					if (!player.getInventory().add(leftover)) {
+						player.drop(leftover, false);
+					}
+				}
+			}
 		}
 
 		awardAdvancements(event.getEntity(), transformedBlock);

--- a/src/main/java/com/simibubi/create/content/kinetics/fan/processing/AllFanProcessingTypes.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/fan/processing/AllFanProcessingTypes.java
@@ -165,7 +165,7 @@ public class AllFanProcessingTypes {
 						.getResultItem(registryAccess),
 					smeltingRecipe.get()
 						.getResultItem(registryAccess))) {
-					return RecipeApplier.applyRecipeOn(level, stack, smeltingRecipe.get());
+					return RecipeApplier.applyRecipeOn(level, stack, smeltingRecipe.get(), false);
 				}
 			}
 
@@ -238,7 +238,7 @@ public class AllFanProcessingTypes {
 			HAUNTING_WRAPPER.setItem(0, stack);
 			Optional<HauntingRecipe> recipe = AllRecipeTypes.HAUNTING.find(HAUNTING_WRAPPER, level);
 			if (recipe.isPresent())
-				return RecipeApplier.applyRecipeOn(level, stack, recipe.get());
+				return RecipeApplier.applyRecipeOn(level, stack, recipe.get(), true);
 			return null;
 		}
 
@@ -364,7 +364,7 @@ public class AllFanProcessingTypes {
 				.filter(AllRecipeTypes.CAN_BE_AUTOMATED);
 
 			if (smokingRecipe.isPresent())
-				return RecipeApplier.applyRecipeOn(level, stack, smokingRecipe.get());
+				return RecipeApplier.applyRecipeOn(level, stack, smokingRecipe.get(), false);
 
 			return null;
 		}
@@ -429,7 +429,7 @@ public class AllFanProcessingTypes {
 			SPLASHING_WRAPPER.setItem(0, stack);
 			Optional<SplashingRecipe> recipe = AllRecipeTypes.SPLASHING.find(SPLASHING_WRAPPER, level);
 			if (recipe.isPresent())
-				return RecipeApplier.applyRecipeOn(level, stack, recipe.get());
+				return RecipeApplier.applyRecipeOn(level, stack, recipe.get(), true);
 			return null;
 		}
 

--- a/src/main/java/com/simibubi/create/content/kinetics/millstone/MillstoneBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/millstone/MillstoneBlockEntity.java
@@ -24,6 +24,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
+
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.common.capabilities.Capability;
@@ -140,10 +141,14 @@ public class MillstoneBlockEntity extends KineticBlockEntity {
 		}
 
 		ItemStack stackInSlot = inputInv.getStackInSlot(0);
+		ItemStack craftingRemainingItem = stackInSlot.getCraftingRemainingItem();
 		stackInSlot.shrink(1);
 		inputInv.setStackInSlot(0, stackInSlot);
 		lastRecipe.rollResults()
 			.forEach(stack -> ItemHandlerHelper.insertItemStacked(outputInv, stack, false));
+		if (!craftingRemainingItem.isEmpty()) {
+			ItemHandlerHelper.insertItemStacked(outputInv, craftingRemainingItem, false);
+		}
 		award(AllAdvancements.MILLSTONE);
 
 		sendData();

--- a/src/main/java/com/simibubi/create/content/kinetics/press/MechanicalPressBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/press/MechanicalPressBlockEntity.java
@@ -124,12 +124,12 @@ public class MechanicalPressBlockEntity extends BasinOperatingBlockEntity implem
 		ItemStack itemCreated = ItemStack.EMPTY;
 		pressingBehaviour.particleItems.add(item);
 		if (canProcessInBulk() || item.getCount() == 1) {
-			RecipeApplier.applyRecipeOn(itemEntity, recipe.get());
+			RecipeApplier.applyRecipeOn(itemEntity, recipe.get(), true);
 			itemCreated = itemEntity.getItem()
 				.copy();
 		} else {
 			for (ItemStack result : RecipeApplier.applyRecipeOn(level, ItemHandlerHelper.copyStackWithSize(item, 1),
-				recipe.get())) {
+				recipe.get(), true)) {
 				if (itemCreated.isEmpty())
 					itemCreated = result.copy();
 				ItemEntity created =
@@ -155,7 +155,7 @@ public class MechanicalPressBlockEntity extends BasinOperatingBlockEntity implem
 			return true;
 		pressingBehaviour.particleItems.add(input.stack);
 		List<ItemStack> outputs = RecipeApplier.applyRecipeOn(level,
-			canProcessInBulk() ? input.stack : ItemHandlerHelper.copyStackWithSize(input.stack, 1), recipe.get());
+			canProcessInBulk() ? input.stack : ItemHandlerHelper.copyStackWithSize(input.stack, 1), recipe.get(), true);
 
 		for (ItemStack created : outputs) {
 			if (!created.isEmpty()) {

--- a/src/main/java/com/simibubi/create/content/kinetics/saw/SawBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/saw/SawBlockEntity.java
@@ -365,6 +365,8 @@ public class SawBlockEntity extends BlockBreakingKineticBlockEntity {
 			for (ItemStack stack : results) {
 				ItemHelper.addToList(stack, list);
 			}
+			if (input.hasCraftingRemainingItem())
+				ItemHelper.addToList(input.getCraftingRemainingItem(), list);
 		}
 
 		for (int slot = 0; slot < list.size() && slot + 1 < inventory.getSlots(); slot++)

--- a/src/main/java/com/simibubi/create/foundation/recipe/RecipeApplier.java
+++ b/src/main/java/com/simibubi/create/foundation/recipe/RecipeApplier.java
@@ -56,6 +56,10 @@ public class RecipeApplier {
 
 					stacks.add(stack);
 				}
+
+				if (stackIn.hasCraftingRemainingItem()) {
+					ItemHelper.addToList(stackIn.getCraftingRemainingItem(), stacks);
+				}
 			}
 		} else {
 			ItemStack out = recipe.getResultItem(level.registryAccess())

--- a/src/main/java/com/simibubi/create/foundation/recipe/RecipeApplier.java
+++ b/src/main/java/com/simibubi/create/foundation/recipe/RecipeApplier.java
@@ -12,11 +12,12 @@ import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.level.Level;
+
 import net.minecraftforge.items.ItemHandlerHelper;
 
 public class RecipeApplier {
-	public static void applyRecipeOn(ItemEntity entity, Recipe<?> recipe) {
-		List<ItemStack> stacks = applyRecipeOn(entity.level(), entity.getItem(), recipe);
+	public static void applyRecipeOn(ItemEntity entity, Recipe<?> recipe, boolean returnProcessingRemainder) {
+		List<ItemStack> stacks = applyRecipeOn(entity.level(), entity.getItem(), recipe, returnProcessingRemainder);
 		if (stacks == null)
 			return;
 		if (stacks.isEmpty()) {
@@ -31,7 +32,7 @@ public class RecipeApplier {
 		}
 	}
 
-	public static List<ItemStack> applyRecipeOn(Level level, ItemStack stackIn, Recipe<?> recipe) {
+	public static List<ItemStack> applyRecipeOn(Level level, ItemStack stackIn, Recipe<?> recipe, boolean returnProcessingRemainder) {
 		List<ItemStack> stacks;
 
 		if (recipe instanceof ProcessingRecipe<?> pr) {
@@ -57,7 +58,7 @@ public class RecipeApplier {
 					stacks.add(stack);
 				}
 
-				if (stackIn.hasCraftingRemainingItem()) {
+				if (returnProcessingRemainder && stackIn.hasCraftingRemainingItem()) {
 					ItemHelper.addToList(stackIn.getCraftingRemainingItem(), stacks);
 				}
 			}


### PR DESCRIPTION
Some items in Minecraft contains "crafting remaining items" which are left behind when the item is used in crafting, e.g. empty buckets are left behind when crafting a cake with milk buckets. This is also how mods implement inconsumable crafting ingredients. However, over half of Create's recipe types do not respect this method, causing unexpected results such as #4853 and #4963.

Seeing that this issue has been in Create for years and I'm already patching one aspect of it in Create: Connected, I've decided to upstream the patch and fix all recipe types once and for all.

Recipe types that already return crafting remaining items include:
- Automated shaped crafting
- Mechanical crafting
- Mixing
- Compacting

Recipe types that did not return remaining items but are fixed in this PR include:
- Crushing
- Deploying
- Fan processing (bulk blasting and smoking removes the remainder to be consistent with vanilla furnace behavior)
- Manual item application
- Milling
- Pressing
- Sandpaper polishing
- Sawing

For your convenience, here's a datapack that adds all types of recipes for lava buckets, so you can verify that an empty bucket remains after processing: [crafting-remaining-items-data.zip](https://github.com/user-attachments/files/20438824/crafting-remaining-items-data.zip)


