### PR TITLE
Adds packager cycle config

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/packager/PackagerBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/packager/PackagerBlockEntity.java
@@ -141,7 +141,7 @@ public class PackagerBlockEntity extends SmartBlockEntity {
 					queuedExitingPackages.remove(0);
 
 				animationInward = false;
-				animationTicks = CYCLE;
+				animationTicks = AllConfigs.server().logistics.packagePackCycle.get();;
 				notifyUpdate();
 			}
 
@@ -149,7 +149,7 @@ public class PackagerBlockEntity extends SmartBlockEntity {
 		}
 
 		if (level.isClientSide) {
-			if (animationTicks == CYCLE - (animationInward ? 5 : 1))
+			if (animationTicks == AllConfigs.server().logistics.packagePackCycle.get() - (animationInward ? 5 : 1))
 				AllSoundEvents.PACKAGER.playAt(level, worldPosition, 1, 1, true);
 			if (animationTicks == (animationInward ? 1 : 5))
 				level.playLocalSound(worldPosition, SoundEvents.IRON_TRAPDOOR_CLOSE, SoundSource.BLOCKS, 0.25f, 0.75f,
@@ -355,7 +355,7 @@ public class PackagerBlockEntity extends SmartBlockEntity {
 		if (unpacked && !simulate) {
 			previouslyUnwrapped = box;
 			animationInward = true;
-			animationTicks = CYCLE;
+			animationTicks = AllConfigs.server().logistics.packagePackCycle.get();
 			notifyUpdate();
 		}
 
@@ -496,7 +496,7 @@ public class PackagerBlockEntity extends SmartBlockEntity {
 
 		heldBox = createdBox;
 		animationInward = false;
-		animationTicks = CYCLE;
+		animationTicks = AllConfigs.server().logistics.packagePackCycle.get();
 
 		advancements.awardPlayer(AllAdvancements.PACKAGER);
 		triggerStockCheck();
@@ -595,15 +595,15 @@ public class PackagerBlockEntity extends SmartBlockEntity {
 
 	public float getTrayOffset(float partialTicks) {
 		float tickCycle = animationInward ? animationTicks - partialTicks : animationTicks - 5 - partialTicks;
-		float progress = Mth.clamp(tickCycle / (CYCLE - 5) * 2 - 1, -1, 1);
+		float progress = Mth.clamp(tickCycle / (AllConfigs.server().logistics.packagePackCycle.get() - 5) * 2 - 1, -1, 1);
 		progress = 1 - progress * progress;
 		return progress * progress;
 	}
 
 	public ItemStack getRenderedBox() {
 		if (animationInward)
-			return animationTicks <= CYCLE / 2 ? ItemStack.EMPTY : previouslyUnwrapped;
-		return animationTicks >= CYCLE / 2 ? ItemStack.EMPTY : heldBox;
+			return animationTicks <= AllConfigs.server().logistics.packagePackCycle.get() / 2 ? ItemStack.EMPTY : previouslyUnwrapped;
+		return animationTicks >= AllConfigs.server().logistics.packagePackCycle.get() / 2 ? ItemStack.EMPTY : heldBox;
 	}
 
 	public boolean isTargetingSameInventory(@Nullable IdentifiedInventory inventory) {

--- a/src/main/java/com/simibubi/create/content/logistics/packager/PackagerBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/packager/PackagerBlockEntity.java
@@ -7,6 +7,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 
+import com.simibubi.create.infrastructure.config.AllConfigs;
+
 import org.jetbrains.annotations.Nullable;
 
 import com.simibubi.create.AllBlocks;
@@ -76,7 +78,7 @@ public class PackagerBlockEntity extends SmartBlockEntity {
 	public PackagerItemHandler inventory;
 	private final LazyOptional<IItemHandler> invProvider;
 
-	public static final int CYCLE = 20;
+	public static final int CYCLE = AllConfigs.server().logistics.packagePackCycle.get();
 	public int animationTicks;
 	public boolean animationInward;
 
@@ -133,11 +135,11 @@ public class PackagerBlockEntity extends SmartBlockEntity {
 			if (!level.isClientSide() && !queuedExitingPackages.isEmpty() && heldBox.isEmpty()) {
 				BigItemStack entry = queuedExitingPackages.get(0);
 				heldBox = entry.stack.copy();
-				
+
 				entry.count--;
 				if (entry.count <= 0)
 					queuedExitingPackages.remove(0);
-				
+
 				animationInward = false;
 				animationTicks = CYCLE;
 				notifyUpdate();

--- a/src/main/java/com/simibubi/create/infrastructure/config/CLogistics.java
+++ b/src/main/java/com/simibubi/create/infrastructure/config/CLogistics.java
@@ -9,7 +9,7 @@ public class CLogistics extends ConfigBase {
 	public final ConfigInt psiTimeout = i(60, 1, "psiTimeout", Comments.psiTimeout);
 	public final ConfigInt mechanicalArmRange = i(5, 1, "mechanicalArmRange", Comments.mechanicalArmRange);
 	public final ConfigInt packagePortRange = i(5, 1, "packagePortRange", Comments.packagePortRange);
-	public final ConfigInt packagePackCycle = i(20, 0, "packagePackCycle", Comments.packagePackCycle);
+	public final ConfigInt packagePackCycle = i(20, 5, "packagePackCycle", Comments.packagePackCycle);
 	public final ConfigInt linkRange = i(256, 1, "linkRange", Comments.linkRange);
 	public final ConfigInt displayLinkRange = i(64, 1, "displayLinkRange", Comments.displayLinkRange);
 	public final ConfigInt vaultCapacity = i(20, 1, 2048, "vaultCapacity", Comments.vaultCapacity);

--- a/src/main/java/com/simibubi/create/infrastructure/config/CLogistics.java
+++ b/src/main/java/com/simibubi/create/infrastructure/config/CLogistics.java
@@ -9,6 +9,7 @@ public class CLogistics extends ConfigBase {
 	public final ConfigInt psiTimeout = i(60, 1, "psiTimeout", Comments.psiTimeout);
 	public final ConfigInt mechanicalArmRange = i(5, 1, "mechanicalArmRange", Comments.mechanicalArmRange);
 	public final ConfigInt packagePortRange = i(5, 1, "packagePortRange", Comments.packagePortRange);
+	public final ConfigInt packagePackCycle = i(20, 0, "packagePackCycle", Comments.packagePackCycle);
 	public final ConfigInt linkRange = i(256, 1, "linkRange", Comments.linkRange);
 	public final ConfigInt displayLinkRange = i(64, 1, "displayLinkRange", Comments.displayLinkRange);
 	public final ConfigInt vaultCapacity = i(20, 1, 2048, "vaultCapacity", Comments.vaultCapacity);
@@ -32,6 +33,7 @@ public class CLogistics extends ConfigBase {
 			"The amount of ticks a portable storage interface waits for transfers until letting contraptions move along.";
 		static String mechanicalArmRange = "Maximum distance in blocks a Mechanical Arm can reach across.";
 		static String packagePortRange = "Maximum distance in blocks a Package Port can be placed at from its target.";
+		static String packagePackCycle = "The amount of ticks the packager waits to pack the next package";
 		static String vaultCapacity = "The total amount of stacks a vault can hold per block in size.";
 		static String chainConveyorCapacity = "The amount of packages a chain conveyor can carry at a time.";
 		static String brassTunnelTimer = "The amount of ticks a brass tunnel waits between distributions.";


### PR DESCRIPTION
Adds a config for packager cycle config, allowing packager packing time to be controlled. I added this as I believe that some aspects of factories can be bottlenecked by a single packager having to export large amounts of a single resource. Added as a config to keep balance for those who want to keep the vanilla feel.