### PR TITLE
Allow any wrench to connect crafters

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/crafter/MechanicalCrafterBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/crafter/MechanicalCrafterBlockEntity.java
@@ -7,10 +7,11 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map.Entry;
 
+import com.simibubi.create.AllTags.AllItemTags;
+
 import org.apache.commons.lang3.tuple.Pair;
 
 import com.simibubi.create.AllBlocks;
-import com.simibubi.create.AllItems;
 import com.simibubi.create.AllSoundEvents;
 import com.simibubi.create.content.kinetics.base.KineticBlockEntity;
 import com.simibubi.create.content.kinetics.belt.behaviour.DirectBeltInputBehaviour;
@@ -115,7 +116,7 @@ public class MechanicalCrafterBlockEntity extends KineticBlockEntity {
 		inserting = new InvManipulationBehaviour(this, this::getTargetFace);
 		connectivity = new EdgeInteractionBehaviour(this, ConnectedInputHandler::toggleConnection)
 			.connectivity(ConnectedInputHandler::shouldConnect)
-			.require(AllItems.WRENCH.get());
+			.require(AllItemTags.WRENCH::matches);
 		behaviours.add(inserting);
 		behaviours.add(connectivity);
 		registerAwardables(behaviours, AllAdvancements.CRAFTER, AllAdvancements.CRAFTER_LAZY);

--- a/src/main/java/com/simibubi/create/foundation/blockEntity/behaviour/edgeInteraction/EdgeInteractionBehaviour.java
+++ b/src/main/java/com/simibubi/create/foundation/blockEntity/behaviour/edgeInteraction/EdgeInteractionBehaviour.java
@@ -1,6 +1,6 @@
 package com.simibubi.create.foundation.blockEntity.behaviour.edgeInteraction;
 
-import java.util.Optional;
+import java.util.function.Predicate;
 
 import com.simibubi.create.foundation.blockEntity.SmartBlockEntity;
 import com.simibubi.create.foundation.blockEntity.behaviour.BehaviourType;
@@ -14,25 +14,29 @@ import net.minecraft.world.level.Level;
 public class EdgeInteractionBehaviour extends BlockEntityBehaviour {
 
 	public static final BehaviourType<EdgeInteractionBehaviour> TYPE = new BehaviourType<>();
-	
+
 	ConnectionCallback connectionCallback;
 	ConnectivityPredicate connectivityPredicate;
-	Optional<Item> requiredItem;
+	Predicate<Item> requiredItem;
 
 	public EdgeInteractionBehaviour(SmartBlockEntity be, ConnectionCallback callback) {
 		super(be);
 		this.connectionCallback = callback;
-		requiredItem = Optional.empty();
+		requiredItem = item -> true;
 		connectivityPredicate = (world, pos, face, face2) -> true;
 	}
-	
+
 	public EdgeInteractionBehaviour connectivity(ConnectivityPredicate pred) {
 		this.connectivityPredicate = pred;
 		return this;
 	}
-	
-	public EdgeInteractionBehaviour require(Item item) {
-		this.requiredItem = Optional.of(item);
+
+	public EdgeInteractionBehaviour require(Item required) {
+		return this.require(item -> item == required);
+	}
+
+	public EdgeInteractionBehaviour require(Predicate<Item> predicate) {
+		this.requiredItem = predicate;
 		return this;
 	}
 
@@ -40,12 +44,12 @@ public class EdgeInteractionBehaviour extends BlockEntityBehaviour {
 	public BehaviourType<?> getType() {
 		return TYPE;
 	}
-	
+
 	@FunctionalInterface
 	public interface ConnectionCallback {
 		public void apply(Level world, BlockPos clicked, BlockPos neighbour);
 	}
-	
+
 	@FunctionalInterface
 	public interface ConnectivityPredicate {
 		public boolean test(Level world, BlockPos pos, Direction selectedFace, Direction connectedFace);

--- a/src/main/java/com/simibubi/create/foundation/blockEntity/behaviour/edgeInteraction/EdgeInteractionHandler.java
+++ b/src/main/java/com/simibubi/create/foundation/blockEntity/behaviour/edgeInteraction/EdgeInteractionHandler.java
@@ -42,7 +42,7 @@ public class EdgeInteractionHandler {
 		EdgeInteractionBehaviour behaviour = BlockEntityBehaviour.get(world, pos, EdgeInteractionBehaviour.TYPE);
 		if (behaviour == null)
 			return;
-		if (behaviour.requiredItem.isPresent() && behaviour.requiredItem.get() != heldItem.getItem())
+		if (!behaviour.requiredItem.test(heldItem.getItem()))
 			return;
 		BlockHitResult ray = RaycastHelper.rayTraceRange(world, player, 10);
 		if (ray == null)

--- a/src/main/java/com/simibubi/create/foundation/blockEntity/behaviour/edgeInteraction/EdgeInteractionRenderer.java
+++ b/src/main/java/com/simibubi/create/foundation/blockEntity/behaviour/edgeInteraction/EdgeInteractionRenderer.java
@@ -46,7 +46,7 @@ public class EdgeInteractionRenderer {
 		EdgeInteractionBehaviour behaviour = BlockEntityBehaviour.get(world, pos, EdgeInteractionBehaviour.TYPE);
 		if (behaviour == null)
 			return;
-		if (behaviour.requiredItem.orElse(heldItem.getItem()) != heldItem.getItem())
+		if (!behaviour.requiredItem.test(heldItem.getItem()))
 			return;
 
 		Direction face = result.getDirection();


### PR DESCRIPTION
Crafters will check `#c:wrenches` instead of just the wrench item.

Upstreaming this from Fabric.