### PR TITLE
applied Fix from hlysien to updated main

### DIFF
--- a/src/main/java/com/simibubi/create/content/equipment/sandPaper/SandPaperItem.java
+++ b/src/main/java/com/simibubi/create/content/equipment/sandPaper/SandPaperItem.java
@@ -23,6 +23,7 @@ import net.minecraft.world.InteractionResult;
 import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -41,7 +42,6 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.extensions.common.IClientItemExtensions;
 import net.minecraftforge.common.ToolAction;
 import net.minecraftforge.common.ToolActions;
-import net.minecraftforge.common.util.FakePlayer;
 
 @MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
@@ -132,12 +132,13 @@ public class SandPaperItem extends Item implements CustomUseEffectsItem {
 				return stack;
 			}
 
+			Inventory playerInv = player.getInventory();
 			if (!polished.isEmpty()) {
-				dropOrPlaceInInventory(player, polished);
+				playerInv.placeItemBackInInventory(polished);
 			}
 
 			if (toPolish.hasCraftingRemainingItem()) {
-				dropOrPlaceInInventory(player, toPolish.getCraftingRemainingItem());
+				playerInv.placeItemBackInInventory(toPolish.getCraftingRemainingItem());
 			}
 
 			tag.remove("Polishing");
@@ -145,14 +146,6 @@ public class SandPaperItem extends Item implements CustomUseEffectsItem {
 		}
 
 		return stack;
-	}
-
-	private void dropOrPlaceInInventory(Player player, ItemStack stack) {
-		if (player instanceof FakePlayer) {
-			player.drop(stack, false, false);
-		} else {
-			player.getInventory().placeItemBackInInventory(stack);
-		}
 	}
 
 	public static void spawnParticles(Vec3 location, ItemStack polishedStack, Level world) {

--- a/src/main/java/com/simibubi/create/content/equipment/sandPaper/SandPaperItem.java
+++ b/src/main/java/com/simibubi/create/content/equipment/sandPaper/SandPaperItem.java
@@ -142,6 +142,14 @@ public class SandPaperItem extends Item implements CustomUseEffectsItem {
 						.placeItemBackInInventory(polished);
 				}
 			}
+			if (!toPolish.isEmpty() && toPolish.hasCraftingRemainingItem()) {
+				if (player instanceof FakePlayer) {
+					player.drop(toPolish.getCraftingRemainingItem(), false, false);
+				} else {
+					player.getInventory()
+						.placeItemBackInInventory(toPolish.getCraftingRemainingItem());
+				}
+			}
 			tag.remove("Polishing");
 			stack.hurtAndBreak(1, entityLiving, p -> p.broadcastBreakEvent(p.getUsedItemHand()));
 		}

--- a/src/main/java/com/simibubi/create/content/equipment/sandPaper/SandPaperItem.java
+++ b/src/main/java/com/simibubi/create/content/equipment/sandPaper/SandPaperItem.java
@@ -117,44 +117,42 @@ public class SandPaperItem extends Item implements CustomUseEffectsItem {
 	}
 
 	@Override
-	public ItemStack finishUsingItem(ItemStack stack, Level worldIn, LivingEntity entityLiving) {
+	public ItemStack finishUsingItem(ItemStack stack, Level level, LivingEntity entityLiving) {
 		if (!(entityLiving instanceof Player player))
 			return stack;
 		CompoundTag tag = stack.getOrCreateTag();
 		if (tag.contains("Polishing")) {
 			ItemStack toPolish = ItemStack.of(tag.getCompound("Polishing"));
 			ItemStack polished =
-				SandPaperPolishingRecipe.applyPolish(worldIn, entityLiving.position(), toPolish, stack);
+				SandPaperPolishingRecipe.applyPolish(level, entityLiving.position(), toPolish, stack);
 
-			if (worldIn.isClientSide) {
+			if (level.isClientSide) {
 				spawnParticles(entityLiving.getEyePosition(1)
-						.add(entityLiving.getLookAngle()
-							.scale(.5f)),
-					toPolish, worldIn);
+					.add(entityLiving.getLookAngle().scale(.5f)), toPolish, level);
 				return stack;
 			}
 
 			if (!polished.isEmpty()) {
-				if (player instanceof FakePlayer) {
-					player.drop(polished, false, false);
-				} else {
-					player.getInventory()
-						.placeItemBackInInventory(polished);
-				}
+				dropOrPlaceInInventory(player, polished);
 			}
-			if (!toPolish.isEmpty() && toPolish.hasCraftingRemainingItem()) {
-				if (player instanceof FakePlayer) {
-					player.drop(toPolish.getCraftingRemainingItem(), false, false);
-				} else {
-					player.getInventory()
-						.placeItemBackInInventory(toPolish.getCraftingRemainingItem());
-				}
+
+			if (toPolish.hasCraftingRemainingItem()) {
+				dropOrPlaceInInventory(player, toPolish.getCraftingRemainingItem());
 			}
+
 			tag.remove("Polishing");
 			stack.hurtAndBreak(1, entityLiving, p -> p.broadcastBreakEvent(p.getUsedItemHand()));
 		}
 
 		return stack;
+	}
+
+	private void dropOrPlaceInInventory(Player player, ItemStack stack) {
+		if (player instanceof FakePlayer) {
+			player.drop(stack, false, false);
+		} else {
+			player.getInventory().placeItemBackInInventory(stack);
+		}
 	}
 
 	public static void spawnParticles(Vec3 location, ItemStack polishedStack, Level world) {

--- a/src/main/java/com/simibubi/create/content/kinetics/crusher/CrushingWheelControllerBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/crusher/CrushingWheelControllerBlockEntity.java
@@ -296,8 +296,8 @@ public class CrushingWheelControllerBlockEntity extends SmartBlockEntity {
 
 		List<ItemStack> list = new ArrayList<>();
 		if (recipe.isPresent()) {
-			int rolls = inventory.getStackInSlot(0)
-				.getCount();
+			ItemStack input = inventory.getStackInSlot(0);
+			int rolls = input.getCount();
 			inventory.clear();
 			for (int roll = 0; roll < rolls; roll++) {
 				List<ItemStack> rolledResults = recipe.get()
@@ -306,6 +306,9 @@ public class CrushingWheelControllerBlockEntity extends SmartBlockEntity {
 					ItemHelper.addToList(stack, list);
 				}
 			}
+			if (input.hasCraftingRemainingItem()) {
+					ItemHelper.addToList(input.getCraftingRemainingItem(), list);
+				}
 			for (int slot = 0; slot < list.size() && slot + 1 < inventory.getSlots(); slot++)
 				inventory.setStackInSlot(slot + 1, list.get(slot));
 		} else {

--- a/src/main/java/com/simibubi/create/content/kinetics/deployer/BeltDeployerCallbacks.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/deployer/BeltDeployerCallbacks.java
@@ -25,6 +25,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.level.Level;
@@ -97,7 +98,7 @@ public class BeltDeployerCallbacks {
 								DeployerBlockEntity blockEntity, Recipe<?> recipe) {
 
 		List<TransportedItemStack> collect =
-			RecipeApplier.applyRecipeOn(blockEntity.getLevel(), ItemHandlerHelper.copyStackWithSize(transported.stack, 1), recipe)
+			RecipeApplier.applyRecipeOn(blockEntity.getLevel(), ItemHandlerHelper.copyStackWithSize(transported.stack, 1), recipe,true)
 				.stream()
 				.map(stack -> {
 					TransportedItemStack copy = transported.copy();
@@ -139,7 +140,16 @@ public class BeltDeployerCallbacks {
 				heldItem.hurtAndBreak(1, blockEntity.player,
 					s -> s.broadcastBreakEvent(InteractionHand.MAIN_HAND));
 			} else {
+				Player player = blockEntity.player;
+				ItemStack leftover = heldItem.hasCraftingRemainingItem() ? heldItem.getCraftingRemainingItem() : ItemStack.EMPTY;
 				heldItem.shrink(1);
+				if (heldItem.isEmpty()) {
+					player.setItemInHand(InteractionHand.MAIN_HAND, leftover);
+				} else {
+					if (!player.getInventory().add(leftover)) {
+						player.drop(leftover, false);
+					}
+				}
 			}
 		}
 

--- a/src/main/java/com/simibubi/create/content/kinetics/deployer/BeltDeployerCallbacks.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/deployer/BeltDeployerCallbacks.java
@@ -141,7 +141,7 @@ public class BeltDeployerCallbacks {
 					s -> s.broadcastBreakEvent(InteractionHand.MAIN_HAND));
 			} else {
 				Player player = blockEntity.player;
-				ItemStack leftover = heldItem.hasCraftingRemainingItem() ? heldItem.getCraftingRemainingItem() : ItemStack.EMPTY;
+				ItemStack leftover = heldItem.getCraftingRemainingItem();
 				heldItem.shrink(1);
 				if (heldItem.isEmpty()) {
 					player.setItemInHand(InteractionHand.MAIN_HAND, leftover);

--- a/src/main/java/com/simibubi/create/content/kinetics/deployer/ManualApplicationRecipe.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/deployer/ManualApplicationRecipe.java
@@ -90,7 +90,7 @@ public class ManualApplicationRecipe extends ItemApplicationRecipe {
 			} else {
 				Player player = event.getEntity();
 				InteractionHand hand = event.getHand();
-				ItemStack leftover = heldItem.hasCraftingRemainingItem() ? heldItem.getCraftingRemainingItem() : ItemStack.EMPTY;
+				ItemStack leftover = heldItem.getCraftingRemainingItem();
 				heldItem.shrink(1);
 				if (heldItem.isEmpty()) {
 					player.setItemInHand(hand, leftover);

--- a/src/main/java/com/simibubi/create/content/kinetics/deployer/ManualApplicationRecipe.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/deployer/ManualApplicationRecipe.java
@@ -88,7 +88,17 @@ public class ManualApplicationRecipe extends ItemApplicationRecipe {
 				heldItem.hurtAndBreak(1, event.getEntity(),
 					s -> s.broadcastBreakEvent(InteractionHand.MAIN_HAND));
 			} else {
+				Player player = event.getEntity();
+				InteractionHand hand = event.getHand();
+				ItemStack leftover = heldItem.hasCraftingRemainingItem() ? heldItem.getCraftingRemainingItem() : ItemStack.EMPTY;
 				heldItem.shrink(1);
+				if (heldItem.isEmpty()) {
+					player.setItemInHand(hand, leftover);
+				} else {
+					if (!player.getInventory().add(leftover)) {
+						player.drop(leftover, false);
+					}
+				}
 			}
 		}
 

--- a/src/main/java/com/simibubi/create/content/kinetics/fan/processing/AllFanProcessingTypes.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/fan/processing/AllFanProcessingTypes.java
@@ -166,7 +166,7 @@ public class AllFanProcessingTypes {
 						.getResultItem(registryAccess),
 					smeltingRecipe.get()
 						.getResultItem(registryAccess))) {
-					return RecipeApplier.applyRecipeOn(level, stack, smeltingRecipe.get());
+					return RecipeApplier.applyRecipeOn(level, stack, smeltingRecipe.get(),false);
 				}
 			}
 
@@ -239,7 +239,7 @@ public class AllFanProcessingTypes {
 			HAUNTING_WRAPPER.setItem(0, stack);
 			Optional<HauntingRecipe> recipe = AllRecipeTypes.HAUNTING.find(HAUNTING_WRAPPER, level);
 			if (recipe.isPresent())
-				return RecipeApplier.applyRecipeOn(level, stack, recipe.get());
+				return RecipeApplier.applyRecipeOn(level, stack, recipe.get(),true);
 			return null;
 		}
 
@@ -365,7 +365,7 @@ public class AllFanProcessingTypes {
 				.filter(AllRecipeTypes.CAN_BE_AUTOMATED);
 
 			if (smokingRecipe.isPresent())
-				return RecipeApplier.applyRecipeOn(level, stack, smokingRecipe.get());
+				return RecipeApplier.applyRecipeOn(level, stack, smokingRecipe.get(),false);
 
 			return null;
 		}
@@ -430,7 +430,7 @@ public class AllFanProcessingTypes {
 			SPLASHING_WRAPPER.setItem(0, stack);
 			Optional<SplashingRecipe> recipe = AllRecipeTypes.SPLASHING.find(SPLASHING_WRAPPER, level);
 			if (recipe.isPresent())
-				return RecipeApplier.applyRecipeOn(level, stack, recipe.get());
+				return RecipeApplier.applyRecipeOn(level, stack, recipe.get(),true);
 			return null;
 		}
 

--- a/src/main/java/com/simibubi/create/content/kinetics/millstone/MillstoneBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/millstone/MillstoneBlockEntity.java
@@ -140,10 +140,14 @@ public class MillstoneBlockEntity extends KineticBlockEntity {
 		}
 
 		ItemStack stackInSlot = inputInv.getStackInSlot(0);
+		ItemStack craftingRemainingItem = stackInSlot.getCraftingRemainingItem();
 		stackInSlot.shrink(1);
 		inputInv.setStackInSlot(0, stackInSlot);
 		lastRecipe.rollResults()
 			.forEach(stack -> ItemHandlerHelper.insertItemStacked(outputInv, stack, false));
+		if (!craftingRemainingItem.isEmpty()) {
+			ItemHandlerHelper.insertItemStacked(outputInv, craftingRemainingItem, false);
+		}
 		award(AllAdvancements.MILLSTONE);
 
 		sendData();

--- a/src/main/java/com/simibubi/create/content/kinetics/press/MechanicalPressBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/press/MechanicalPressBlockEntity.java
@@ -3,8 +3,6 @@ package com.simibubi.create.content.kinetics.press;
 import java.util.List;
 import java.util.Optional;
 
-import org.checkerframework.checker.units.qual.C;
-
 import com.simibubi.create.AllRecipeTypes;
 import com.simibubi.create.AllTags;
 import com.simibubi.create.content.kinetics.belt.transport.TransportedItemStack;

--- a/src/main/java/com/simibubi/create/content/kinetics/press/MechanicalPressBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/press/MechanicalPressBlockEntity.java
@@ -3,6 +3,8 @@ package com.simibubi.create.content.kinetics.press;
 import java.util.List;
 import java.util.Optional;
 
+import org.checkerframework.checker.units.qual.C;
+
 import com.simibubi.create.AllRecipeTypes;
 import com.simibubi.create.AllTags;
 import com.simibubi.create.content.kinetics.belt.transport.TransportedItemStack;
@@ -124,12 +126,12 @@ public class MechanicalPressBlockEntity extends BasinOperatingBlockEntity implem
 		ItemStack itemCreated = ItemStack.EMPTY;
 		pressingBehaviour.particleItems.add(item);
 		if (canProcessInBulk() || item.getCount() == 1) {
-			RecipeApplier.applyRecipeOn(itemEntity, recipe.get());
+			RecipeApplier.applyRecipeOn(itemEntity, recipe.get(), true);
 			itemCreated = itemEntity.getItem()
 				.copy();
 		} else {
 			for (ItemStack result : RecipeApplier.applyRecipeOn(level, ItemHandlerHelper.copyStackWithSize(item, 1),
-				recipe.get())) {
+				recipe.get(),true)) {
 				if (itemCreated.isEmpty())
 					itemCreated = result.copy();
 				ItemEntity created =
@@ -155,7 +157,7 @@ public class MechanicalPressBlockEntity extends BasinOperatingBlockEntity implem
 			return true;
 		pressingBehaviour.particleItems.add(input.stack);
 		List<ItemStack> outputs = RecipeApplier.applyRecipeOn(level,
-			canProcessInBulk() ? input.stack : ItemHandlerHelper.copyStackWithSize(input.stack, 1), recipe.get());
+			canProcessInBulk() ? input.stack : ItemHandlerHelper.copyStackWithSize(input.stack, 1), recipe.get(), true);
 
 		for (ItemStack created : outputs) {
 			if (!created.isEmpty()) {

--- a/src/main/java/com/simibubi/create/content/kinetics/saw/SawBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/saw/SawBlockEntity.java
@@ -365,6 +365,8 @@ public class SawBlockEntity extends BlockBreakingKineticBlockEntity {
 			for (ItemStack stack : results) {
 				ItemHelper.addToList(stack, list);
 			}
+			if (input.hasCraftingRemainingItem())
+				ItemHelper.addToList(input.getCraftingRemainingItem(), list);
 		}
 
 		for (int slot = 0; slot < list.size() && slot + 1 < inventory.getSlots(); slot++)

--- a/src/main/java/com/simibubi/create/foundation/recipe/RecipeApplier.java
+++ b/src/main/java/com/simibubi/create/foundation/recipe/RecipeApplier.java
@@ -15,8 +15,8 @@ import net.minecraft.world.level.Level;
 import net.minecraftforge.items.ItemHandlerHelper;
 
 public class RecipeApplier {
-	public static void applyRecipeOn(ItemEntity entity, Recipe<?> recipe) {
-		List<ItemStack> stacks = applyRecipeOn(entity.level(), entity.getItem(), recipe);
+	public static void applyRecipeOn(ItemEntity entity, Recipe<?> recipe, boolean returnProcessingRemainder) {
+		List<ItemStack> stacks = applyRecipeOn(entity.level(), entity.getItem(), recipe, returnProcessingRemainder);
 		if (stacks == null)
 			return;
 		if (stacks.isEmpty()) {
@@ -31,7 +31,7 @@ public class RecipeApplier {
 		}
 	}
 
-	public static List<ItemStack> applyRecipeOn(Level level, ItemStack stackIn, Recipe<?> recipe) {
+	public static List<ItemStack> applyRecipeOn(Level level, ItemStack stackIn, Recipe<?> recipe, boolean returnProcessingRemainder) { {
 		List<ItemStack> stacks;
 
 		if (recipe instanceof ProcessingRecipe<?> pr) {
@@ -56,6 +56,10 @@ public class RecipeApplier {
 
 					stacks.add(stack);
 				}
+				if (returnProcessingRemainder && stackIn.hasCraftingRemainingItem()) {
+					ItemHelper.addToList(stackIn.getCraftingRemainingItem(), stacks);
+				}
+
 			}
 		} else {
 			ItemStack out = recipe.getResultItem(level.registryAccess())

--- a/src/main/java/com/simibubi/create/foundation/recipe/RecipeApplier.java
+++ b/src/main/java/com/simibubi/create/foundation/recipe/RecipeApplier.java
@@ -12,6 +12,7 @@ import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.level.Level;
+
 import net.minecraftforge.items.ItemHandlerHelper;
 
 public class RecipeApplier {
@@ -31,7 +32,7 @@ public class RecipeApplier {
 		}
 	}
 
-	public static List<ItemStack> applyRecipeOn(Level level, ItemStack stackIn, Recipe<?> recipe, boolean returnProcessingRemainder) { {
+	public static List<ItemStack> applyRecipeOn(Level level, ItemStack stackIn, Recipe<?> recipe, boolean returnProcessingRemainder) {
 		List<ItemStack> stacks;
 
 		if (recipe instanceof ProcessingRecipe<?> pr) {


### PR DESCRIPTION
This is related to the pull request https://github.com/Creators-of-Create/Create/compare/mc1.20.1/dev...hlysine:Create:fix/crafting-remaining-item.
It applies all this Some items in Minecraft contains "crafting remaining items" which are left behind when the item is used in crafting, e.g. empty buckets are left behind when crafting a cake with milk buckets. This is also how mods implement inconsumable crafting ingredients. However, over half of Create's recipe types do not respect this method, causing unexpected results such as https://github.com/Creators-of-Create/Create/issues/4853 and https://github.com/Creators-of-Create/Create/issues/4963.

Seeing that this issue has been in Create for years and I'm already patching one aspect of it in Create: Connected, I've decided to upstream the patch and fix all recipe types once and for all.

Recipe types that already return crafting remaining items include:

    Automated shaped crafting
    Mechanical crafting
    Mixing
    Compacting

Recipe types that did not return remaining items but are fixed in this PR include:

    Crushing
    Deploying
    Fan processing (bulk blasting and smoking removes the remainder to be consistent with vanilla furnace behavior)
    Manual item application
    Milling
    Pressing
    Sandpaper polishing
    Sawing

For your convenience, here's a datapack that adds all types of recipes for lava buckets, so you can verify that an empty bucket remains after processing: [crafting-remaining-items-data.zip](https://github.com/user-attachments/files/20438824/crafting-remaining-items-data.zip)

To the current main branch and resolves the merge conflicts