### PR TITLE
Defensive null checks for Chain Conveyor renderer to prevent NPE during package rendering

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/chainConveyor/ChainConveyorRenderer.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/chainConveyor/ChainConveyorRenderer.java
@@ -49,16 +49,27 @@ public class ChainConveyorRenderer extends KineticBlockEntityRenderer<ChainConve
 
 	@Override
 	protected void renderSafe(ChainConveyorBlockEntity be, float partialTicks, PoseStack ms, MultiBufferSource buffer,
-		int light, int overlay) {
+							  int light, int overlay) {
+		// Defensive: if the BE has no level or blockstate yet, bail out early.
+		if (be == null)
+			return;
+		Level level = be.getLevel();
+		if (level == null)
+			return;
+		BlockState state = be.getBlockState();
+		if (state == null)
+			return;
+
 		super.renderSafe(be, partialTicks, ms, buffer, light, overlay);
 		BlockPos pos = be.getBlockPos();
 
 		renderChains(be, ms, buffer, light, overlay);
 
-		if (VisualizationManager.supportsVisualization(be.getLevel()))
+		if (VisualizationManager.supportsVisualization(level))
 			return;
 
-		CachedBuffers.partial(AllPartialModels.CHAIN_CONVEYOR_WHEEL, be.getBlockState())
+		// use the validated state variable
+		CachedBuffers.partial(AllPartialModels.CHAIN_CONVEYOR_WHEEL, state)
 			.light(light)
 			.overlay(overlay)
 			.renderInto(ms, buffer.getBuffer(RenderType.cutoutMipped()));
@@ -100,10 +111,22 @@ public class ChainConveyorRenderer extends KineticBlockEntityRenderer<ChainConve
 			physicsData.modelKey = key;
 		}
 
+		//More Safety Checks
+		ResourceLocation modelKey = physicsData.modelKey;
+		if (modelKey == null)
+			return;
+
+		var rigModel = AllPartialModels.PACKAGE_RIGGING.get(modelKey);
+		var boxModel = AllPartialModels.PACKAGES.get(modelKey);
+
+		// If either partial model is missing, skip rendering this package to avoid cache loader nulls.
+		if (rigModel == null || boxModel == null)
+			return;
+
 		SuperByteBuffer rigBuffer =
-			CachedBuffers.partial(AllPartialModels.PACKAGE_RIGGING.get(physicsData.modelKey), blockState);
+			CachedBuffers.partial(rigModel, blockState);
 		SuperByteBuffer boxBuffer =
-			CachedBuffers.partial(AllPartialModels.PACKAGES.get(physicsData.modelKey), blockState);
+			CachedBuffers.partial(boxModel, blockState);
 
 		Vec3 dangleDiff = VecHelper.rotate(targetPosition.add(0, 0.5, 0)
 			.subtract(position), -yaw, Axis.Y);
@@ -153,20 +176,25 @@ public class ChainConveyorRenderer extends KineticBlockEntityRenderer<ChainConve
 				.length());
 
 			Level level = be.getLevel();
+			if (level == null)
+				continue;
 			BlockPos tilePos = be.getBlockPos();
 			Vec3 startOffset = stats.start()
 				.subtract(Vec3.atCenterOf(tilePos));
 
-			if (!VisualizationManager.supportsVisualization(be.getLevel())) {
-				SuperByteBuffer guard =
-					CachedBuffers.partial(AllPartialModels.CHAIN_CONVEYOR_GUARD, be.getBlockState());
-				guard.center();
-				guard.rotateYDegrees((float) yaw);
+			if (!VisualizationManager.supportsVisualization(level)) {
+				BlockState state = be.getBlockState();
+				if (state != null) {
+					SuperByteBuffer guard =
+						CachedBuffers.partial(AllPartialModels.CHAIN_CONVEYOR_GUARD, state);
+					guard.center();
+					guard.rotateYDegrees((float) yaw);
 
-				guard.uncenter();
-				guard.light(light)
-					.overlay(overlay)
-					.renderInto(ms, buffer.getBuffer(RenderType.cutoutMipped()));
+					guard.uncenter();
+					guard.light(light)
+						.overlay(overlay)
+						.renderInto(ms, buffer.getBuffer(RenderType.cutoutMipped()));
+				}
 			}
 
 			ms.pushPose();


### PR DESCRIPTION
## Summary
This patch prevents a client crash that happened while rendering `ChainConveyorBlockEntity` packages by adding defensive null checks and safer model lookups. Instead of attempting to render when required data is missing, the renderer now skips the problematic work gracefully.

---

## Stacktrace (excerpt)
    Description: Rendering Block Entity

    java.lang.NullPointerException: Rendering Block Entity
    	at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:889)
    	at com.google.common.cache.LocalCache.get(LocalCache.java:3965)
    	at com.google.common.cache.LocalCache$LocalManualCache.get(LocalCache.java:4863)
    	at net.createmod.catnip.render.SuperByteBufferCache.get(SuperByteBufferCache.java:43)
    	at net.createmod.catnip.render.CachedBuffers.partial(CachedBuffers.java:49)
    	at com.simibubi.create.content.kinetics.chainConveyor.ChainConveyorRenderer.renderBox(ChainConveyorRenderer.java:104)
    	at com.simibubi.create.content.kinetics.chainConveyor.ChainConveyorRenderer.renderSafe(ChainConveyorRenderer.java:67)
    	at com.simibubi.create.content.kinetics.chainConveyor.ChainConveyorRenderer.renderSafe(ChainConveyorRenderer.java:41)
    	at com.simibubi.create.foundation.blockEntity.renderer.SafeBlockEntityRenderer.m_6922_(SafeBlockEntityRenderer.java:24)
    	at net.minecraft.client.renderer.blockentity.BlockEntityRenderDispatcher.m_112284_(BlockEntityRenderDispatcher.java:90)
    	... (render loop frames)

    Block Entity Details:
    Name: create:chain_conveyor // com.simibubi.create.content.kinetics.chainConveyor.ChainConveyorBlockEntity
    Block location: World: (366,-17,-9)

---

## Problem
Rendering sometimes tried to build buffers for package models while required inputs were missing. That led to a null-path inside the buffer creation/caching flow and caused an NPE during block entity rendering.

---

## What changed
- **Early null checks in `renderSafe`**
  - Return early if the block entity (`be`), its `Level`, or its `BlockState` are null.
  - Store `level` and `state` in local variables and reuse them.

- **Guarded package model resolution in `renderBox`**
  - Ensure `physicsData.modelKey` is present before use.
  - Resolve `rigModel` and `boxModel` from `AllPartialModels` once and check for null.
  - If either model is missing, skip rendering that package.

- **Use validated `state` for wheel/guard buffer creation**
  - Replace direct calls to `be.getBlockState()` with the validated `state` variable.

- **Null check inside chain rendering loop**
  - Added a check for `level` inside the connections loop to skip iterations if not present.

- **Formatting and comments**
  - Small clarity improvements and comments for future maintainers.

---

## Why this fixes it
The renderer no longer attempts to create buffers or query partial models when the required inputs (level, state, or partial model entries) are missing. Missing input is handled by skipping the render of that package or guard, preventing the null-path that caused the crash.

---

## Tests / Verification
- Reproduced the original crash scenario and confirmed the client no longer crashes. Packages with missing models are skipped cleanly.
- Verified normal conveyor visuals (chain, wheel, guard) still render correctly for valid packages.
- No regressions observed during manual playtesting.

---

## Follow-ups / suggestions
- Optionally add debug/warn logging when a model key is present but there is no registered partial model to aid modpack debugging.
- Consider adding a generic fallback partial model so packages always display in a basic form instead of being skipped.
- The change is intentionally minimal and defensive to avoid touching buffer/cache internals.

---

## Files changed
`src/main/java/com/simibubi/create/content/kinetics/chainConveyor/ChainConveyorRenderer.java`
- Added defensive null checks for BE, level, and state.
- Added guarded model resolution before invoking buffer creation.
- Re-used validated `state` for model buffer calls.
- Added `level` check inside the chain rendering loop.

---
