### PR TITLE
fix: hand crank rotation visuals

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/base/KineticBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/base/KineticBlockEntity.java
@@ -505,6 +505,8 @@ public class KineticBlockEntity extends SmartBlockEntity implements IHaveGoggleI
 	}
 
 	public static float convertToAngular(float speed) {
+		// speed (rpm) * 360 (revolution->deg) / 60 (min->sec) / 20 (sec->tick)
+		// rpm -> deg/tick
 		return speed * 360f / 60f / 20f;
 	}
 

--- a/src/main/java/com/simibubi/create/content/kinetics/base/KineticBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/base/KineticBlockEntity.java
@@ -505,7 +505,7 @@ public class KineticBlockEntity extends SmartBlockEntity implements IHaveGoggleI
 	}
 
 	public static float convertToAngular(float speed) {
-		return speed * 3 / 10f;
+		return speed * 360f / 60f / 20f;
 	}
 
 	public boolean isOverStressed() {

--- a/src/main/java/com/simibubi/create/content/kinetics/crank/HandCrankBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/crank/HandCrankBlockEntity.java
@@ -3,7 +3,10 @@ package com.simibubi.create.content.kinetics.crank;
 import com.simibubi.create.AllBlocks;
 import com.simibubi.create.AllPartialModels;
 import com.simibubi.create.AllSoundEvents;
+import com.simibubi.create.Create;
 import com.simibubi.create.content.kinetics.base.GeneratingKineticBlockEntity;
+
+import com.simibubi.create.content.kinetics.base.KineticBlockEntity;
 
 import net.createmod.catnip.animation.AnimationTickHolder;
 import net.createmod.catnip.render.CachedBuffers;
@@ -22,8 +25,11 @@ public class HandCrankBlockEntity extends GeneratingKineticBlockEntity {
 
 	public int inUse;
 	public boolean backwards;
+	/**
+	 * In degrees
+	 */
 	public float independentAngle;
-	public float chasingVelocity;
+	public float chasingAngularVelocity;
 
 	public HandCrankBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
 		super(type, pos, state);
@@ -41,8 +47,11 @@ public class HandCrankBlockEntity extends GeneratingKineticBlockEntity {
 			updateGeneratedRotation();
 	}
 
+	/**
+	 * In degrees
+	 */
 	public float getIndependentAngle(float partialTicks) {
-		return (independentAngle + partialTicks * chasingVelocity) / 360;
+		return independentAngle + partialTicks * chasingAngularVelocity;
 	}
 
 	@Override
@@ -76,9 +85,9 @@ public class HandCrankBlockEntity extends GeneratingKineticBlockEntity {
 	public void tick() {
 		super.tick();
 
-		float actualSpeed = getSpeed();
-		chasingVelocity += ((actualSpeed * 10 / 3f) - chasingVelocity) * .25f;
-		independentAngle += chasingVelocity;
+		float actualAngularSpeed = KineticBlockEntity.convertToAngular(getSpeed());
+		chasingAngularVelocity += (actualAngularSpeed - chasingAngularVelocity) / 4f;
+		independentAngle += chasingAngularVelocity;
 
 		if (inUse > 0) {
 			inUse--;

--- a/src/main/java/com/simibubi/create/content/kinetics/crank/HandCrankRenderer.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/crank/HandCrankRenderer.java
@@ -6,6 +6,7 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import com.simibubi.create.content.kinetics.base.KineticBlockEntityRenderer;
 
 import dev.engine_room.flywheel.api.visualization.VisualizationManager;
+import net.createmod.catnip.math.AngleHelper;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
@@ -28,8 +29,8 @@ public class HandCrankRenderer extends KineticBlockEntityRenderer<HandCrankBlock
 
 		Direction facing = be.getBlockState()
 			.getValue(FACING);
-		kineticRotationTransform(be.getRenderedHandle(), be, facing.getAxis(), be.getIndependentAngle(partialTicks),
-			light).renderInto(ms, buffer.getBuffer(RenderType.solid()));
+		kineticRotationTransform(be.getRenderedHandle(), be, facing.getAxis(), AngleHelper.rad(be.getIndependentAngle(partialTicks)), light)
+			.renderInto(ms, buffer.getBuffer(RenderType.solid()));
 	}
 
 }

--- a/src/main/java/com/simibubi/create/content/kinetics/crank/HandCrankVisual.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/crank/HandCrankVisual.java
@@ -2,6 +2,8 @@ package com.simibubi.create.content.kinetics.crank;
 
 import java.util.function.Consumer;
 
+import net.createmod.catnip.math.AngleHelper;
+
 import org.joml.Quaternionf;
 
 import com.simibubi.create.AllPartialModels;
@@ -47,7 +49,7 @@ public class HandCrankVisual extends KineticBlockEntityVisual<HandCrankBlockEnti
 
 	private void rotateCrank(float pt) {
 		var facing = blockState.getValue(BlockStateProperties.FACING);
-		float angle = blockEntity.getIndependentAngle(pt);
+		float angle = AngleHelper.rad(blockEntity.getIndependentAngle(pt));
 
 		crank.setIdentityTransform()
 			.translate(getVisualPosition())

--- a/src/main/java/com/simibubi/create/content/kinetics/crank/ValveHandleBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/crank/ValveHandleBlockEntity.java
@@ -16,6 +16,7 @@ import com.simibubi.create.foundation.blockEntity.behaviour.ValueSettingsFormatt
 import com.simibubi.create.foundation.blockEntity.behaviour.scrollValue.ScrollValueBehaviour;
 import com.simibubi.create.foundation.utility.CreateLang;
 
+import net.createmod.catnip.math.AngleHelper;
 import net.createmod.catnip.math.VecHelper;
 import net.createmod.catnip.render.CachedBuffers;
 import net.createmod.catnip.render.SuperByteBuffer;
@@ -90,8 +91,8 @@ public class ValveHandleBlockEntity extends HandCrankBlockEntity {
 	@Override
 	public float getIndependentAngle(float partialTicks) {
 		if (inUse == 0 && source != null && getSpeed() != 0)
-			return KineticBlockEntityRenderer.getAngleForBe(this, worldPosition,
-				KineticBlockEntityRenderer.getRotationAxisOf(this));
+			return AngleHelper.deg(KineticBlockEntityRenderer.getAngleForBe(this, worldPosition,
+				KineticBlockEntityRenderer.getRotationAxisOf(this)));
 
 		int step = getBlockState().getOptionalValue(ValveHandleBlock.FACING)
 			.orElse(Direction.SOUTH)
@@ -101,7 +102,7 @@ public class ValveHandleBlockEntity extends HandCrankBlockEntity {
 		return (inUse > 0 && totalUseTicks > 0
 			? Mth.lerp(Math.min(totalUseTicks, totalUseTicks - inUse + partialTicks) / (float) totalUseTicks,
 			startAngle, targetAngle)
-			: targetAngle) * Mth.DEG_TO_RAD * (backwards ? -1 : 1) * step;
+			: targetAngle) * (backwards ? -1 : 1) * step;
 	}
 
 	public boolean showValue() {

--- a/src/main/java/com/simibubi/create/content/kinetics/crank/ValveHandleVisual.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/crank/ValveHandleVisual.java
@@ -2,6 +2,8 @@ package com.simibubi.create.content.kinetics.crank;
 
 import java.util.function.Consumer;
 
+import net.createmod.catnip.math.AngleHelper;
+
 import org.joml.Quaternionf;
 
 import com.simibubi.create.AllPartialModels;
@@ -45,7 +47,7 @@ public class ValveHandleVisual extends KineticBlockEntityVisual<HandCrankBlockEn
 
 	private void rotateCrank(float pt) {
 		var facing = blockState.getValue(BlockStateProperties.FACING);
-		float angle = blockEntity.getIndependentAngle(pt);
+		float angle = AngleHelper.rad(blockEntity.getIndependentAngle(pt));
 
 		crank.setIdentityTransform()
 			.translate(getVisualPosition())


### PR DESCRIPTION
The visuals in handcrank don't match the actual rotation. This was caused by not applying proper degrees to radians in rendering. The commit applys them.

**Angle semantics for `HandCrankBlockEntity` stay as degrees**

## Before:

https://github.com/user-attachments/assets/54aebae4-0ba0-45e4-bf91-d6b4123568bb

## After:

https://github.com/user-attachments/assets/572d654c-fcb3-4779-a9e1-77d93d3009a2

I also modified `convertToAngular(float speed)` function to better explain where the magic `3 / 10f` conversion value comes from (let me know if you want it removed)



TL;DR: codebase mixed degrees and radians and also had a wrong conversion formula in the middle. The resolution taken is only using degrees for `getIndependentAngle()/independentAngle` and converting them to radians at render time