### PR TITLE
Fixed bug with creative tab

### DIFF
--- a/src/main/java/com/simibubi/create/AllCreativeModeTabs.java
+++ b/src/main/java/com/simibubi/create/AllCreativeModeTabs.java
@@ -193,7 +193,9 @@ public class AllCreativeModeTabs {
 			});
 
 			PackageStyles.STANDARD_BOXES.forEach(item -> {
-				orderings.add(ItemOrdering.after(item, AllBlocks.PACKAGER.asItem()));
+				if(ForgeRegistries.ITEMS.getKey(item).toString().split(":")[0] == Create.ID){
+					orderings.add(ItemOrdering.after(item, AllBlocks.PACKAGER.asItem()));
+				}
 			});
 
 			return orderings;


### PR DESCRIPTION
now create only adds packages to its tab if the item's modid is create
this is necessary because now any custom package from the addon will no longer be on the main tab.