### PR TITLE
fixed threshold switch not counting stacks correctly.

### DIFF
--- a/src/main/java/com/simibubi/create/content/redstone/thresholdSwitch/ConfigureThresholdSwitchPacket.java
+++ b/src/main/java/com/simibubi/create/content/redstone/thresholdSwitch/ConfigureThresholdSwitchPacket.java
@@ -19,11 +19,11 @@ public class ConfigureThresholdSwitchPacket extends BlockEntityConfigurationPack
 		this.invert = invert;
 		this.inStacks = inStacks;
 	}
-	
+
 	public ConfigureThresholdSwitchPacket(FriendlyByteBuf buffer) {
 		super(buffer);
 	}
-	
+
 	@Override
 	protected void readSettings(FriendlyByteBuf buffer) {
 		offBelow = buffer.readInt();
@@ -45,7 +45,7 @@ public class ConfigureThresholdSwitchPacket extends BlockEntityConfigurationPack
 		be.offWhenBelow = offBelow;
 		be.onWhenAbove = onAbove;
 		be.setInverted(invert);
-		be.inStacks = inStacks;
+		be.setInStacks(inStacks);
 	}
-	
+
 }

--- a/src/main/java/com/simibubi/create/content/redstone/thresholdSwitch/ThresholdSwitchBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/redstone/thresholdSwitch/ThresholdSwitchBlockEntity.java
@@ -123,7 +123,6 @@ public class ThresholdSwitchBlockEntity extends SmartBlockEntity {
 	}
 
 	public void updateCurrentLevel() {
-		boolean changed = false;
 		int prevLevel = currentLevel;
 		int prevMaxLevel = currentMaxLevel;
 
@@ -137,66 +136,68 @@ public class ThresholdSwitchBlockEntity extends SmartBlockEntity {
 			currentMinLevel = observable.getMinValue();
 			currentLevel = observable.getCurrentValue();
 			currentMaxLevel = observable.getMaxValue();
-
-		/*} else if (StorageDrawers.isDrawer(targetBlockEntity) && observedInventory.hasInventory()) {
-			currentMinLevel = 0;
-			currentLevel = StorageDrawers.getItemCount(observedInventory.getInventory(), filtering);
-			currentMaxLevel = StorageDrawers.getTotalStorageSpace(observedInventory.getInventory());
-		*/
-
-		} else if (observedInventory.hasInventory() || observedTank.hasInventory()) {
+		} else if (observedInventory.hasInventory()) {
 			currentMinLevel = 0;
 			currentLevel = 0;
 			currentMaxLevel = 0;
 
-			if (observedInventory.hasInventory()) {
+			IItemHandler inv = observedInventory.getInventory();
+			if (invVersionTracker.stillWaiting(inv)) {
+				currentLevel = prevLevel;
+				currentMaxLevel = prevMaxLevel;
+			} else {
+				invVersionTracker.awaitNewVersion(inv);
+				for (int slot = 0; slot < inv.getSlots(); slot++) {
+					ItemStack stackInSlot = inv.getStackInSlot(slot);
 
-				// Item inventory
-				IItemHandler inv = observedInventory.getInventory();
-				if (invVersionTracker.stillWaiting(inv)) {
-					currentLevel = prevLevel;
-					currentMaxLevel = prevMaxLevel;
+					final int slotClone = slot;
+					long space = COMPAT.stream()
+						.filter(compat -> compat.isFromThisMod(targetBlockEntity))
+						.map(compat -> compat.getSpaceInSlot(inv, slotClone))
+						.findFirst()
+						.orElseGet(() -> (long) Math.min(stackInSlot.getMaxStackSize(), inv.getSlotLimit(slotClone)));
 
-				} else {
-					invVersionTracker.awaitNewVersion(inv);
-					for (int slot = 0; slot < inv.getSlots(); slot++) {
-						ItemStack stackInSlot = inv.getStackInSlot(slot);
+					if (space == 0) continue;
 
-						int finalSlot = slot;
-						long space = COMPAT
-							.stream()
-							.filter(compat -> compat.isFromThisMod(targetBlockEntity))
-							.map(compat -> compat.getSpaceInSlot(inv, finalSlot))
-							.findFirst()
-							.orElseGet(() -> (long) Math.min(stackInSlot.getMaxStackSize(), inv.getSlotLimit(finalSlot)));
+					if (inStacks) {
+						// When counting in stacks, each slot has 1 unit of capacity
+						currentMaxLevel += 1;
 
-						int count = stackInSlot.getCount();
-						if (space == 0)
-							continue;
-
+						if (filtering.test(stackInSlot)) {
+							// only count full stacks as 1, partial stacks as 0
+							if (stackInSlot.getCount() == space) {
+								currentLevel += 1;
+							}
+						}
+					} else {
+						// When counting individual items, use actual item capacity
 						currentMaxLevel += space;
-						if (filtering.test(stackInSlot))
-							currentLevel += count;
+
+						// Count items that pass the filter
+						if (filtering.test(stackInSlot)) {
+							currentLevel += stackInSlot.getCount();
+						}
 					}
 				}
 			}
+		} else if (observedTank.hasInventory()) {
+			currentMinLevel = 0;
+			currentLevel = 0;
+			currentMaxLevel = 0;
 
-			if (observedTank.hasInventory()) {
-				// Fluid inventory
-				IFluidHandler tank = observedTank.getInventory();
-				for (int slot = 0; slot < tank.getTanks(); slot++) {
-					FluidStack stackInSlot = tank.getFluidInTank(slot);
-					int space = tank.getTankCapacity(slot);
-					int count = stackInSlot.getAmount();
-					if (space == 0)
-						continue;
+			// Fluid inventory
+			IFluidHandler tank = observedTank.getInventory();
+			for (int slot = 0; slot < tank.getTanks(); slot++) {
+				FluidStack stackInSlot = tank.getFluidInTank(slot);
+				int space = tank.getTankCapacity(slot);
+				int count = stackInSlot.getAmount();
+				if (space == 0) continue;
 
-					currentMaxLevel += space;
-					if (filtering.test(stackInSlot))
-						currentLevel += count;
+				currentMaxLevel += space;
+				if (filtering.test(stackInSlot)) {
+					currentLevel += count;
 				}
 			}
-
 		} else {
 			// No compatible inventories found
 			currentMinLevel = -1;
@@ -213,7 +214,8 @@ public class ThresholdSwitchBlockEntity extends SmartBlockEntity {
 		}
 
 		currentLevel = Mth.clamp(currentLevel, currentMinLevel, currentMaxLevel);
-		changed = currentLevel != prevLevel;
+		boolean levelChanged = currentLevel != prevLevel;
+		boolean anyChanged = levelChanged || currentMaxLevel != prevMaxLevel || currentMinLevel != prevLevel;
 
 		boolean previouslyPowered = redstoneState;
 		if (redstoneState && currentLevel <= offWhenBelow)
@@ -232,10 +234,11 @@ public class ThresholdSwitchBlockEntity extends SmartBlockEntity {
 		if (update)
 			scheduleBlockTick();
 
-		if (changed || update) {
+		if (levelChanged || update)
 			DisplayLinkBlock.notifyGatherers(level, worldPosition);
+
+		if (anyChanged)
 			notifyUpdate();
-		}
 	}
 
 	private boolean isSuitableInventory(BlockEntity be) {

--- a/src/main/java/com/simibubi/create/content/redstone/thresholdSwitch/ThresholdSwitchBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/redstone/thresholdSwitch/ThresholdSwitchBlockEntity.java
@@ -1,6 +1,7 @@
 package com.simibubi.create.content.redstone.thresholdSwitch;
 
 import java.util.List;
+import java.util.Optional;
 
 import com.simibubi.create.compat.thresholdSwitch.FunctionalStorage;
 import com.simibubi.create.compat.thresholdSwitch.SophisticatedStorage;
@@ -147,15 +148,19 @@ public class ThresholdSwitchBlockEntity extends SmartBlockEntity {
 				currentMaxLevel = prevMaxLevel;
 			} else {
 				invVersionTracker.awaitNewVersion(inv);
+				Optional<ThresholdSwitchCompat> compatibilityHandler = COMPAT.stream()
+					.filter(compat -> compat.isFromThisMod(targetBlockEntity))
+					.findFirst();
+
 				for (int slot = 0; slot < inv.getSlots(); slot++) {
 					ItemStack stackInSlot = inv.getStackInSlot(slot);
 
-					final int slotClone = slot;
-					long space = COMPAT.stream()
-						.filter(compat -> compat.isFromThisMod(targetBlockEntity))
-						.map(compat -> compat.getSpaceInSlot(inv, slotClone))
-						.findFirst()
-						.orElseGet(() -> (long) Math.min(stackInSlot.getMaxStackSize(), inv.getSlotLimit(slotClone)));
+					long space;
+					if (compatibilityHandler.isPresent()){
+						space = compatibilityHandler.get().getSpaceInSlot(inv, slot);
+					} else {
+						space = Math.min(stackInSlot.getMaxStackSize(), inv.getSlotLimit(slot));
+					}
 
 					if (space == 0) continue;
 
@@ -349,5 +354,15 @@ public class ThresholdSwitchBlockEntity extends SmartBlockEntity {
 			return;
 		this.inverted = inverted;
 		updatePowerAfterDelay();
+	}
+
+	public void setInStacks(Boolean value) {
+		// When configuration values such as inStacks are changed from the screen,
+		// ensure that the next tick recalculates the inventory even if its version
+		// has not changed yet.
+		inStacks = value;
+		if (invVersionTracker != null)
+			invVersionTracker.reset();
+		updateCurrentLevel();
 	}
 }

--- a/src/main/java/com/simibubi/create/content/redstone/thresholdSwitch/ThresholdSwitchScreen.java
+++ b/src/main/java/com/simibubi/create/content/redstone/thresholdSwitch/ThresholdSwitchScreen.java
@@ -67,6 +67,7 @@ public class ThresholdSwitchScreen extends AbstractSimiScreen {
 			.forOptions(List.of(CreateLang.translateDirect("schedule.condition.threshold.items"),
 				CreateLang.translateDirect("schedule.condition.threshold.stacks")))
 			.titled(CreateLang.translateDirect("schedule.condition.threshold.item_measure"))
+			.calling((state) -> send(blockEntity.isInverted()))
 			.setState(blockEntity.inStacks ? 1 : 0);
 
 		offBelow = new ScrollInput(x + 48, y + 47, 1, 18)
@@ -78,7 +79,6 @@ public class ThresholdSwitchScreen extends AbstractSimiScreen {
 
 				if (onAbove.getState() / valueStep == 0 && state / valueStep == 0)
 					return;
-				
 				if (onAbove.getState() / valueStep <= state / valueStep) {
 					onAbove.setState((state + valueStep) / valueStep * valueStep);
 					onAbove.onChanged();
@@ -152,19 +152,16 @@ public class ThresholdSwitchScreen extends AbstractSimiScreen {
 		inputBg.render(graphics, x + 44, y + 21);
 		inputBg.render(graphics, x + 44, y + 21 + 24);
 
-		int valueStep = 1;
+		int valueStep = typeOfCurrentTarget == ThresholdType.FLUID ? 1000 : 1;
 		boolean stacks = inStacks.getState() == 1;
-		if (typeOfCurrentTarget == ThresholdType.FLUID)
-			valueStep = 1000;
 
 		if (forItems) {
 			Component suffix =
-				inStacks.getState() == 0 ? CreateLang.translateDirect("schedule.condition.threshold.items")
-					: CreateLang.translateDirect("schedule.condition.threshold.stacks");
-			valueStep = inStacks.getState() == 0 ? 1 : 64;
+				stacks
+					? CreateLang.translateDirect("schedule.condition.threshold.stacks")
+					: CreateLang.translateDirect("schedule.condition.threshold.items");
 			graphics.drawString(font, suffix, x + 105, y + 28, 0xFFFFFFFF, true);
 			graphics.drawString(font, suffix, x + 105, y + 28 + 24, 0xFFFFFFFF, true);
-
 		}
 
 		graphics.drawString(font,
@@ -327,13 +324,9 @@ public class ThresholdSwitchScreen extends AbstractSimiScreen {
 	}
 
 	private int getValueStep() {
-		boolean stacks = inStacks.getState() == 1;
-		int valueStep = 1;
 		if (blockEntity.getTypeOfCurrentTarget() == ThresholdType.FLUID)
-			valueStep = 1000;
-		else if (stacks)
-			valueStep = 64;
-		return valueStep;
+			return 1000;
+		return 1;
 	}
 
 	@Override


### PR DESCRIPTION
fix: https://github.com/Creators-of-Create/Create/issues/7688#issue-2894355570

behavior changed:
- item measure mode has the same behavior as before
- stack measure mode measures stacks, if count is equal to the space
- reinterpreted BlockEntity data, may cause backward compatibility issue
  - maybe implement an one-time migration?
- fluid tank, custom has the same behavior as before

previous pr targeted a wrong branch, so i cherrypicked the code here