### PR TITLE
Fix for #9214

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/Contraption.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/Contraption.java
@@ -5,9 +5,11 @@ import static com.simibubi.create.content.contraptions.piston.MechanicalPistonBl
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -181,7 +183,7 @@ public abstract class Contraption {
 	protected ContraptionWorld collisionLevel;
 
 	public Contraption() {
-		blocks = new HashMap<>();
+		blocks = new LinkedHashMap<>();
 		updateTags = new HashMap<>();
 		isLegacy = new Object2BooleanArrayMap<>();
 		seats = new ArrayList<>();
@@ -1009,6 +1011,12 @@ public abstract class Contraption {
 	}
 
 	public void removeBlocksFromWorld(Level world, BlockPos offset) {
+		// Invert order of the blocks LinkedHashMap, so all posterior iterations are inverted
+		List<Map.Entry<BlockPos, StructureBlockInfo>> entries = new ArrayList<>(blocks.entrySet());
+		Collections.reverse(entries);
+		blocks.clear();
+		entries.forEach(e -> blocks.put(e.getKey(), e.getValue()));
+
 		glueToRemove.forEach(glue -> {
 			superglue.add(glue.getBoundingBox()
 				.move(Vec3.atLowerCornerOf(offset.offset(anchor))

--- a/src/main/java/com/simibubi/create/content/contraptions/Contraption.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/Contraption.java
@@ -5,7 +5,6 @@ import static com.simibubi.create.content.contraptions.piston.MechanicalPistonBl
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -16,6 +15,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Queue;
+import java.util.SequencedMap;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
@@ -144,7 +144,7 @@ public abstract class Contraption {
 	public boolean disassembled;
 
 	// TODO: SoA to reduce map lookups.
-	protected Map<BlockPos, StructureBlockInfo> blocks;
+	protected SequencedMap<BlockPos, StructureBlockInfo> blocks;
 	protected Map<BlockPos, CompoundTag> updateTags;
 	public Object2BooleanMap<BlockPos> isLegacy;
 	protected List<MutablePair<StructureBlockInfo, MovementContext>> actors;
@@ -1011,12 +1011,6 @@ public abstract class Contraption {
 	}
 
 	public void removeBlocksFromWorld(Level world, BlockPos offset) {
-		// Invert order of the blocks LinkedHashMap, so all posterior iterations are inverted
-		List<Map.Entry<BlockPos, StructureBlockInfo>> entries = new ArrayList<>(blocks.entrySet());
-		Collections.reverse(entries);
-		blocks.clear();
-		entries.forEach(e -> blocks.put(e.getKey(), e.getValue()));
-
 		glueToRemove.forEach(glue -> {
 			superglue.add(glue.getBoundingBox()
 				.move(Vec3.atLowerCornerOf(offset.offset(anchor))
@@ -1029,7 +1023,7 @@ public abstract class Contraption {
 			minimisedGlue.add(null);
 
 		for (boolean brittles : Iterate.trueAndFalse) {
-			for (Iterator<StructureBlockInfo> iterator = blocks.values()
+			for (Iterator<StructureBlockInfo> iterator = blocks.reversed().values()
 				.iterator(); iterator.hasNext(); ) {
 				StructureBlockInfo block = iterator.next();
 				if (brittles != BlockMovementChecks.isBrittle(block.state()))
@@ -1077,7 +1071,7 @@ public abstract class Contraption {
 				superglue.add(bb);
 		}
 
-		for (StructureBlockInfo block : blocks.values()) {
+		for (StructureBlockInfo block : blocks.reversed().values()) {
 			BlockPos add = block.pos().offset(anchor)
 				.offset(offset);
 //			if (!shouldUpdateAfterMovement(block))


### PR DESCRIPTION
Links can be attached  to contraptions in chains, causing  trees of dependencies of the order they need to be deleted when the contraption is assembled.  This change makes so the information of that dependency (the insertion order to the HashMap) is not lost by using a LinkedHashMap, and  it is used to remove the blocks in the proper order by iterating that LinkedHashMap in reverse. This fixes #9214.


<img width="687" height="477" alt="{7B9DCFB8-9410-4C18-92AC-CD033CF7A80D}" src="https://github.com/user-attachments/assets/4730f661-12bb-447a-961f-273e755cb775" />
fancy links shapes :D



It's a proposal cose I only used data structures of "java.util.". Any HashMap that guarantees that the iteration order will be the insertion one and it can be iterated in reverse would be a nice candidate, even if its a custom one.  

edit: Java 21 now has SequencedMap and it has reversed()
