### PR TITLE
Called Back III

### DIFF
--- a/src/main/java/com/simibubi/create/api/registrate/CreateRegistrateRegistrationCallback.java
+++ b/src/main/java/com/simibubi/create/api/registrate/CreateRegistrateRegistrationCallback.java
@@ -1,10 +1,8 @@
 package com.simibubi.create.api.registrate;
 
-import java.util.function.Consumer;
-
 import com.simibubi.create.foundation.data.CreateRegistrate;
 import com.simibubi.create.impl.registrate.CreateRegistrateRegistrationCallbackImpl;
-import com.tterrag.registrate.util.entry.RegistryEntry;
+import com.tterrag.registrate.util.nullness.NonNullConsumer;
 
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
@@ -14,7 +12,16 @@ import net.minecraft.resources.ResourceLocation;
  * Register a callback for when an entry is added to any {@link CreateRegistrate} instance
  */
 public class CreateRegistrateRegistrationCallback {
-	public static <T> void register(ResourceKey<? extends Registry<T>> registry, ResourceLocation id, Consumer<RegistryEntry<T>> callback) {
-		CreateRegistrateRegistrationCallbackImpl.register(registry, id, callback);
+	public static <R, T extends R> void register(ResourceKey<? extends Registry<R>> registry, ResourceLocation id, NonNullConsumer<? super T> callback) {
+		CreateRegistrateRegistrationCallbackImpl.<R, T>register(registry, id, callback);
+	}
+
+	/**
+	 * Provide a {@link CreateRegistrate} instance to be used by the API.
+	 * Instances created by {@link CreateRegistrate#create(String)} will automatically be registered.
+	 * It is illegal to call this method more than once for the same mod ID.
+	 */
+	public static void provideRegistrate(CreateRegistrate registrate) {
+		CreateRegistrateRegistrationCallbackImpl.provideRegistrate(registrate);
 	}
 }

--- a/src/main/java/com/simibubi/create/foundation/data/CreateRegistrate.java
+++ b/src/main/java/com/simibubi/create/foundation/data/CreateRegistrate.java
@@ -17,6 +17,7 @@ import com.simibubi.create.api.behaviour.display.DisplaySource;
 import com.simibubi.create.api.behaviour.display.DisplayTarget;
 import com.simibubi.create.api.contraption.storage.fluid.MountedFluidStorageType;
 import com.simibubi.create.api.contraption.storage.item.MountedItemStorageType;
+import com.simibubi.create.api.registrate.CreateRegistrateRegistrationCallback;
 import com.simibubi.create.api.registry.CreateRegistries;
 import com.simibubi.create.api.registry.registrate.SimpleBuilder;
 import com.simibubi.create.content.decoration.encasing.CasingConnectivity;
@@ -24,8 +25,6 @@ import com.simibubi.create.content.fluids.VirtualFluid;
 import com.simibubi.create.foundation.block.connected.CTModel;
 import com.simibubi.create.foundation.block.connected.ConnectedTextureBehaviour;
 import com.simibubi.create.foundation.item.TooltipModifier;
-import com.simibubi.create.impl.registrate.CreateRegistrateRegistrationCallbackImpl;
-import com.simibubi.create.impl.registrate.CreateRegistrateRegistrationCallbackImpl.CallbackImpl;
 import com.tterrag.registrate.AbstractRegistrate;
 import com.tterrag.registrate.builders.BlockBuilder;
 import com.tterrag.registrate.builders.BlockEntityBuilder.BlockEntityFactory;
@@ -74,7 +73,12 @@ public class CreateRegistrate extends AbstractRegistrate<CreateRegistrate> {
 	}
 
 	public static CreateRegistrate create(String modid) {
-		return new CreateRegistrate(modid);
+		CreateRegistrate registrate = new CreateRegistrate(modid);
+		// The registrate is registered here instead of in the constructor so that if a subclass
+		// overrides the addRegisterCallback to be dependent on some sort of state initialized in the constructor,
+		// it won't explode. The consequence is that subclasses must manually provide their registrate to the callback API
+		CreateRegistrateRegistrationCallback.provideRegistrate(registrate);
+		return registrate;
 	}
 
 	public static boolean isInCreativeTab(RegistryEntry<?> entry, RegistryObject<CreativeModeTab> tab) {
@@ -121,15 +125,6 @@ public class CreateRegistrate extends AbstractRegistrate<CreateRegistrate> {
 		}
 		if (currentTab != null)
 			TAB_LOOKUP.put(entry, currentTab);
-
-		for (CallbackImpl<?> callback : CreateRegistrateRegistrationCallbackImpl.CALLBACKS_VIEW) {
-			String modId = callback.id().getNamespace();
-			String entryId = callback.id().getPath();
-			if (callback.registry().equals(type) && getModid().equals(modId) && name.equals(entryId)) {
-				//noinspection unchecked,rawtypes
-				callback.callback().accept((RegistryEntry) entry);
-			}
-		}
 
 		return entry;
 	}

--- a/src/main/java/com/simibubi/create/impl/registrate/CreateRegistrateRegistrationCallbackImpl.java
+++ b/src/main/java/com/simibubi/create/impl/registrate/CreateRegistrateRegistrationCallbackImpl.java
@@ -1,29 +1,64 @@
 package com.simibubi.create.impl.registrate;
 
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
-import java.util.function.Consumer;
+import java.util.Map;
 
-import org.jetbrains.annotations.UnmodifiableView;
-
-import com.tterrag.registrate.util.entry.RegistryEntry;
+import com.mojang.datafixers.util.Either;
+import com.simibubi.create.foundation.data.CreateRegistrate;
+import com.tterrag.registrate.util.nullness.NonNullConsumer;
 
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 
 public class CreateRegistrateRegistrationCallbackImpl {
-	private static final List<CallbackImpl<?>> CALLBACKS = Collections.synchronizedList(new ArrayList<>());
+	// Intentionally not a synchronized map, since all safe accesses have to be synchronized anyway.
+	private static final Map<String, Either<List<CallbackImpl<?, ?>>, CreateRegistrate>> CALLBACKS = new HashMap<>();
 
-	@UnmodifiableView
-	public static final List<CallbackImpl<?>> CALLBACKS_VIEW = Collections.unmodifiableList(CALLBACKS);
+	public static void provideRegistrate(CreateRegistrate registrate) {
+		synchronized (CALLBACKS) {
+			String modid = registrate.getModid();
 
-	public static <T> void register(ResourceKey<? extends Registry<T>> registry, ResourceLocation id, Consumer<RegistryEntry<T>> callback) {
-		CALLBACKS.add(new CallbackImpl<>(registry, id, callback));
+			var either = CALLBACKS.remove(modid);
+			if (either != null) {
+				var optionalCallbacks = either.left();
+				if (optionalCallbacks.isEmpty()) { // in other words, either.right().isPresent()
+					throw new IllegalArgumentException("Tried to register a duplicate CreateRegistrate instance for mod ID: " + modid);
+				}
+
+				for (CallbackImpl<?, ?> callback : optionalCallbacks.get()) {
+					callback.addToRegistrate(registrate);
+				}
+			}
+
+			CALLBACKS.put(modid, Either.right(registrate));
+		}
 	}
 
-	public record CallbackImpl<T>(ResourceKey<? extends Registry<T>> registry, ResourceLocation id,
-								  Consumer<RegistryEntry<T>> callback) {
+	public static <R, T extends R> void register(ResourceKey<? extends Registry<R>> registry, ResourceLocation id, NonNullConsumer<? super T> callback) {
+		CallbackImpl<R, T> callbackImpl = new CallbackImpl<>(registry, id, callback);
+
+		Either<List<CallbackImpl<?, ?>>, CreateRegistrate> either;
+		synchronized (CALLBACKS) {
+			either = CALLBACKS.computeIfAbsent(id.getNamespace(),
+				k -> Either.left(new ArrayList<>()));
+			// must be synchronized here, because if `registerRegistrate` were called between these two calls,
+			// we would be adding to a list that would never be used
+			either.ifLeft(callbacks -> callbacks.add(callbackImpl));
+		}
+
+		// This is safe to call outside the synchronized block, because a registrate will only ever be added once.
+		either.ifRight(callbackImpl::addToRegistrate);
+	}
+
+	private record CallbackImpl<R, T extends R>(ResourceKey<? extends Registry<R>> registry, ResourceLocation id, NonNullConsumer<? super T> callback) {
+		// Helper method so javac doesn't explode on the generic types.
+		// Otherwise, IntelliJ does type inference better than javac,
+		// and everything becomes illegible with generic erasure casts.
+		public void addToRegistrate(CreateRegistrate registrate) {
+			registrate.<R, T>addRegisterCallback(id.getPath(), registry, callback);
+		}
 	}
 }


### PR DESCRIPTION
rework CreateRegistrateRegistrationCallback API to be safe to use for as long as is reasonably possible (until registrate actually registers to Minecraft registries)

crucially, it is now mod load order-independent