### PR TITLE
[1.21.1] Fix train track itemstacks not stacking in some circumstances

### DIFF
--- a/src/main/java/com/simibubi/create/content/trains/track/TrackBlockItem.java
+++ b/src/main/java/com/simibubi/create/content/trains/track/TrackBlockItem.java
@@ -117,6 +117,7 @@ public class TrackBlockItem extends BlockItem {
 		stack = player.getMainHandItem();
 		if (AllTags.AllBlockTags.TRACKS.matches(stack)) {
 			stack.remove(AllDataComponents.TRACK_CONNECTING_FROM);
+			stack.remove(AllDataComponents.TRACK_EXTENDED_CURVE);
 			player.setItemInHand(pContext.getHand(), stack);
 		}
 


### PR DESCRIPTION
Hi there,

I noticed a bug where sometimes tracks don't stack on 1.21.1.

Original reproduction steps for issue (there are probably easier ways to trigger this):
1. Start placing a train track with a stack size greater than 1
2. Split the stack while still "placing" the track
3. Place the smallest 45 degree **curved** track possible with one of the stacks. 
4. Cancel placing the second stack while hovering over the end of the newly placed curve.
5. Try to combine the stacks. 

The cause seems to be that the track extended curve data component is removed when the curve is started to be placed, but isn't removed when the selection is cleared, meaning in certain conditions track stacks can be left with this data, preventing them from stacking.

This PR simply removes the leftover data component upon cancelling placement, which solves the issue.

Note: This issue does not exist in 1.20.1 due to the stack's tag being set to null upon clearing the track selection, which allows tracks to stack.

If you have questions or concerns, please let me know.
Thanks,
Jensen