### PR TITLE
fixed empty list filter blacklist bug in FilterItemStack

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/filter/FilterItemStack.java
+++ b/src/main/java/com/simibubi/create/content/logistics/filter/FilterItemStack.java
@@ -144,8 +144,6 @@ public class FilterItemStack {
 
 		@Override
 		public boolean test(Level world, ItemStack stack, boolean matchNBT) {
-			if (containedItems.isEmpty())
-				return super.test(world, stack, matchNBT);
 			for (FilterItemStack filterItemStack : containedItems)
 				if (filterItemStack.test(world, stack, shouldRespectNBT))
 					return !isBlacklist;


### PR DESCRIPTION
Fixed a list filter blacklist bug in FilterItemStack.java. More details about this are below.


Changes:
Removed two lines that were causing a bug in list filters. The bug occurs when an empty list filter is set to blacklist mode, it doesn't allow any item(s) through except for list filters themselves. The cause of the bug sources from the two lines of code I removed.

This is applicable to all versions of Create, not just 1.20.1.