### PR TITLE
StockTickerPeripheral order mutability fix

### DIFF
--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/StockTickerPeripheral.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/StockTickerPeripheral.java
@@ -85,8 +85,8 @@ public class StockTickerPeripheral extends SyncedPeripheral<StockTickerBlockEnti
 					int toTake = Math.min(foundItems, itemsRequested);
 					itemsRequested -= toTake;
 					totalItemsSent += toTake;
-					BigItemStack requestedItem = new BigItemStack(entry.stack, toTake);
-					entry.count -= toTake; // we could also probably free the entry but i dont feel like refactoring this
+					BigItemStack requestedItem = new BigItemStack(entry.stack.copy(), toTake);
+					entry.count -= toTake;
 					validItems.add(requestedItem);
 				}
 				if (itemsRequested <= 0)


### PR DESCRIPTION
simple fix targeting dev 1.20.1 and 1.21.1. Stock ticker's would freak out during a CC `requestFiltered` call and forget what they were supposed to order as they were fulfilling the order for repeat items.

Shout outs to spending 2.5 hours fixing a bug by adding 7 extra characters to one line of code

Also removed the comment suggesting refactoring this. It's best to leave this function untouched, actually.