### PR TITLE
Remove refmap

### DIFF
--- a/src/main/resources/create.mixins.json
+++ b/src/main/resources/create.mixins.json
@@ -4,7 +4,6 @@
   "priority": 1100,
   "package": "com.simibubi.create.foundation.mixin",
   "compatibilityLevel": "JAVA_21",
-  "refmap": "create.refmap.json",
   "mixins": [
     "ArmorTrimMixin",
     "BeehiveBlockMixin",


### PR DESCRIPTION
NeoForge don't need refmaps and it only causes warning in the logs. I tested it an mixins are applied correctly
Fixes #8742 