### PR TITLE
Fix claim protection bypass and possible packet exploits with BlockEntityConfigurationPacket

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/transmission/sequencer/ConfigureSequencedGearshiftPacket.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/transmission/sequencer/ConfigureSequencedGearshiftPacket.java
@@ -27,7 +27,7 @@ public class ConfigureSequencedGearshiftPacket extends BlockEntityConfigurationP
 
 	@Override
 	protected void applySettings(ServerPlayer player, SequencedGearshiftBlockEntity be) {
-		if (be.computerBehaviour.hasAttachedComputer())
+		if (be.computerBehaviour.hasAttachedComputer() || this.instructions.size() > 5)
 			return;
 
 		be.run(-1);

--- a/src/main/java/com/simibubi/create/foundation/codec/CreateStreamCodecs.java
+++ b/src/main/java/com/simibubi/create/foundation/codec/CreateStreamCodecs.java
@@ -16,7 +16,7 @@ public interface CreateStreamCodecs {
 	 */
 	@Deprecated(forRemoval = true)
 	static <B extends ByteBuf, V> StreamCodec.CodecOperation<B, V, Vector<V>> vector() {
-		return codec -> ByteBufCodecs.collection(Vector::new, codec);
+		return codec -> ByteBufCodecs.collection(Vector::new, codec, 256);
 	}
 
 	/**

--- a/src/main/java/com/simibubi/create/foundation/networking/BlockEntityConfigurationPacket.java
+++ b/src/main/java/com/simibubi/create/foundation/networking/BlockEntityConfigurationPacket.java
@@ -7,8 +7,15 @@ import com.simibubi.create.foundation.utility.AdventureUtil;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
+
+import net.minecraft.world.phys.BlockHitResult;
+
+import net.minecraft.world.phys.Vec3;
+
+import net.neoforged.neoforge.common.CommonHooks;
 
 
 public abstract class BlockEntityConfigurationPacket<BE extends SyncedBlockEntity> implements ServerboundPacketPayload {
@@ -30,6 +37,9 @@ public abstract class BlockEntityConfigurationPacket<BE extends SyncedBlockEntit
 			return;
 		BlockEntity blockEntity = world.getBlockEntity(this.pos);
 		if (blockEntity instanceof SyncedBlockEntity) {
+			var result = CommonHooks.onRightClickBlock(player, InteractionHand.MAIN_HAND, this.pos, new BlockHitResult(Vec3.atCenterOf(this.pos), player.getDirection().getOpposite(), this.pos, true));
+			if (result.isCanceled())
+				return;
 			applySettings(player, (BE) blockEntity);
 			if (!causeUpdate())
 				return;

--- a/src/main/java/com/simibubi/create/foundation/networking/BlockEntityConfigurationPacket.java
+++ b/src/main/java/com/simibubi/create/foundation/networking/BlockEntityConfigurationPacket.java
@@ -16,6 +16,7 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
 
 import net.neoforged.neoforge.common.CommonHooks;
+import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
 
 
 public abstract class BlockEntityConfigurationPacket<BE extends SyncedBlockEntity> implements ServerboundPacketPayload {
@@ -37,7 +38,7 @@ public abstract class BlockEntityConfigurationPacket<BE extends SyncedBlockEntit
 			return;
 		BlockEntity blockEntity = world.getBlockEntity(this.pos);
 		if (blockEntity instanceof SyncedBlockEntity) {
-			var result = CommonHooks.onRightClickBlock(player, InteractionHand.MAIN_HAND, this.pos, new BlockHitResult(Vec3.atCenterOf(this.pos), player.getDirection().getOpposite(), this.pos, true));
+			PlayerInteractEvent.RightClickBlock result = CommonHooks.onRightClickBlock(player, InteractionHand.MAIN_HAND, this.pos, new BlockHitResult(Vec3.atCenterOf(this.pos), player.getDirection().getOpposite(), this.pos, true));
 			if (result.isCanceled())
 				return;
 			applySettings(player, (BE) blockEntity);


### PR DESCRIPTION
Closes #8648

There may be a better way to dispatch an interaction event in BlockEntityConfigurationPacket#handle(), but those values seem reasonable enough and did fix FTBChunks claim bypass. One thing to note is that Factory Gauges still show up their GUI, but players that can't interact with it won't have any of their changes saved.