### PR TITLE
Fixes #9488 & #9501

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/chute/ChuteItemHandler.java
+++ b/src/main/java/com/simibubi/create/content/logistics/chute/ChuteItemHandler.java
@@ -2,6 +2,7 @@ package com.simibubi.create.content.logistics.chute;
 
 import com.simibubi.create.foundation.item.ItemHelper;
 
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.world.item.ItemStack;
 
 import net.neoforged.neoforge.items.IItemHandler;
@@ -45,7 +46,7 @@ public class ChuteItemHandler implements IItemHandler {
 
 	@Override
 	public int getSlotLimit(int slot) {
-		return Math.min(getStackInSlot(slot).getMaxStackSize(), 64);
+		return Math.min(getStackInSlot(slot).getOrDefault(DataComponents.MAX_STACK_SIZE, 64), 64);
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/foundation/data/recipe/CreateStandardRecipeGen.java
+++ b/src/main/java/com/simibubi/create/foundation/data/recipe/CreateStandardRecipeGen.java
@@ -161,7 +161,7 @@ public final class CreateStandardRecipeGen extends BaseRecipeProvider {
 		BOUND_CARDBOARD_BLOCK = create(AllBlocks.BOUND_CARDBOARD_BLOCK).returns(1)
 			.unlockedBy(I::cardboard)
 			.viaShapeless(b -> b.requires(AllBlocks.CARDBOARD_BLOCK.get())
-				.requires(Items.STRING)),
+				.requires(Tags.Items.STRINGS)),
 
 		CARDBOARD_FROM_BLOCK = create(AllItems.CARDBOARD).withSuffix("_from_block")
 			.returns(4)


### PR DESCRIPTION
Applys the same fix Thundxr made to Chutes.

<img width="370" height="223" alt="Screenshot 2025-11-07 at 15 21 04" src="https://github.com/user-attachments/assets/c480917b-1c1a-4fd2-b412-9542a6ac9964" />

Attached image to show it works. I forgot to show nbt data for the chute but it has no items in it.

Also fixes recipe for bound cardboard boxes for 1.21.1.