### PR TITLE
Fix filter inconsistencies when filtering filters

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/filter/AttributeFilterMenu.java
+++ b/src/main/java/com/simibubi/create/content/logistics/filter/AttributeFilterMenu.java
@@ -140,11 +140,6 @@ public class AttributeFilterMenu extends AbstractFilterMenu {
 			attributes.add(new ItemAttribute.ItemAttributeEntry(at.attribute(), at.inverted()));
 		});
 		filterItem.set(AllDataComponents.ATTRIBUTE_FILTER_MATCHED_ATTRIBUTES, attributes);
-
-		if (attributes.isEmpty() && whitelistMode == AttributeFilterWhitelistMode.WHITELIST_DISJ) {
-			filterItem.remove(AllDataComponents.ATTRIBUTE_FILTER_MATCHED_ATTRIBUTES);
-			filterItem.remove(AllDataComponents.ATTRIBUTE_FILTER_WHITELIST_MODE);
-		}
 	}
 
 }

--- a/src/main/java/com/simibubi/create/content/logistics/filter/FilterItemStack.java
+++ b/src/main/java/com/simibubi/create/content/logistics/filter/FilterItemStack.java
@@ -234,8 +234,7 @@ public class FilterItemStack {
 
 		@Override
 		public boolean test(Level world, ItemStack stack, boolean matchNBT) {
-			return (filterString.isBlank() && super.test(world, stack, matchNBT))
-				|| PackageItem.isPackage(stack) && PackageItem.matchAddress(stack, filterString);
+			return PackageItem.isPackage(stack) && PackageItem.matchAddress(stack, filterString);
 		}
 
 		@Override

--- a/src/main/java/com/simibubi/create/content/logistics/filter/FilterItemStack.java
+++ b/src/main/java/com/simibubi/create/content/logistics/filter/FilterItemStack.java
@@ -183,8 +183,6 @@ public class FilterItemStack {
 
 		@Override
 		public boolean test(Level world, ItemStack stack, boolean matchNBT) {
-			if (attributeTests.isEmpty())
-				return super.test(world, stack, matchNBT);
 			for (Pair<ItemAttribute, Boolean> test : attributeTests) {
 				ItemAttribute attribute = test.getFirst();
 				boolean inverted = test.getSecond();

--- a/src/main/java/com/simibubi/create/content/logistics/filter/FilterMenu.java
+++ b/src/main/java/com/simibubi/create/content/logistics/filter/FilterMenu.java
@@ -65,15 +65,6 @@ public class FilterMenu extends AbstractFilterMenu {
 		super.saveData(filterItem);
 		filterItem.set(AllDataComponents.FILTER_ITEMS_RESPECT_NBT, respectNBT);
 		filterItem.set(AllDataComponents.FILTER_ITEMS_BLACKLIST, blacklist);
-
-		if (respectNBT || blacklist)
-			return;
-		for (int i = 0; i < ghostInventory.getSlots(); i++)
-			if (!ghostInventory.getStackInSlot(i)
-				.isEmpty())
-				return;
-		filterItem.remove(AllDataComponents.FILTER_ITEMS_RESPECT_NBT);
-		filterItem.remove(AllDataComponents.FILTER_ITEMS_BLACKLIST);
 	}
 
 }

--- a/src/main/java/com/simibubi/create/content/logistics/filter/PackageFilterMenu.java
+++ b/src/main/java/com/simibubi/create/content/logistics/filter/PackageFilterMenu.java
@@ -60,12 +60,9 @@ public class PackageFilterMenu extends AbstractFilterMenu {
 	@Override
 	protected void saveData(ItemStack filterItem) {
 		super.saveData(filterItem);
-		if (address.isBlank())
-			filterItem.remove(AllDataComponents.PACKAGE_ADDRESS);
-		else
-			filterItem.set(AllDataComponents.PACKAGE_ADDRESS, address);
+		filterItem.set(AllDataComponents.PACKAGE_ADDRESS, address);
 	}
-	
+
 	@Override
 	public ItemStack quickMoveStack(Player playerIn, int index) {
 		return ItemStack.EMPTY;


### PR DESCRIPTION
This PR changes a few inconsistencies with filters. 
The primary reason for this PR is essentially the same as in #9286 except now for the allow-list case: the list filter says that an empty filter in allow mode should reject everything. Instead, if we also have ignore data (the default) on, list filters are still allowed through. This is due to ffa85dc8891362ce9baa8e84bd89326be5594e9, ever since which unmodified filters are cleared of the additional data (or even additional data in earlier Minecraft versions (e.g. #5017)) so that they can stack again immediately instead of needing to use the recipe to clear them.
In the existing code for FilterItemStack, there is a meaningful difference between 'stack has no components' (which will make a basic FilterItemStack that just filters for that specific type of item) and 'stack has the default values for its components' (which is the case described in the list filter): https://github.com/Creators-of-Create/Create/blob/0a17a7243c3e5e6e3ceb34450d9c6df240af1b83/src/main/java/com/simibubi/create/content/logistics/filter/FilterItemStack.java#L27-L32
but as described above the latter is currently unobtainable.

So to resolve that case, that convenience optimization has to be removed. I've made essentially the same changes to the attribute filter and package filter for the sake of consistency, so that all filters have their 'default' filter obtainable (admittedly, none of them are very useful filters, but it's odd for one specific filtering option to be unavailable). 

Doing so exposes further issues in the same vein as the primary reason, which I've subsequently also fixed, by removing the checking for empty states and just letting filtering for filter items be handled up in FilterItemStack:
- Package filters with an empty address string still accepting package filters.
- Attribute filters with empty attribute lists always and only accepting attribute filters, irrespective of whitelist mode (traditional definitions of 'matches any', 'matches all', and 'not matches any' would result in nothing, everything, everything, when given no predicates)