### PR TITLE
Use side Parameter in BaseUnpackingHandler

### DIFF
--- a/src/main/java/com/simibubi/create/impl/unpacking/DefaultUnpackingHandler.java
+++ b/src/main/java/com/simibubi/create/impl/unpacking/DefaultUnpackingHandler.java
@@ -26,7 +26,7 @@ public enum DefaultUnpackingHandler implements UnpackingHandler {
 		if (targetBE == null)
 			return false;
 
-		IItemHandler targetInv = level.getCapability(ItemHandler.BLOCK, pos, state, targetBE, null);
+		IItemHandler targetInv = level.getCapability(ItemHandler.BLOCK, pos, state, targetBE, side);
 		if (targetInv == null)
 			return false;
 


### PR DESCRIPTION
This pull request refactors the BaseUnpackingHandler to utilize the `side` parameter when retrieving the inventory handler of the target. This change enables directional context when accessing inventories, improving compatibility with sided inventories and block interactions.