### PR TITLE
Fix wrong chain riding animation when wrench is in offhand

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/render/PlayerSkyhookRenderer.java
+++ b/src/main/java/com/simibubi/create/foundation/render/PlayerSkyhookRenderer.java
@@ -5,6 +5,8 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
+import com.simibubi.create.AllTags.AllItemTags;
+
 import net.createmod.catnip.animation.AnimationTickHolder;
 import net.createmod.catnip.math.AngleHelper;
 import net.minecraft.client.Minecraft;
@@ -38,7 +40,8 @@ public class PlayerSkyhookRenderer {
 
 	public static void afterSetupAnim(Player player, HumanoidModel<?> model) {
 		if (hangingPlayers.contains(player.getUUID()))
-			setHangingPose(player.getMainArm() == HumanoidArm.LEFT, model);
+			setHangingPose(player.getMainArm() == HumanoidArm.LEFT ^
+				!AllItemTags.CHAIN_RIDEABLE.matches(player.getMainHandItem()), model);
 	}
 
 	private static void setHangingPose(boolean isLeftArmMain, HumanoidModel<?> model) {


### PR DESCRIPTION
xor'd with not matched in main hand instead of matches offhand since that would have the animation prefer having the wrench in the offhand, and xor'ed of course so that it isn't broken if we have both left hand enabled and are holding it in the offhand.