### PR TITLE
Massively optimize basin recipe lookups

### DIFF
--- a/src/main/java/com/simibubi/create/content/processing/basin/BasinBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/processing/basin/BasinBlockEntity.java
@@ -8,6 +8,9 @@ import java.util.Optional;
 
 import javax.annotation.Nonnull;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import com.google.common.collect.ImmutableList;
 import com.simibubi.create.AllParticleTypes;
 import com.simibubi.create.AllTags;
@@ -100,6 +103,8 @@ public class BasinBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 	public static final int OUTPUT_ANIMATION_TIME = 10;
 	List<IntAttached<ItemStack>> visualizedOutputItems;
 	List<IntAttached<FluidStack>> visualizedOutputFluids;
+
+	private @Nullable HeatLevel cachedHeatLevel;
 
 	public BasinBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
 		super(type, pos, state);
@@ -334,6 +339,8 @@ public class BasinBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 
 	@Override
 	public void tick() {
+		cachedHeatLevel = null;
+
 		super.tick();
 		if (level.isClientSide) {
 			createFluidParticles();
@@ -781,6 +788,16 @@ public class BasinBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 			tooltip.remove(0);
 
 		return true;
+	}
+
+	@NotNull HeatLevel getHeatLevel() {
+		if (cachedHeatLevel == null) {
+			if (level == null)
+				return HeatLevel.NONE;
+
+			cachedHeatLevel = getHeatLevelOf(level.getBlockState(getBlockPos().below(1)));
+		}
+		return cachedHeatLevel;
 	}
 
 	class BasinValueBox extends ValueBoxTransform.Sided {

--- a/src/main/java/com/simibubi/create/content/processing/basin/BasinRecipe.java
+++ b/src/main/java/com/simibubi/create/content/processing/basin/BasinRecipe.java
@@ -72,9 +72,7 @@ public class BasinRecipe extends ProcessingRecipe<Container> {
 		if (availableItems == null || availableFluids == null)
 			return false;
 
-		HeatLevel heat = BasinBlockEntity.getHeatLevelOf(basin.getLevel()
-			.getBlockState(basin.getBlockPos()
-				.below(1)));
+		HeatLevel heat = basin.getHeatLevel();
 		if (isBasinRecipe && !((BasinRecipe) recipe).getRequiredHeat()
 			.testBlazeBurner(heat))
 			return false;

--- a/src/main/java/com/simibubi/create/foundation/events/CommonEvents.java
+++ b/src/main/java/com/simibubi/create/foundation/events/CommonEvents.java
@@ -19,6 +19,7 @@ import com.simibubi.create.foundation.data.RuntimeDataGenerator;
 import com.simibubi.create.foundation.pack.DynamicPack;
 import com.simibubi.create.foundation.pack.DynamicPackSource;
 import com.simibubi.create.foundation.recipe.RecipeFinder;
+import com.simibubi.create.foundation.recipe.trie.RecipeTrieFinder;
 import com.simibubi.create.foundation.utility.ServerSpeedProvider;
 import com.simibubi.create.foundation.utility.TickBasedCache;
 import com.simibubi.create.infrastructure.command.AllCommands;
@@ -141,6 +142,7 @@ public class CommonEvents {
 	@SubscribeEvent
 	public static void addReloadListeners(AddReloadListenerEvent event) {
 		event.addListener(RecipeFinder.LISTENER);
+		event.addListener(RecipeTrieFinder.LISTENER);
 		event.addListener(BeltHelper.LISTENER);
 	}
 

--- a/src/main/java/com/simibubi/create/foundation/recipe/trie/AbstractIngredient.java
+++ b/src/main/java/com/simibubi/create/foundation/recipe/trie/AbstractIngredient.java
@@ -1,0 +1,48 @@
+package com.simibubi.create.foundation.recipe.trie;
+
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
+
+public class AbstractIngredient {
+    final Set<AbstractVariant> variants;
+    final int hashCode;
+
+    public AbstractIngredient(Set<AbstractVariant> variants) {
+        this.variants = ImmutableSet.copyOf(variants);
+        this.hashCode = variants.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof AbstractIngredient that)) return false;
+        if (this == that) return true;
+
+        return this.hashCode == that.hashCode && this.variants.equals(that.variants);
+    }
+
+    @Override
+    public int hashCode() {
+        return hashCode;
+    }
+
+    // For any ingredients that aren't representable as a finite set of variants, to handle fabric's CustomIngredient
+    public static class Universal extends AbstractIngredient {
+        public static final Universal INSTANCE = new Universal();
+        private static final int hashCode = Universal.class.hashCode();
+
+        private Universal() {
+            super(Set.of());
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return obj instanceof Universal;
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode;
+        }
+    }
+}

--- a/src/main/java/com/simibubi/create/foundation/recipe/trie/AbstractRecipe.java
+++ b/src/main/java/com/simibubi/create/foundation/recipe/trie/AbstractRecipe.java
@@ -1,0 +1,15 @@
+package com.simibubi.create.foundation.recipe.trie;
+
+import java.util.Set;
+
+import net.minecraft.world.item.crafting.Recipe;
+
+public class AbstractRecipe<R extends Recipe<?>> {
+    final R recipe;
+    final Set<AbstractIngredient> ingredients;
+
+    public AbstractRecipe(R recipe, Set<AbstractIngredient> ingredients) {
+        this.recipe = recipe;
+        this.ingredients = ingredients;
+    }
+}

--- a/src/main/java/com/simibubi/create/foundation/recipe/trie/AbstractVariant.java
+++ b/src/main/java/com/simibubi/create/foundation/recipe/trie/AbstractVariant.java
@@ -1,0 +1,52 @@
+package com.simibubi.create.foundation.recipe.trie;
+
+import org.jetbrains.annotations.NotNull;
+
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.material.Fluid;
+
+public sealed interface AbstractVariant {
+    final class AbstractItem implements AbstractVariant {
+        private final @NotNull Item item;
+        private final int hashCode;
+
+        public AbstractItem(@NotNull Item item) {
+            this.item = item;
+            this.hashCode = item.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof AbstractItem that)) return false;
+
+            return item == that.item;
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode;
+        }
+    }
+
+    final class AbstractFluid implements AbstractVariant {
+        private final @NotNull Fluid fluid;
+        private final int hashCode;
+
+        public AbstractFluid(@NotNull Fluid fluid) {
+            this.fluid = fluid;
+            this.hashCode = fluid.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof AbstractFluid that)) return false;
+
+            return fluid == that.fluid;
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode;
+        }
+    }
+}

--- a/src/main/java/com/simibubi/create/foundation/recipe/trie/IntArrayTrie.java
+++ b/src/main/java/com/simibubi/create/foundation/recipe/trie/IntArrayTrie.java
@@ -1,0 +1,97 @@
+package com.simibubi.create.foundation.recipe.trie;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.ints.IntSet;
+
+/**
+ * A one-to-many, lookup-optimized data structure for storing {@code int[]} -> {@code V} mappings,
+ * which provides subset-to-many lookup.
+ */
+public class IntArrayTrie<V> {
+    static class TrieNode<V> {
+        final Int2ObjectMap<TrieNode<V>> children = new Int2ObjectOpenHashMap<>();
+        final List<V> values = new ArrayList<>();
+    }
+
+    private final TrieNode<V> root = new TrieNode<>();
+
+    private int maxDepth = 0;
+    private int nodeCount = 1; // count root
+    private int valueCount = 0;
+
+    public int getMaxDepth() {
+        return maxDepth;
+    }
+
+    public int getNodeCount() {
+        return nodeCount;
+    }
+
+    public int getValueCount() {
+        return valueCount;
+    }
+
+    /**
+     * Insert a key-value pair into the trie.
+     * @param key a sorted array of integers
+     * @param value the value to associate with the key
+     */
+    public void insert(int[] key, V value) {
+        TrieNode<V> currentNode = root;
+        for (int k : key) {
+            currentNode = currentNode.children.computeIfAbsent(k, k1 -> {
+                nodeCount++;
+                return new TrieNode<>();
+            });
+        }
+        currentNode.values.add(value);
+
+        maxDepth = Math.max(maxDepth, key.length);
+        valueCount++;
+    }
+
+    /**
+     * Look up all values associated with a subset of {@code pool}.
+     * @param pool the set of allowable keys. It SHOULD have O(1) lookup time.
+     * @return all associated values
+     */
+    public List<V> lookup(IntSet pool) {
+        List<V> result = new ArrayList<>();
+        dfs(root, pool, result);
+        return result;
+    }
+
+    private static <V> void dfs(TrieNode<V> node, IntSet pool, List<V> out) {
+        out.addAll(node.values);
+
+        // With node.children length n and pool length m,
+        // The time complexity is O(min(n, m)), assuming O(1) lookup time for pool.
+        if (node.children.size() > pool.size()) {
+            for (int key : pool) {
+                TrieNode<V> child = node.children.get(key);
+                if (child != null) {
+                    dfs(child, pool, out);
+                }
+            }
+        } else {
+            for (var entry : node.children.int2ObjectEntrySet()) {
+                if (pool.contains(entry.getIntKey())) {
+                    dfs(entry.getValue(), pool, out);
+                }
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "IntArrayTrie{" +
+            "maxDepth=" + maxDepth +
+            ", nodeCount=" + nodeCount +
+            ", valueCount=" + valueCount +
+            '}';
+    }
+}

--- a/src/main/java/com/simibubi/create/foundation/recipe/trie/README.md
+++ b/src/main/java/com/simibubi/create/foundation/recipe/trie/README.md
@@ -1,0 +1,42 @@
+# Optimizing Basin Recipe Lookups
+
+By Slimeist (techno-sam)
+
+## Definitions
+
+- **Recipe<?>**: A Minecraft recipe
+- **AbstractVariant**: A representation of a "thing" (i.e. an item or a fluid)
+- **AbstractIngredient**: A set of `AbstractVariant`s
+- **AbstractRecipe**: A set of `AbstractIngredient`s, mapping one-to-many to `Recipe<?>`
+- **Basin**: A set of `AbstractVariant`s
+- **SuperBasin**: A set of `AbstractIngredient`s
+
+An `AbstractIngredient` is satisfied by any `AbstractVariant` it contains. (OR semantics)
+An `AbstractRecipe` is satisfied by a set containing all `AbstractIngredient`s it contains. (AND semantics)
+
+A `SuperBasin` can be constructed from a `Basin` by defining it as the set of all `AbstractIngredient`s that can be satisfied by at least one `AbstractVariant` in the `Basin`.
+
+`AbstractVariant`s and `AbstractIngredient`s have unique int IDs within the type (i.e. there may be an `AV{42}` and an `AI{42}`, but not two `AV{42}`s).
+
+## Problem Statement
+
+### Base
+
+Given a `Basin`, find all `AbstractRecipe`s that can be satisfied by the `Basin`'s contents.
+
+### Revised
+
+Given a `SuperBasin`, find all `AbstractRecipe`s whose ingredient sets are subsets of the `SuperBasin`.
+
+## Solution
+
+### Setup
+
+We pre-construct a sparse trie map from a sorted string of `AbstractVariant` IDs (i.e. `int[]`) to a list of `Recipe<?>`s.
+
+### Lookup
+
+1. Given a `Basin`, convert it to a `SuperBasin`. This may be useful to cache.
+2. Traverse the trie map to find all satisfiable `AbstractRecipe`s.
+3. Convert the `AbstractRecipe`s to `Recipe<?>`s.
+4. Profit

--- a/src/main/java/com/simibubi/create/foundation/recipe/trie/RecipeTrie.java
+++ b/src/main/java/com/simibubi/create/foundation/recipe/trie/RecipeTrie.java
@@ -1,0 +1,230 @@
+package com.simibubi.create.foundation.recipe.trie;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.simibubi.create.Create;
+import com.simibubi.create.content.processing.basin.BasinRecipe;
+
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.level.material.Fluid;
+
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.capability.IFluidHandler;
+import net.minecraftforge.items.IItemHandler;
+
+public class RecipeTrie<R extends Recipe<?>> {
+    private static final int MAX_CACHE_SIZE = Integer.getInteger("create.recipe_trie.max_cache_size", 512);
+
+    private final IntArrayTrie<R> trie;
+    private final Object2IntMap<AbstractVariant> variantToId;
+    private final Int2ObjectMap<IntSet> variantToIngredients;
+    private final int universalIngredientId;
+
+    private final Cache<Set<AbstractVariant>, IntSet> ingredientCache = CacheBuilder.newBuilder()
+        .maximumSize(MAX_CACHE_SIZE)
+        .build();
+
+    private RecipeTrie(IntArrayTrie<R> trie, Object2IntMap<AbstractVariant> variantToId, Int2ObjectMap<IntSet> variantToIngredients, int universalIngredientId) {
+        this.trie = trie;
+        this.variantToId = variantToId;
+        this.variantToIngredients = variantToIngredients;
+        this.universalIngredientId = universalIngredientId;
+    }
+
+    public static @NotNull Set<AbstractVariant> getVariants(@Nullable IItemHandler itemStorage, @Nullable IFluidHandler fluidStorage) {
+        Set<AbstractVariant> variants = new HashSet<>();
+
+        if (itemStorage != null) {
+            for (int slot = 0; slot < itemStorage.getSlots(); slot++) {
+                ItemStack item = itemStorage.getStackInSlot(slot);
+                if (item.isEmpty()) continue;
+
+                variants.add(new AbstractVariant.AbstractItem(item.getItem()));
+            }
+        }
+
+        if (fluidStorage != null) {
+            for (int tank = 0; tank < fluidStorage.getTanks(); tank++) {
+                FluidStack fluid = fluidStorage.getFluidInTank(tank);
+                if (fluid.isEmpty()) continue;
+
+                variants.add(new AbstractVariant.AbstractFluid(fluid.getFluid()));
+            }
+        }
+
+        return variants;
+    }
+
+    private IntSet getAvailableIngredients(@NotNull Set<AbstractVariant> pool) {
+        pool.retainAll(variantToId.keySet());
+
+        try {
+            return ingredientCache.get(Set.copyOf(pool), () -> {
+                IntSet ingredients = new IntOpenHashSet();
+                ingredients.add(universalIngredientId);
+
+                for (AbstractVariant variant : pool) {
+                    int id = variantToId.getInt(variant);
+                    if (id >= 0) {
+                        var ingredientIds = variantToIngredients.get(id);
+                        if (ingredientIds != null) {
+                            ingredients.addAll(ingredientIds);
+                        }
+                    }
+                }
+
+                return ingredients;
+            });
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Look up all recipes that can be made with (a subset of) the given pool of resources.
+     * @param pool the set of allowable variants. It will be modified to only contain known variants.
+     * @return all recipes that can be made with the given pool of resources.
+     */
+    public @NotNull List<R> lookup(@NotNull Set<AbstractVariant> pool) {
+        return trie.lookup(getAvailableIngredients(pool));
+    }
+
+    public static <R extends Recipe<?>> Builder<R> builder() {
+        return new Builder<>();
+    }
+
+    public static class Builder<R extends Recipe<?>> {
+        private final IntArrayTrie<R> trie = new IntArrayTrie<>();
+
+        private final Map<Object, AbstractVariant> variantCache = new HashMap<>();
+        private final Object2IntOpenHashMap<AbstractVariant> variantToId = new Object2IntOpenHashMap<>();
+        private int nextVariantId = 0;
+
+        private final Object2IntMap<AbstractIngredient> ingredientToId = new Object2IntOpenHashMap<>();
+        private int nextIngredientId = 0;
+        private final int universalIngredientId;
+
+        private final Int2ObjectOpenHashMap<IntSet> variantToIngredients = new Int2ObjectOpenHashMap<>();
+
+        private Builder() {
+            variantToId.defaultReturnValue(-1);
+            ingredientToId.defaultReturnValue(-1);
+
+            universalIngredientId = getOrAssignId(AbstractIngredient.Universal.INSTANCE);
+        }
+
+        private int getOrAssignId(AbstractIngredient ingredient) {
+            return ingredientToId.computeIfAbsent(ingredient, $ -> {
+                int id = nextIngredientId++;
+                for (AbstractVariant variant : ingredient.variants) {
+                    variantToIngredients.computeIfAbsent(getOrAssignId(variant), $1 -> new IntOpenHashSet()).add(id);
+                }
+                return id;
+            });
+        }
+
+        private int getOrAssignId(AbstractVariant variant) {
+            return variantToId.computeIfAbsent(variant, $ -> nextVariantId++);
+        }
+
+        private AbstractVariant getOrAssignVariant(Item item) {
+            AbstractVariant variant = variantCache.computeIfAbsent(item, $ -> new AbstractVariant.AbstractItem(item));
+            getOrAssignId(variant);
+            return variant;
+        }
+
+        private AbstractVariant getOrAssignVariant(Fluid fluid) {
+            AbstractVariant variant = variantCache.computeIfAbsent(fluid, $ -> new AbstractVariant.AbstractFluid(fluid));
+            getOrAssignId(variant);
+            return variant;
+        }
+
+        private void insert(AbstractRecipe<? extends R> recipe) {
+            int[] key = new int[recipe.ingredients.size()];
+            int i = 0;
+            for (AbstractIngredient ingredient : recipe.ingredients) {
+                key[i++] = getOrAssignId(ingredient);
+            }
+            Arrays.sort(key);
+            trie.insert(key, recipe.recipe);
+        }
+
+        /**
+         * Insert a recipe into the trie.
+         * <br/>
+         * Will handle item ingredients for all recipes, and fluid ingredients for {@link BasinRecipe}s.
+         */
+        public <R1 extends R> void insert(R1 recipe) {
+            insert(createRecipe(recipe));
+        }
+
+        private <R1 extends R> AbstractRecipe<R1> createRecipe(R1 recipe) {
+            Set<AbstractIngredient> ingredients = new HashSet<>();
+
+            for (Ingredient ingredient : recipe.getIngredients()) {
+                if (ingredient.isEmpty()) {
+                    ingredients.add(AbstractIngredient.Universal.INSTANCE);
+                    continue;
+                }
+                if (!ingredient.isSimple()) {
+                    ingredients.add(AbstractIngredient.Universal.INSTANCE);
+                    continue;
+                }
+
+                Set<AbstractVariant> variants = new HashSet<>();
+                for (ItemStack stack : ingredient.getItems()) {
+                    variants.add(getOrAssignVariant(stack.getItem()));
+                }
+
+                ingredients.add(new AbstractIngredient(variants));
+            }
+
+            if (recipe instanceof BasinRecipe basinRecipe) for (var ingredient : basinRecipe.getFluidIngredients()) {
+                if (ingredient.getRequiredAmount() == 0) {
+                    ingredients.add(AbstractIngredient.Universal.INSTANCE);
+                    continue;
+                }
+
+                Set<AbstractVariant> variants = new HashSet<>();
+                for (FluidStack stack : ingredient.getMatchingFluidStacks()) {
+                    variants.add(getOrAssignVariant(stack.getFluid()));
+                }
+
+                ingredients.add(new AbstractIngredient(variants));
+            }
+
+            return new AbstractRecipe<>(recipe, ingredients);
+        }
+
+        public RecipeTrie<R> build() {
+            variantToId.trim();
+            variantToIngredients.trim();
+            Create.LOGGER.info(
+                "RecipeTrie of depth {} with {} nodes built with {} variants, {} ingredients, and {} recipes",
+                trie.getMaxDepth(), trie.getNodeCount(),
+                variantToId.size(), ingredientToId.size(), trie.getValueCount()
+            );
+            return new RecipeTrie<>(trie, variantToId, variantToIngredients, universalIngredientId);
+        }
+    }
+}

--- a/src/main/java/com/simibubi/create/foundation/recipe/trie/RecipeTrieFinder.java
+++ b/src/main/java/com/simibubi/create/foundation/recipe/trie/RecipeTrieFinder.java
@@ -1,0 +1,34 @@
+package com.simibubi.create.foundation.recipe.trie;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Predicate;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.simibubi.create.foundation.recipe.RecipeFinder;
+
+import net.minecraft.server.packs.resources.ResourceManagerReloadListener;
+import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.level.Level;
+
+public class RecipeTrieFinder {
+    private static final Cache<Object, RecipeTrie<?>> CACHED_TRIES = CacheBuilder.newBuilder().build();
+
+    public static RecipeTrie<?> get(@NotNull Object cacheKey, Level world, Predicate<Recipe<?>> conditions) throws ExecutionException {
+        return CACHED_TRIES.get(cacheKey, () -> {
+            List<Recipe<?>> list = RecipeFinder.get(cacheKey, world, conditions);
+
+            RecipeTrie.Builder<Recipe<?>> builder = RecipeTrie.builder();
+            for (Recipe<?> recipe : list) {
+                builder.insert(recipe);
+            }
+
+            return builder.build();
+        });
+    }
+
+	public static final ResourceManagerReloadListener LISTENER = resourceManager -> CACHED_TRIES.invalidateAll();
+}


### PR DESCRIPTION
Optimizations from [Layers-of-Railways/RailwaysTweaks](https://github.com/Layers-of-Railways/RailwaysTweaks).

Especially in modpacks with many shapeless or otherwise basin-craftable recipes, basin recipe lookup begins to take up an outsized amount of tick time. This PR (performance-tested in Mixin form on the SnR S2 server) makes the cost of basin recipe lookup negligible by:
- Caching basin heat to avoid expensive blockstate lookups for thousands of recipes.
- Using [tries](https://en.wikipedia.org/wiki/Trie) to reduce the number of recipes that actually have to be matched against.

Fixes #9184