### PR TITLE
Fix Portable Storage Interface Connection Issue

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/actors/psi/PortableItemInterfaceBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/actors/psi/PortableItemInterfaceBlockEntity.java
@@ -34,6 +34,8 @@ public class PortableItemInterfaceBlockEntity extends PortableStorageInterfaceBl
 	public void startTransferringTo(Contraption contraption, float distance) {
 		capability = new InterfaceItemHandler(contraption.getStorage().getAllItems());
 		invalidateCapability();
+        if (level != null && !level.isClientSide)
+            level.updateNeighborsAt(worldPosition, getBlockState().getBlock());
 		super.startTransferringTo(contraption, distance);
 	}
 
@@ -41,6 +43,8 @@ public class PortableItemInterfaceBlockEntity extends PortableStorageInterfaceBl
 	protected void stopTransferring() {
 		capability = createEmptyHandler();
 		invalidateCapability();
+        if (level != null && !level.isClientSide)
+            level.updateNeighborsAt(worldPosition, getBlockState().getBlock());
 		super.stopTransferring();
 	}
 


### PR DESCRIPTION
Fixes #7882

This fixes the portable storage interface not connecting by updating neighbors to ensure blocks like funnels can always get the correct capability state.

Before:

https://github.com/user-attachments/assets/57a2275f-d72b-413b-9b01-b6d1aa8437b7




After:

https://github.com/user-attachments/assets/8e98cb3a-2c00-4178-8bde-e864262a348e



