### PR TITLE
Simplistic cache for TreeFertilizerItem's TreesDreamWorld.

### DIFF
--- a/src/main/java/com/simibubi/create/content/equipment/TreeFertilizerItem.java
+++ b/src/main/java/com/simibubi/create/content/equipment/TreeFertilizerItem.java
@@ -1,14 +1,18 @@
 package com.simibubi.create.content.equipment;
 
 
+import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
 import net.createmod.catnip.levelWrappers.PlacementSimulationServerLevel;
 import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.item.BoneMealItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.BonemealableBlock;
@@ -16,7 +20,14 @@ import net.minecraft.world.level.block.MangrovePropaguleBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 
+import java.util.Map;
+
 public class TreeFertilizerItem extends Item {
+	private static final Map<ResourceKey<Level>, TreesDreamWorld> WORLD_CACHE = new Reference2ObjectOpenHashMap<>();
+
+	public static void clearCache() {
+		WORLD_CACHE.clear();
+	}
 
 	public TreeFertilizerItem(Properties properties) {
 		super(properties);
@@ -38,8 +49,11 @@ public class TreeFertilizerItem extends Item {
 				return InteractionResult.SUCCESS;
 			}
 
+			ServerLevel level = (ServerLevel) context.getLevel();
+
 			BlockPos saplingPos = context.getClickedPos();
-			TreesDreamWorld world = new TreesDreamWorld((ServerLevel) context.getLevel(), saplingPos);
+			TreesDreamWorld world = WORLD_CACHE.computeIfAbsent(level.dimension(), k -> new TreesDreamWorld(level));
+			world.initializeSoil(level.getBlockState(saplingPos.below()));
 
 			for (BlockPos pos : BlockPos.betweenClosed(-1, 0, -1, 1, 0, 1)) {
 				if (context.getLevel()
@@ -90,17 +104,19 @@ public class TreeFertilizerItem extends Item {
 	}
 
 	private static class TreesDreamWorld extends PlacementSimulationServerLevel {
-		private final BlockState soil;
+		private BlockState soil;
 
-		protected TreesDreamWorld(ServerLevel wrapped, BlockPos saplingPos) {
+		protected TreesDreamWorld(ServerLevel wrapped) {
 			super(wrapped);
-			BlockState stateUnderSapling = wrapped.getBlockState(saplingPos.below());
+		}
 
+		public void initializeSoil(BlockState stateUnderSapling) {
 			// Tree features don't seem to succeed with mud as soil
 			if (stateUnderSapling.is(BlockTags.DIRT))
 				stateUnderSapling = Blocks.DIRT.defaultBlockState();
 
 			soil = stateUnderSapling;
+			blocksAdded.clear();
 		}
 
 		@Override
@@ -117,5 +133,4 @@ public class TreeFertilizerItem extends Item {
 			return super.setBlock(pos, newState, flags);
 		}
 	}
-
 }

--- a/src/main/java/com/simibubi/create/foundation/events/CommonEvents.java
+++ b/src/main/java/com/simibubi/create/foundation/events/CommonEvents.java
@@ -6,6 +6,7 @@ import com.simibubi.create.content.contraptions.ContraptionHandler;
 import com.simibubi.create.content.contraptions.actors.trainControls.ControlsServerHandler;
 import com.simibubi.create.content.contraptions.minecart.CouplingPhysics;
 import com.simibubi.create.content.contraptions.minecart.capability.CapabilityMinecartController;
+import com.simibubi.create.content.equipment.TreeFertilizerItem;
 import com.simibubi.create.content.equipment.toolbox.ToolboxHandler;
 import com.simibubi.create.content.equipment.wrench.WrenchItem;
 import com.simibubi.create.content.equipment.zapper.ZapperInteractionHandler;
@@ -165,6 +166,7 @@ public class CommonEvents {
 		Create.TORQUE_PROPAGATOR.onUnloadWorld(world);
 		WorldAttached.invalidateWorld(world);
 		CobbleGenOptimisation.invalidateWorld(world);
+		TreeFertilizerItem.clearCache();
 	}
 
 	@SubscribeEvent


### PR DESCRIPTION
@Jozufozu requested I post this after I mentioned server difficulties with a bunch of people extensively using tree fertilizer in contraptions.

It would appear that TreeFertilizerItem hasn't been modified since the 0.0.1 1.14 code base.  Apart from consistently creating a `TreesDreamWorld` level every time the item is used, the checks for which blocks should be replaced in the real world isn't as extensive as it could be.

EDIT: This is a draft because I wrote this while (and still am) recovering from influenza A and I've no idea why I used a Reference2ObjectMap and it doesn't fit the same paradigm that the rest of the level caches use.