### PR TITLE
Check filter before centering package on funnel block, preventing packages getting stuck on funnels that cannot pick them up.

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/funnel/FunnelBlock.java
+++ b/src/main/java/com/simibubi/create/content/logistics/funnel/FunnelBlock.java
@@ -6,6 +6,8 @@ import com.simibubi.create.AllShapes;
 import com.simibubi.create.content.logistics.box.PackageEntity;
 import com.simibubi.create.foundation.advancement.AdvancementBehaviour;
 import com.simibubi.create.foundation.block.ProperWaterloggedBlock;
+import com.simibubi.create.foundation.blockEntity.behaviour.BlockEntityBehaviour;
+import com.simibubi.create.foundation.blockEntity.behaviour.filtering.FilteringBehaviour;
 import com.simibubi.create.foundation.item.ItemHelper;
 
 import net.createmod.catnip.math.VecHelper;
@@ -131,7 +133,8 @@ public abstract class FunnelBlock extends AbstractDirectionalFunnelBlock {
 		if (projectedDiff < 0 == (direction.getAxisDirection() == AxisDirection.POSITIVE))
 			return;
 		float yOffset = direction == Direction.UP ? 0.25f : direction == Direction.DOWN ? -0.5f : -0.5f;
-		if (!PackageEntity.centerPackage(entityIn, openPos.add(0, yOffset, 0)))
+		FilteringBehaviour filter = BlockEntityBehaviour.get(worldIn, pos, FilteringBehaviour.TYPE);
+		if (filter.test(stack) && !PackageEntity.centerPackage(entityIn, openPos.add(0, yOffset, 0)))
 			return;
 
 		ItemStack remainder = tryInsert(worldIn, pos, stack, false);


### PR DESCRIPTION
Fixes issue where brass funnels with a package filter will pull in packages with an address that does not match the filter, resulting in them getting stuck.
This allows you to filter packages with funnels while they're dropped on the ground.