### PR TITLE
Make Potato Projectiles respect vanilla knockback resistance

### DIFF
--- a/src/main/java/com/simibubi/create/content/equipment/potatoCannon/PotatoProjectileEntity.java
+++ b/src/main/java/com/simibubi/create/content/equipment/potatoCannon/PotatoProjectileEntity.java
@@ -247,10 +247,9 @@ public class PotatoProjectileEntity extends AbstractHurtingProjectile implements
 		if (onServer && knockback > 0) {
 			Vec3 appliedMotion = this.getDeltaMovement()
 				.multiply(1.0D, 0.0D, 1.0D)
-				.normalize()
-				.scale(knockback * 0.6);
+				.normalize();
 			if (appliedMotion.lengthSqr() > 0.0D)
-				livingentity.push(appliedMotion.x, 0.1D, appliedMotion.z);
+				livingentity.knockback(knockback * 0.6, -appliedMotion.x, -appliedMotion.z);
 		}
 
 		if (onServer && owner instanceof LivingEntity) {


### PR DESCRIPTION
This PR changes Potato Projectiles to use the vanilla method for knockback, allowing knockback resistance to be accounted for. Fixes #8659 