### PR TITLE
TranslationKey in ArmInteractionPoint

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/mechanicalArm/ArmInteractionPoint.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/mechanicalArm/ArmInteractionPoint.java
@@ -195,8 +195,8 @@ public class ArmInteractionPoint {
 	}
 
 	public enum Mode {
-		DEPOSIT("create.mechanical_arm.deposit_to", 0xDDC166),
-		TAKE("create.mechanical_arm.extract_from", 0x7FCDE0);
+		DEPOSIT("mechanical_arm.deposit_to", 0xDDC166),
+		TAKE("mechanical_arm.extract_from", 0x7FCDE0);
 
 		private final String translationKey;
 		private final int color;


### PR DESCRIPTION
Fixed translation keys in Mode enum remove the redundant create. prefix as it should of  just been "mechanical_arm.extract_from" and "mechanical_arm.deposit_to"