### PR TITLE
Second Approach to Fix #5420 & #6988

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/Contraption.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/Contraption.java
@@ -1109,6 +1109,8 @@ public abstract class Contraption {
 
 		translateMultiblockControllers(transform);
 
+		GhostPlacementServerLevel ghostLevel = null;
+
 		for (boolean nonBrittles : Iterate.trueAndFalse) {
 			for (StructureBlockInfo block : blocks.values()) {
 				if (nonBrittles == BlockMovementChecks.isBrittle(block.state()))
@@ -1129,12 +1131,25 @@ public abstract class Contraption {
 				if (blockState.getDestroySpeed(world, targetPos) == -1 || (state.getCollisionShape(world, targetPos)
 					.isEmpty()
 					&& !blockState.getCollisionShape(world, targetPos)
-					.isEmpty())) {
+					.isEmpty()) || world.isOutsideBuildHeight(targetPos) || (state.isAir() && !block.state().isAir())) {
+					state = block.state();
 					if (targetPos.getY() == world.getMinBuildHeight())
 						targetPos = targetPos.above();
 					world.levelEvent(LevelEvent.PARTICLES_DESTROY_BLOCK, targetPos, Block.getId(state));
-					if (shouldDropBlocks) {
-						Block.dropResources(state, world, targetPos, null);
+					if (!shouldDropBlocks)
+						continue;
+					if (ghostLevel == null && world instanceof ServerLevel serverWorld)
+						ghostLevel = new GhostPlacementServerLevel(serverWorld);
+					if (ghostLevel != null) {
+						ghostLevel.setBlock(targetPos, state, Block.UPDATE_NONE);
+						BlockEntity blockEntity = ghostLevel.getBlockEntity(targetPos);
+						if (blockEntity != null) {
+							CompoundTag tag = block.nbt();
+							tag = NBTProcessors.process(state, blockEntity, tag, false);
+							if (tag != null)
+								blockEntity.loadWithComponents(tag, ghostLevel.registryAccess());
+						}
+						ghostLevel.destroyBlock(targetPos, true);
 					}
 					continue;
 				}

--- a/src/main/java/com/simibubi/create/content/contraptions/GhostPlacementServerLevel.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/GhostPlacementServerLevel.java
@@ -1,0 +1,70 @@
+package com.simibubi.create.content.contraptions;
+
+import javax.annotation.Nullable;
+
+import net.createmod.catnip.levelWrappers.WrappedServerLevel;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.EntityBlock;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class GhostPlacementServerLevel extends WrappedServerLevel {
+
+	protected final Map<BlockPos, BlockState> blockStates = new HashMap<>();
+	protected final Map<BlockPos, BlockEntity> blockEntities = new HashMap<>();
+
+	public GhostPlacementServerLevel(ServerLevel level) {
+		super(level);
+	}
+
+	@Override
+	public boolean setBlock(BlockPos pos, BlockState newState, int flags) {
+		pos = pos.immutable();
+		getBlockState(pos).onRemove(this, pos, newState,false);
+		blockStates.put(pos, newState);
+		return true;
+	}
+
+	@Override
+	public BlockState getBlockState(BlockPos pos) {
+		return blockStates.getOrDefault(pos, Blocks.AIR.defaultBlockState());
+	}
+
+	@Nullable
+	public BlockEntity getBlockEntity(BlockPos pos) {
+		BlockState blockState = getBlockState(pos);
+		BlockEntity blockEntity = blockEntities.getOrDefault(pos, null);
+		if (blockState.hasBlockEntity() && blockEntity == null) {
+			blockEntity = ((EntityBlock) blockState.getBlock()).newBlockEntity(pos, blockState);
+			if (blockEntity != null)
+				blockEntity.setLevel(this);
+			pos = pos.immutable();
+			blockEntities.put(pos, blockEntity);
+		}
+		return blockEntity;
+	}
+
+	@Override
+	public void removeBlockEntity(BlockPos pos) {
+		blockEntities.remove(pos);
+	}
+
+	@Override
+	public boolean destroyBlock(BlockPos pos, boolean dropBlock, @Nullable Entity entity, int recursionLeft) {
+		BlockState blockState = getBlockState(pos);
+		if (blockState.isAir())
+			return false;
+		if (dropBlock)
+			Block.dropResources(blockState, this, pos, getBlockEntity(pos), entity, ItemStack.EMPTY);
+		setBlock(pos, Blocks.AIR.defaultBlockState(), Block.UPDATE_NONE);
+		return true;
+	}
+}


### PR DESCRIPTION
This is a second approach to fix #5420 (first one is https://github.com/Creators-of-Create/Create/pull/8774). This PR adds a Ghost Wrapper of ServelLevel to load the blocks and their entity data  allowing for the full use of their .onRemove method when the block is deleted "virtually" dropping the block and it's content. The class is only instanced the first time is needed on the disassembly of a contraption. Also added the cases were is the target location isOutsideBuildHeight and when updateShape changes the state to AIR (fixes #6988)