### PR TITLE
Adjusted Gantry Shaft speed limit so players can accurately control Gantry moving at 256 speeds with gt.

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/gantry/GantryShaftBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/gantry/GantryShaftBlockEntity.java
@@ -104,7 +104,7 @@ public class GantryShaftBlockEntity extends KineticBlockEntity {
 		BlockState blockState = getBlockState();
 		if (!AllBlocks.GANTRY_SHAFT.has(blockState))
 			return 0;
-		return Mth.clamp(convertToLinear(-getSpeed()), -.49f, .49f);
+		return Mth.clamp(convertToLinear(-getSpeed()), -.5f, .5f);
 	}
 
 	@Override


### PR DESCRIPTION
Currently, the movement speed of Gantry Shaft is limited to 0.49, which means that when moving Gantry at a speed of 256, each block is not exactly 2gt. This error will increase with the movement distance and exceed 0.5 after 25 blocks, causing the final position to be inconsistent with the expected position.