### PR TITLE
Feature: Data-driven seat recognition for Contraptions

### DIFF
--- a/src/main/java/com/simibubi/create/AllTags.java
+++ b/src/main/java/com/simibubi/create/AllTags.java
@@ -96,7 +96,6 @@ public class AllTags {
 		CASING,
 		COPYCAT_ALLOW,
 		COPYCAT_DENY,
-		FAKE_SEATS,
 		FAN_PROCESSING_CATALYSTS_BLASTING(MOD, "fan_processing_catalysts/blasting"),
 		FAN_PROCESSING_CATALYSTS_HAUNTING(MOD, "fan_processing_catalysts/haunting"),
 		FAN_PROCESSING_CATALYSTS_SMOKING(MOD, "fan_processing_catalysts/smoking"),

--- a/src/main/java/com/simibubi/create/AllTags.java
+++ b/src/main/java/com/simibubi/create/AllTags.java
@@ -96,6 +96,7 @@ public class AllTags {
 		CASING,
 		COPYCAT_ALLOW,
 		COPYCAT_DENY,
+		FAKE_SEATS,
 		FAN_PROCESSING_CATALYSTS_BLASTING(MOD, "fan_processing_catalysts/blasting"),
 		FAN_PROCESSING_CATALYSTS_HAUNTING(MOD, "fan_processing_catalysts/haunting"),
 		FAN_PROCESSING_CATALYSTS_SMOKING(MOD, "fan_processing_catalysts/smoking"),

--- a/src/main/java/com/simibubi/create/content/contraptions/Contraption.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/Contraption.java
@@ -385,7 +385,7 @@ public abstract class Contraption {
 			moveWindmillBearing(pos, frontier, visited, state);
 
 		// Seats transfer their passenger to the contraption
-		if (state.getBlock() instanceof SeatBlock || AllBlockTags.FAKE_SEATS.matches(state))
+		if (AllBlockTags.SEATS.matches(state))
 			moveSeat(world, pos);
 
 		// Pulleys drag their rope and their attached structure

--- a/src/main/java/com/simibubi/create/content/contraptions/Contraption.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/Contraption.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import com.simibubi.create.AllBlockEntityTypes;
 import com.simibubi.create.AllBlocks;
+import com.simibubi.create.AllTags.AllBlockTags;
 import com.simibubi.create.AllTags.AllContraptionTypeTags;
 import com.simibubi.create.api.behaviour.interaction.MovingInteractionBehaviour;
 import com.simibubi.create.api.behaviour.movement.MovementBehaviour;
@@ -384,7 +385,7 @@ public abstract class Contraption {
 			moveWindmillBearing(pos, frontier, visited, state);
 
 		// Seats transfer their passenger to the contraption
-		if (state.getBlock() instanceof SeatBlock)
+		if (state.getBlock() instanceof SeatBlock || AllBlockTags.FAKE_SEATS.matches(state))
 			moveSeat(world, pos);
 
 		// Pulleys drag their rope and their attached structure


### PR DESCRIPTION
Treat blocks with tag create:fake_seats as seat blocks at contraption assembly. This allows for chair-like blocks from other furniture mods to be used on trains or other contraptions (see attached video).

I’m not sure if fake_seats is a bad tag name, if so, maybe custom_contraption_seats would be better.

https://github.com/user-attachments/assets/ab7debde-a920-4049-b3c7-bb162ad9946c


