### PR TITLE
Fix redstone links breaking behaviour

### DIFF
--- a/src/main/java/com/simibubi/create/content/redstone/link/RedstoneLinkBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/redstone/link/RedstoneLinkBlockEntity.java
@@ -114,16 +114,27 @@ public class RedstoneLinkBlockEntity extends SmartBlockEntity {
 		}
 
 		if (receivedSignalChanged) {
-			Direction attachedFace = blockState.getValue(RedstoneLinkBlock.FACING)
-				.getOpposite();
-			BlockPos attachedPos = worldPosition.relative(attachedFace);
-			level.blockUpdated(worldPosition, level.getBlockState(worldPosition)
-				.getBlock());
-			level.blockUpdated(attachedPos, level.getBlockState(attachedPos)
-				.getBlock());
-			receivedSignalChanged = false;
-			panelSupport.notifyPanels();
+			updateSelfAndAttached(blockState);
 		}
+	}
+
+	@Override
+	public void remove() {
+		super.remove();
+
+		updateSelfAndAttached(getBlockState());
+	}
+
+	public void updateSelfAndAttached(BlockState blockState) {
+		Direction attachedFace = blockState.getValue(RedstoneLinkBlock.FACING)
+			.getOpposite();
+		BlockPos attachedPos = worldPosition.relative(attachedFace);
+		level.blockUpdated(worldPosition, level.getBlockState(worldPosition)
+			.getBlock());
+		level.blockUpdated(attachedPos, level.getBlockState(attachedPos)
+			.getBlock());
+		receivedSignalChanged = false;
+		panelSupport.notifyPanels();
 	}
 
 	protected Boolean isTransmitterBlock() {


### PR DESCRIPTION
When breaking a redstone link that is hard-powering a block, blocks neighboring that powered block would not be updated correctly.

To replicate this behavior, this simple set up is all that is required:
![image](https://github.com/user-attachments/assets/9f607a97-09f9-477f-9484-ad4229bbfd03)

Before the changes in this PR, breaking the link would result in this:
![image](https://github.com/user-attachments/assets/3127259a-fb9b-4f48-aa8d-0e2e68cec19f)

After:
![image](https://github.com/user-attachments/assets/51a05422-9831-436c-8b0b-cae9fc408892)
