### PR TITLE
Fix wrong hashCode implementation for ClipboardEntry

### DIFF
--- a/src/main/java/com/simibubi/create/content/equipment/clipboard/ClipboardEntry.java
+++ b/src/main/java/com/simibubi/create/content/equipment/clipboard/ClipboardEntry.java
@@ -119,7 +119,7 @@ public class ClipboardEntry {
 	public int hashCode() {
 		int result = Boolean.hashCode(checked);
 		result = 31 * result + text.hashCode();
-		result = 31 * result + icon.hashCode();
+		result = 31 * result + ItemStack.hashItemAndComponents(icon);
 		return result;
 	}
 }


### PR DESCRIPTION
ItemStack does not implement the hashcode function; ItemStack.hashItemAndComponents needs to be used for calculation.
Please merge this PR. The faulty hashcode implementation of ClipboardEntry may cause ClipboardItem to become unpick-up-able when placed into some storage mods.
Additionally, it only modifies one line, making it very easy to review.