### PR TITLE
Fix BeehiveBlockMixin

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/mixin/BeehiveBlockMixin.java
+++ b/src/main/java/com/simibubi/create/foundation/mixin/BeehiveBlockMixin.java
@@ -12,7 +12,7 @@ import net.minecraft.world.level.block.BeehiveBlock;
 
 @Mixin(BeehiveBlock.class)
 public class BeehiveBlockMixin {
-	@ModifyExpressionValue(method = "use", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/block/CampfireBlock;isSmokeyPos(Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;)Z"))
+	@ModifyExpressionValue(method = "useItemOn", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/block/CampfireBlock;isSmokeyPos(Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;)Z"))
 	private static boolean create$dontGetAngryAtDeployers(boolean original, @Local(argsOnly = true) Player player) {
 		return original || player instanceof DeployerFakePlayer;
 	}


### PR DESCRIPTION
The specified method in BeehiveBlockMixin is "use", however it is now named "useItemOn" in 1.21.1.

Edit:
- [1.20.1 Javadocs](https://mcstreetguy.github.io/ForgeJavaDocs/1.20.1-latest/net/minecraft/world/level/block/BeehiveBlock.html#use(net.minecraft.world.level.block.state.BlockState,net.minecraft.world.level.Level,net.minecraft.core.BlockPos,net.minecraft.world.entity.player.Player,net.minecraft.world.InteractionHand,net.minecraft.world.phys.BlockHitResult))
- [1.21.1 Javadocs](https://nekoyue.github.io/ForgeJavaDocs-NG/javadoc/1.21.x-neoforge/net/minecraft/world/level/block/BeehiveBlock.html#useItemOn(net.minecraft.world.item.ItemStack,net.minecraft.world.level.block.state.BlockState,net.minecraft.world.level.Level,net.minecraft.core.BlockPos,net.minecraft.world.entity.player.Player,net.minecraft.world.InteractionHand,net.minecraft.world.phys.BlockHitResult))