### PR TITLE
Fix package ports not being able to contain matching packages

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/packagePort/PackagePortBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/packagePort/PackagePortBlockEntity.java
@@ -53,13 +53,7 @@ public abstract class PackagePortBlockEntity extends SmartBlockEntity implements
 		super(type, pos, state);
 		addressFilter = "";
 		acceptsPackages = true;
-		inventory = new SmartInventory(18, this, (slot, stack) -> {
-			if (!PackageItem.isPackage(stack))
-				return false;
-
-			String filterString = getFilterString();
-			return filterString != null && PackageItem.matchAddress(stack, filterString);
-		});
+		inventory = new SmartInventory(18, this, (slot, stack) -> PackageItem.isPackage(stack));
 		itemHandler = LazyOptional.of(() -> new PackagePortAutomationInventoryWrapper(inventory, this));
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Creators-of-Create/Create/issues/9111.

EDIT: Despite the fact the above issue was closed, an issue still exists caused by the fix made. Please see the latest comment I left on the above issue.

Please let me know if you need any changes or if there is a reason why the change I've made is invalid, to be clear the changes do not affect the actual routing of packages but only what can be stored inside a package port.