### PR TITLE
refactor: Clarify collection step with Contraption Actors

### DIFF
--- a/src/main/java/com/simibubi/create/api/behaviour/movement/MovementBehaviour.java
+++ b/src/main/java/com/simibubi/create/api/behaviour/movement/MovementBehaviour.java
@@ -66,7 +66,17 @@ public interface MovementBehaviour {
 		return false;
 	}
 
+	/**
+	 * @deprecated since 6.0.9 - use {@link #collectOrDropItem(context, stack)} instead.
+	 * No behaviours altered, simply a rename to reflect that we do collect items when
+	 * applicable before considering dropping the remainder into the world.
+	 */
+	@Deprecated(since = "6.0.9", forRemoval = true)
 	default void dropItem(MovementContext context, ItemStack stack) {
+		collectOrDropItem(context, stack);
+	}
+
+	default void collectOrDropItem(MovementContext context, ItemStack stack) {
 		ItemStack remainder;
 		if (AllConfigs.server().kinetics.moveItemsToStorage.get())
 			remainder = ItemHandlerHelper.insertItem(context.contraption.getStorage().getAllItems(), stack, false);

--- a/src/main/java/com/simibubi/create/content/contraptions/actors/harvester/HarvesterMovementBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/actors/harvester/HarvesterMovementBehaviour.java
@@ -90,7 +90,7 @@ public class HarvesterMovementBehaviour implements MovementBehaviour {
 				stack.shrink(1);
 				seedSubtracted.setTrue();
 			}
-			dropItem(context, stack);
+			collectOrDropItem(context, stack);
 		});
 
 		BlockState cutCrop = cutCrop(world, pos, stateVisited);

--- a/src/main/java/com/simibubi/create/content/contraptions/actors/plough/PloughMovementBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/actors/plough/PloughMovementBehaviour.java
@@ -125,7 +125,7 @@ public class PloughMovementBehaviour extends BlockBreakingMovementBehaviour {
 					.withParameter(LootContextParams.ORIGIN, Vec3.atCenterOf(pos))
 					.withParameter(LootContextParams.THIS_ENTITY, getPlayer(context))
 					.withParameter(LootContextParams.TOOL, new ItemStack(Items.IRON_SHOVEL)))
-				.forEach(s -> dropItem(context, s));
+				.forEach(s -> collectOrDropItem(context, s));
 		}
 	}
 

--- a/src/main/java/com/simibubi/create/content/contraptions/actors/roller/RollerMovementBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/actors/roller/RollerMovementBehaviour.java
@@ -178,7 +178,7 @@ public class RollerMovementBehaviour extends BlockBreakingMovementBehaviour {
 		BlockHelper.destroyBlock(context.world, breakingPos, 1f, stack -> {
 			if (noHarvest || context.world.random.nextBoolean())
 				return;
-			this.dropItem(context, stack);
+			this.collectOrDropItem(context, stack);
 		});
 
 		super.destroyBlock(context, breakingPos);

--- a/src/main/java/com/simibubi/create/content/kinetics/base/BlockBreakingMovementBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/base/BlockBreakingMovementBehaviour.java
@@ -218,7 +218,7 @@ public class BlockBreakingMovementBehaviour implements MovementBehaviour {
 	}
 
 	protected void destroyBlock(MovementContext context, BlockPos breakingPos) {
-		BlockHelper.destroyBlock(context.world, breakingPos, 1f, stack -> this.dropItem(context, stack));
+		BlockHelper.destroyBlock(context.world, breakingPos, 1f, stack -> this.collectOrDropItem(context, stack));
 	}
 
 	protected float getBlockBreakingSpeed(MovementContext context) {

--- a/src/main/java/com/simibubi/create/content/kinetics/deployer/DeployerMovementBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/deployer/DeployerMovementBehaviour.java
@@ -259,7 +259,7 @@ public class DeployerMovementBehaviour implements MovementBehaviour {
 				if (list == inv.items && i == inv.selected && filter.test(context.world, itemstack))
 					continue;
 
-				dropItem(context, itemstack);
+				collectOrDropItem(context, itemstack);
 				list.set(i, ItemStack.EMPTY);
 			}
 		}


### PR DESCRIPTION
With the expectation that the various method signatures accurately describe their functions, the "dropItem" was exceptionally hard to doubt and had been considered for several months before concluding that perhaps some side effects were implemented that the signature may not suggest.

This does not do any functional change, but improves the readability as now, in the five places where this "dropItem" was used, there is a clear indication that the item collection does happen, and suggests that the context needed to be passed not only for position, but for the contraption storage as well.