### PR TITLE
Fix: Single line displays not showing train station summaries (#6085)

### DIFF
--- a/src/main/java/com/simibubi/create/content/redstone/displayLink/source/StationSummaryDisplaySource.java
+++ b/src/main/java/com/simibubi/create/content/redstone/displayLink/source/StationSummaryDisplaySource.java
@@ -50,7 +50,12 @@ public class StationSummaryDisplaySource extends DisplaySource {
 
     @Override
 	public List<MutableComponent> provideText(DisplayLinkContext context, DisplayTargetStats stats) {
-		return EMPTY;
+		List<List<MutableComponent>> list = provideFlapDisplayText(context, stats);
+		if (list.isEmpty()) {
+			return EMPTY;
+		} else {
+			return list.get(0);
+		}
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/redstone/displayLink/target/SingleLineDisplayTarget.java
+++ b/src/main/java/com/simibubi/create/content/redstone/displayLink/target/SingleLineDisplayTarget.java
@@ -1,6 +1,7 @@
 package com.simibubi.create.content.redstone.displayLink.target;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.simibubi.create.api.behaviour.display.DisplayTarget;
 import com.simibubi.create.content.redstone.displayLink.DisplayLinkContext;
@@ -13,7 +14,11 @@ public abstract class SingleLineDisplayTarget extends DisplayTarget {
 
 	@Override
 	public final void acceptText(int line, List<MutableComponent> text, DisplayLinkContext context) {
-		acceptLine(text.get(0), context);
+		acceptLine(
+			text.size() == 1 ?
+				text.get(0) :
+				Component.literal(text.stream().map(Component::getString).filter(section -> !section.isBlank()).collect(Collectors.joining(" ")))
+			, context);
 	}
 
 	protected abstract void acceptLine(MutableComponent text, DisplayLinkContext context);


### PR DESCRIPTION
Fix issue #6085

Now it's possible to use a single nixie tube to show the seconds/minutes until the next train in a very compact way.

![2025-07-05_12 36 14](https://github.com/user-attachments/assets/436c6dea-eb71-487c-9212-99f00c3f7727)
