### PR TITLE
Fix #8508 Validate item in ChainPackageInteractionPacket

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/chainConveyor/ChainPackageInteractionPacket.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/chainConveyor/ChainPackageInteractionPacket.java
@@ -90,6 +90,9 @@ public class ChainPackageInteractionPacket extends BlockEntityConfigurationPacke
 			return;
 
 		if (!player.isCreative()) {
+			if(!(ItemStack.matches(player.getMainHandItem(), this.insertedPackage))){
+				return;
+			}
 			player.getMainHandItem()
 				.shrink(1);
 			if (player.getMainHandItem()


### PR DESCRIPTION
Adds a check to the ChainPackageInteractionPacket to check if the players main hand matches what was sent to the server.

This not only fixes the dupe but also fixes a packet exploit that would allow malicious actors to spawn in any item by simply providing bogus data when sending the packet to the server.

Example of packet exploit [youtube video](https://youtu.be/wEExGdWZTno).