### PR TITLE
Fix tracks copying the waterlogged state across portals

### DIFF
--- a/src/main/java/com/simibubi/create/content/trains/track/TrackBlock.java
+++ b/src/main/java/com/simibubi/create/content/trains/track/TrackBlock.java
@@ -280,8 +280,9 @@ public class TrackBlock extends Block
 			if (be instanceof TrackBlockEntity tbe)
 				tbe.bind(otherLevel.dimension(), otherTrackPos);
 
-			otherLevel.setBlock(otherTrackPos, state.setValue(SHAPE, TrackShape.asPortal(otherTrack.getFace()))
-				.setValue(HAS_BE, true), 3);
+			BlockState otherState = ProperWaterloggedBlock.withWater(otherLevel, state.setValue(SHAPE,
+					TrackShape.asPortal(otherTrack.getFace())).setValue(HAS_BE, true), otherTrackPos);
+			otherLevel.setBlock(otherTrackPos, otherState, 3);
 			BlockEntity otherBE = otherLevel.getBlockEntity(otherTrackPos);
 			if (otherBE instanceof TrackBlockEntity tbe)
 				tbe.bind(level.dimension(), pos);


### PR DESCRIPTION
Caused water duping/voiding (depending on whether the position on the other side of the portal didn't/did have water when track was placed in/outside water, respectively), which resulted in a water-in-nether exploit.