### PR TITLE
Fix multiple fluid tanks on train to lose contents when unloading.

### DIFF
--- a/src/main/java/com/simibubi/create/content/fluids/FluidNetwork.java
+++ b/src/main/java/com/simibubi/create/content/fluids/FluidNetwork.java
@@ -202,6 +202,7 @@ public class FluidNetwork {
 					continue;
 				FluidStack toExtract = FluidHelper.copyStackWithAmount(contained, flowSpeed);
 				transfer = handler.drain(toExtract, action);
+				break;
 			}
 
 			if (transfer.isEmpty()) {


### PR DESCRIPTION
This fixes the issue of multiple fluid tanks on a train loosing contents when unloading as mentioned in #6658

The loop continues to extract from tanks even after the first tank was found, discarding any previous extraction results. Now we only extract from one tank per transfer tick.