### PR TITLE
Fix all doors sounding like train doors when placed/broken

### DIFF
--- a/src/main/java/com/simibubi/create/AllBlocks.java
+++ b/src/main/java/com/simibubi/create/AllBlocks.java
@@ -2412,26 +2412,23 @@ public class AllBlocks {
 	});
 
 	public static final BlockEntry<SlidingDoorBlock> ANDESITE_DOOR =
-		REGISTRATE.block("andesite_door", p -> SlidingDoorBlock.metal(p, true))
+		REGISTRATE.block("andesite_door", p -> SlidingDoorBlock.stone(p, true))
 			.transform(BuilderTransformers.slidingDoor("andesite"))
 			.properties(p -> p.mapColor(MapColor.STONE)
-				.sound(SoundType.STONE)
 				.noOcclusion())
 			.register();
 
 	public static final BlockEntry<SlidingDoorBlock> BRASS_DOOR =
-		REGISTRATE.block("brass_door", p -> SlidingDoorBlock.metal(p, false))
+		REGISTRATE.block("brass_door", p -> SlidingDoorBlock.stone(p, false))
 			.transform(BuilderTransformers.slidingDoor("brass"))
 			.properties(p -> p.mapColor(MapColor.TERRACOTTA_YELLOW)
-				.sound(SoundType.STONE)
 				.noOcclusion())
 			.register();
 
 	public static final BlockEntry<SlidingDoorBlock> COPPER_DOOR =
-		REGISTRATE.block("copper_door", p -> SlidingDoorBlock.metal(p, true))
+		REGISTRATE.block("copper_door", p -> SlidingDoorBlock.stone(p, true))
 			.transform(BuilderTransformers.slidingDoor("copper"))
 			.properties(p -> p.mapColor(MapColor.COLOR_ORANGE)
-				.sound(SoundType.STONE)
 				.noOcclusion())
 			.register();
 
@@ -2439,15 +2436,13 @@ public class AllBlocks {
 		REGISTRATE.block("train_door", p -> SlidingDoorBlock.metal(p, false))
 			.transform(BuilderTransformers.slidingDoor("train"))
 			.properties(p -> p.mapColor(MapColor.TERRACOTTA_CYAN)
-				.sound(SoundType.NETHERITE_BLOCK)
 				.noOcclusion())
 			.register();
 
 	public static final BlockEntry<TrainTrapdoorBlock> TRAIN_TRAPDOOR =
-		REGISTRATE.block("train_trapdoor", TrainTrapdoorBlock::new)
+		REGISTRATE.block("train_trapdoor", TrainTrapdoorBlock::metal)
 			.initialProperties(SharedProperties::softMetal)
-			.properties(p -> p.mapColor(MapColor.TERRACOTTA_CYAN)
-				.sound(SoundType.NETHERITE_BLOCK))
+			.properties(p -> p.mapColor(MapColor.TERRACOTTA_CYAN))
 			.transform(BuilderTransformers.trapdoor(true))
 			.register();
 
@@ -2455,16 +2450,14 @@ public class AllBlocks {
 		REGISTRATE.block("framed_glass_door", p -> SlidingDoorBlock.glass(p, false))
 			.transform(BuilderTransformers.slidingDoor("glass"))
 			.properties(p -> p.mapColor(MapColor.NONE)
-				.sound(SoundType.GLASS)
 				.noOcclusion())
 			.register();
 
 	public static final BlockEntry<TrainTrapdoorBlock> FRAMED_GLASS_TRAPDOOR =
-		REGISTRATE.block("framed_glass_trapdoor", TrainTrapdoorBlock::new)
+		REGISTRATE.block("framed_glass_trapdoor", TrainTrapdoorBlock::glass)
 			.initialProperties(SharedProperties::softMetal)
 			.transform(BuilderTransformers.trapdoor(false))
 			.properties(p -> p.mapColor(MapColor.NONE)
-				.sound(SoundType.GLASS)
 				.noOcclusion())
 			.onRegister(connectedTextures(TrapdoorCTBehaviour::new))
 			.addLayer(() -> RenderType::cutoutMipped)

--- a/src/main/java/com/simibubi/create/content/decoration/TrainTrapdoorBlock.java
+++ b/src/main/java/com/simibubi/create/content/decoration/TrainTrapdoorBlock.java
@@ -11,14 +11,28 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.TrapDoorBlock;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockSetType;
 import net.minecraft.world.level.block.state.properties.Half;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.phys.BlockHitResult;
 
 public class TrainTrapdoorBlock extends TrapDoorBlock implements IWrenchable {
 
+	@Deprecated
 	public TrainTrapdoorBlock(Properties p_57526_) {
 		super(p_57526_, SlidingDoorBlock.TRAIN_SET_TYPE.get());
+	}
+
+	public TrainTrapdoorBlock(Properties properties, BlockSetType type) {
+		super(properties, type);
+	}
+
+	public static TrainTrapdoorBlock metal(Properties properties) {
+		return new TrainTrapdoorBlock(properties, SlidingDoorBlock.TRAIN_SET_TYPE.get());
+	}
+
+	public static TrainTrapdoorBlock glass(Properties properties) {
+		return new TrainTrapdoorBlock(properties, SlidingDoorBlock.GLASS_SET_TYPE.get());
 	}
 
 	public InteractionResult use(BlockState pState, Level pLevel, BlockPos pPos, Player pPlayer, InteractionHand pHand,

--- a/src/main/java/com/simibubi/create/content/decoration/slidingDoor/SlidingDoorBlock.java
+++ b/src/main/java/com/simibubi/create/content/decoration/slidingDoor/SlidingDoorBlock.java
@@ -44,13 +44,19 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 public class SlidingDoorBlock extends DoorBlock implements IWrenchable, IBE<SlidingDoorBlockEntity>, IHaveBigOutline {
 
 	public static final Supplier<BlockSetType> TRAIN_SET_TYPE =
-		() -> new BlockSetType("train", true, SoundType.NETHERITE_BLOCK, SoundEvents.IRON_DOOR_CLOSE,
+		() -> new BlockSetType("create:train", true, SoundType.NETHERITE_BLOCK, SoundEvents.IRON_DOOR_CLOSE,
 			SoundEvents.IRON_DOOR_OPEN, SoundEvents.IRON_TRAPDOOR_CLOSE, SoundEvents.IRON_TRAPDOOR_OPEN,
 			SoundEvents.METAL_PRESSURE_PLATE_CLICK_OFF, SoundEvents.METAL_PRESSURE_PLATE_CLICK_ON,
 			SoundEvents.STONE_BUTTON_CLICK_OFF, SoundEvents.STONE_BUTTON_CLICK_ON);
 
 	public static final Supplier<BlockSetType> GLASS_SET_TYPE =
-		() -> new BlockSetType("train", true, SoundType.NETHERITE_BLOCK, SoundEvents.IRON_DOOR_CLOSE,
+		() -> new BlockSetType("create:glass", true, SoundType.GLASS, SoundEvents.IRON_DOOR_CLOSE,
+			SoundEvents.IRON_DOOR_OPEN, SoundEvents.IRON_TRAPDOOR_CLOSE, SoundEvents.IRON_TRAPDOOR_OPEN,
+			SoundEvents.METAL_PRESSURE_PLATE_CLICK_OFF, SoundEvents.METAL_PRESSURE_PLATE_CLICK_ON,
+			SoundEvents.STONE_BUTTON_CLICK_OFF, SoundEvents.STONE_BUTTON_CLICK_ON);
+
+	public static final Supplier<BlockSetType> STONE_SET_TYPE =
+		() -> new BlockSetType("create:stone", true, SoundType.STONE, SoundEvents.IRON_DOOR_CLOSE,
 			SoundEvents.IRON_DOOR_OPEN, SoundEvents.IRON_TRAPDOOR_CLOSE, SoundEvents.IRON_TRAPDOOR_OPEN,
 			SoundEvents.METAL_PRESSURE_PLATE_CLICK_OFF, SoundEvents.METAL_PRESSURE_PLATE_CLICK_ON,
 			SoundEvents.STONE_BUTTON_CLICK_OFF, SoundEvents.STONE_BUTTON_CLICK_ON);
@@ -64,6 +70,10 @@ public class SlidingDoorBlock extends DoorBlock implements IWrenchable, IBE<Slid
 
 	public static SlidingDoorBlock glass(Properties p_52737_, boolean folds) {
 		return new SlidingDoorBlock(p_52737_, GLASS_SET_TYPE.get(), folds);
+	}
+
+	public static SlidingDoorBlock stone(Properties p_52737_, boolean folds) {
+		return new SlidingDoorBlock(p_52737_, STONE_SET_TYPE.get(), folds);
 	}
 
 	public SlidingDoorBlock(Properties p_52737_, BlockSetType type, boolean folds) {


### PR DESCRIPTION
Fixes #5738

1.19.4 has moved the soundtype property into the DoorBlock/TrapdoorBlock constructors, overriding the property set in the allblocks file. 
Trapdoor wasn't using the glass set type to begin with.
Additionally, the glass type was a duplicated train set type, and no stone set type existed for the andesite/brass/copper doors, which all tried to set the **stone soundtype (matching the casings; edit: wait no the casings have the wood sound, should that change the soundtype for the doors? and as pointed out in #8683, the copper casing tries to assign the copper soundtype but still sounds like wood, should that door sound like copper then?**).

Deprecates the old TrainTrapdoorBlock constructor (the new constructor + static helpers cover that case), but doesn't remove it since it's used by addons.
Prepended the blocksettypes with `create:`. Waifu analysis shows the name field isn't used by anyone, but it is safer should something start using it.