### PR TITLE
Fix sequenced assembly recipe misselection when recipes have the same transition item

### DIFF
--- a/src/main/java/com/simibubi/create/content/processing/sequenced/SequencedAssemblyRecipe.java
+++ b/src/main/java/com/simibubi/create/content/processing/sequenced/SequencedAssemblyRecipe.java
@@ -155,13 +155,15 @@ public class SequencedAssemblyRecipe implements Recipe<RecipeWrapper> {
 	}
 
 	private boolean appliesTo(ItemStack input) {
-		if (ingredient.test(input))
-			return true;
-		return input.hasTag() && getTransitionalItem().getItem() == input.getItem() && input.getTag()
-			.contains("SequencedAssembly") && input.getTag()
-			.getCompound("SequencedAssembly")
-			.getString("id")
-			.equals(id.toString());
+		// First check if the item is already in the middle of a sequenced assembly recipe
+		if (input.hasTag() && input.getTag().contains("SequencedAssembly")) {
+			return getTransitionalItem().getItem() == input.getItem() && input.getTag()
+				.getCompound("SequencedAssembly")
+				.getString("id")
+				.equals(id.toString());
+		}
+		// Else it must be the first step in a new sequenced assembly recipe
+		return ingredient.test(input);
 	}
 
 	private SequencedRecipe<?> getNextRecipe(ItemStack input) {


### PR DESCRIPTION
I've got a long one here so get ready. Fixes https://github.com/Creators-of-Create/Create/issues/3947 and probably a lot more that were previously unexplainable. 


There are no recipes in base Create that use the same transition item. Most or maybe all recipes use a separate, unique item like `create:incomplete_track` or `create:incomplete_precision_mechanism`. This is all fine and works.

By using data packs, we can add recipes that do not have this constraint. For example, both recipes below use `minecraft:netherrack` as the starter ingredient and the transition item. See section at the end for the full json for each.

<img width="302" height="240" alt="image" src="https://github.com/user-attachments/assets/b1026630-4b72-4834-80be-eb276bf7fd2e" />
<img width="302" height="240" alt="image" src="https://github.com/user-attachments/assets/6e669206-230e-4229-b923-55eb61801738" />

Both recipes are straight forward, so lets try to craft them using the below setup.

<img width="1140" height="841" alt="image" src="https://github.com/user-attachments/assets/6f7139bf-9846-46fb-8025-9be126b4b762" />

One loop of the warped mushroom yields a netherrack block with the correct sequenced nbt and the correct next step.
<img width="261" height="158" alt="image" src="https://github.com/user-attachments/assets/298171f0-3297-4187-8566-e69b373c25d0" />

But one loop of the crimson mushroom yields .. the same item with the exact same nbt. It is as if the deployer applied the warped fungus when should have applied the crimson.

```
{SequencedAssembly:{Progress:0.5f,Step:2,id:"test:sequenced_assembly/warped_nylium"}}
```

And when finishing the second loop for both cases, only warped nylium is ever produced. Furthermore, when mixing the steps together, you expectedly get the same result. There is no way to get crimson. So clearly something is wrong here.

Observations:
1. multiple recipes use the same starter ingredient
2. multiple recipes use the same transition item
3. starter ingredient for one recipe = transition item for another recipe

If (1) and the first step is the same then we have a truly ambiguous recipe - not much you can do and it is expected that something is wrong - but we don't have a ambiguous recipe in the nylium example. Create should differentiate these recipes.

If (2), Create breaks currently and leads to the above behavior. This should be fixed.

If (3), and we use the transition item with nbt as the starter ingredient for another recipe, it is up for debate. Should we
- pass on the item since it already has the sequenced assembly tag?
- process it from the beginning as if it had no nbt?

Either could work, but I think passing on the item is better (and easier to implement).

So this all leads to the code change which is thankfully really simple. Just check for the existence of the sequenced assembly nbt before checking if the item is the same. Changing these lines makes the nylium example work as expected and makes (3) pass on the item.



## Attachments

crimson_nylium.json
```json
{
  "type": "create:sequenced_assembly",
  "ingredient": {
    "item": "minecraft:netherrack"
  },
  "loops": 2,
  "results": [
    {
      "chance": 100.0,
      "item": "minecraft:crimson_nylium"
    }
  ],
  "sequence": [
    {
      "type": "create:deploying",
      "ingredients": [
        {
          "item": "minecraft:netherrack"
        },
        {
          "item": "minecraft:crimson_fungus"
        }
      ],
      "results": [
        {
          "item": "minecraft:netherrack"
        }
      ]
    },
    {
      "type": "create:pressing",
      "ingredients": [
        {
          "item": "minecraft:netherrack"
        }
      ],
      "results": [
        {
          "item": "minecraft:netherrack"
        }
      ]
    }
  ],
  "transitionalItem": {
    "item": "minecraft:netherrack"
  }
}
```

warped_nylium.json
```json
{
  "type": "create:sequenced_assembly",
  "ingredient": {
    "item": "minecraft:netherrack"
  },
  "loops": 2,
  "results": [
    {
      "chance": 100.0,
      "item": "minecraft:warped_nylium"
    }
  ],
  "sequence": [
    {
      "type": "create:deploying",
      "ingredients": [
        {
          "item": "minecraft:netherrack"
        },
        {
          "item": "minecraft:warped_fungus"
        }
      ],
      "results": [
        {
          "item": "minecraft:netherrack"
        }
      ]
    },
    {
      "type": "create:pressing",
      "ingredients": [
        {
          "item": "minecraft:netherrack"
        }
      ],
      "results": [
        {
          "item": "minecraft:netherrack"
        }
      ]
    }
  ],
  "transitionalItem": {
    "item": "minecraft:netherrack"
  }
}
```


