### PR TITLE
 Fix proposal for issue #9117 (Right clicking on a nixie tube with an empty clipboard seems to crash the game)

### DIFF
--- a/src/main/java/com/simibubi/create/content/redstone/nixieTube/NixieTubeBlock.java
+++ b/src/main/java/com/simibubi/create/content/redstone/nixieTube/NixieTubeBlock.java
@@ -87,7 +87,8 @@ public class NixieTubeBlock extends DoubleFaceAttachedBlock
 
 		if (AllBlocks.CLIPBOARD.isIn(stack)) {
 			List<ClipboardEntry> entries = ClipboardEntry.getLastViewedEntries(stack);
-			component = entries.getFirst().text;
+			if (!entries.isEmpty())
+				component = entries.getFirst().text;
 		}
 
 		if (level.isClientSide)


### PR DESCRIPTION
Fix proposal for issue #9117.

> Right clicking on a nixie tube with an empty clipboard seems to crash the game.

Problem specific to 1.21.1.