### PR TITLE
Improve TreeCutter#findTree Performance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -207,6 +207,7 @@ dependencies {
     modCompileOnly("curse.maven:xaeros-world-map-317780:6212636")
     // modImplementation("ignored:journeymap-1.20.1-5.10.1-forge")
 
+    // modRuntimeOnly("curse.maven:spark-361579:4738952")
     // modRuntimeOnly("curse.maven:framedblocks-441647:5399211")
     // modRuntimeOnly("curse.maven:galosphere-631098:4574834")
     // modRuntimeOnly("curse.maven:elementary-ores-332609:4514276") 1.19.4 only


### PR DESCRIPTION
Fixes - #9284
Is probably sufficient to resolve - #5785

So as pointed out in the more recent issue, we were performing a very expensive List#contains call, which dates back to fca3b7490958c74116a051bbd613c5738472bf38. I don't exactly see how that line ever helped with preventing infinite looping, it just seems to bypass the contains check for logs that are in the visited set (simpler solution to that though: don't add them to the visited set then) so that we can still search their neighbours.
I've resolved this by just always going to forNeighbours if something is in the frontier (and passes the relevant checks at that stage, ofc). The visited contains check (add) still needs to be done though, which brings us to improvement number 2:

The more recent issue also pointed out very high numbers of leaves and logs in the respective lists, and if we actually looked at the number of unique logs and leaves in them, they are way too high, this is just from a single oak tree, #unique after the comma:
```
[01:11:06] [Server thread/WARN] [co.si.cr.Create/]: Initial Tally
[01:11:06] [Server thread/WARN] [co.si.cr.Create/]: Logs: 4, 4   
[01:11:06] [Server thread/WARN] [co.si.cr.Create/]: Final Tally  
[01:11:06] [Server thread/WARN] [co.si.cr.Create/]: Logs: 4, 4
[01:11:06] [Server thread/WARN] [co.si.cr.Create/]: Leaves: 229, 55
[01:11:06] [Server thread/WARN] [co.si.cr.Create/]: Attachments: 0, 0
```

And mangroves are excessive:
```
[02:20:17] [Server thread/WARN] [co.si.cr.Create/]: Initial Tally
[02:20:17] [Server thread/WARN] [co.si.cr.Create/]: Logs: 43, 43 
[02:20:17] [Server thread/WARN] [co.si.cr.Create/]: After Roots  
[02:20:17] [Server thread/WARN] [co.si.cr.Create/]: Logs: 468, 64
[02:20:17] [Server thread/WARN] [co.si.cr.Create/]: Final Tally          
[02:20:17] [Server thread/WARN] [co.si.cr.Create/]: Logs: 468, 64        
[02:20:17] [Server thread/WARN] [co.si.cr.Create/]: Leaves: 3486, 586    
[02:20:17] [Server thread/WARN] [co.si.cr.Create/]: Attachments: 191, 191
```

https://github.com/Creators-of-Create/Create/blob/880ec94f86cade553f7b69a0391aaf02e2490949/src/main/java/com/simibubi/create/content/kinetics/saw/TreeCutter.java#L147-L159
Because some roots are already in the list of logs, they fail the !contains check, and get added to the list again. Also, they will likely have downward neighbours that are also already in the list. The leaves have a similar problem where the same blockpos can get added to the frontier (and leaves list) from multiple directions before it's ever added to the visited set, exacerbated by the fact that there will be duplicate roots that all do this. So solution to both cases, move the visited check/addition to directly before adding to the frontier. Do need to keep a copy of the initial logs list (as a set though, obviously) to ensure we can still add new roots while not duplicating any.

Tests were performed on this line of 8 mangroves grown into each other on a non-mob spawning superflat world, inside my dev env, which is already quite stuttery compared to a production environment.
<img width="569" height="867" alt="image" src="https://github.com/user-attachments/assets/15ed1a30-8ed8-4953-96b5-084230137b34" />

Before:
https://spark.lucko.me/1Jtr6zYYdE, 97% of SawBlockEntity#onBlockbroken is taken up by TreeCutter#findTree
```
[01:14:44] [Server thread/WARN] [co.si.cr.Create/]: Initial Tally
[01:14:44] [Server thread/WARN] [co.si.cr.Create/]: Logs: 186, 186
[01:14:52] [Server thread/WARN] [co.si.cr.Create/]: After Roots
[01:14:52] [Server thread/WARN] [co.si.cr.Create/]: Logs: 11366, 328
[01:14:54] [Server thread/WARN] [co.si.cr.Create/]: Final Tally        
[01:14:54] [Server thread/WARN] [co.si.cr.Create/]: Logs: 11366, 328   
[01:14:54] [Server thread/WARN] [co.si.cr.Create/]: Leaves: 11788, 1491
[01:14:54] [Server thread/WARN] [co.si.cr.Create/]: Attachments: 355, 355
```
After:
https://spark.lucko.me/SpQK7Gsk5b, only 13% now.
```
[01:24:31] [Server thread/WARN] [co.si.cr.Create/]: Initial Tally 
[01:24:31] [Server thread/WARN] [co.si.cr.Create/]: Logs: 186, 186
[01:24:31] [Server thread/WARN] [co.si.cr.Create/]: After Roots   
[01:24:31] [Server thread/WARN] [co.si.cr.Create/]: Logs: 328, 328
[01:24:31] [Server thread/WARN] [co.si.cr.Create/]: Final Tally       
[01:24:31] [Server thread/WARN] [co.si.cr.Create/]: Logs: 328, 328    
[01:24:31] [Server thread/WARN] [co.si.cr.Create/]: Leaves: 1491, 1491
[01:24:31] [Server thread/WARN] [co.si.cr.Create/]: Attachments: 358, 358
```