### PR TITLE
Fix for #8881

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/item/ItemHelper.java
+++ b/src/main/java/com/simibubi/create/foundation/item/ItemHelper.java
@@ -328,6 +328,10 @@ public class ItemHelper {
 			throw new IllegalArgumentException("Slot count mismatch");
 		}
 
+		for (int slot = to.getSlots() - 1; slot >= 0; slot--) {
+			to.setStackInSlot(slot, ItemStack.EMPTY);
+		}
+
 		for (int i = 0; i < from.getSlots(); i++) {
 			to.setStackInSlot(i, from.getStackInSlot(i).copy());
 		}


### PR DESCRIPTION
This fix makes ItemHelper clean the inventory backwards before copying the slots forward, helpful for inventories that move stacks inside them on insertions (toolboxes for example) fixes #8881