### PR TITLE
Fix Furnace Minecart contraption not stopping when mining blocks

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/OrientedContraptionEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/OrientedContraptionEntity.java
@@ -281,7 +281,7 @@ public class OrientedContraptionEntity extends AbstractContraptionEntity {
 		boolean isStalled = isStalled();
 
 		MinecartController controller = riding.getData(AllAttachmentTypes.MINECART_CONTROLLER);
-		if (controller != MinecartController.EMPTY) {
+		if (controller.isPresent()) {
 			if (!level().isClientSide())
 				controller.setStalledExternally(isStalled);
 		} else {

--- a/src/main/java/com/simibubi/create/content/contraptions/minecart/MinecartSim2020.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/minecart/MinecartSim2020.java
@@ -55,7 +55,7 @@ public class MinecartSim2020 {
 				&& Mth.equal(furnace.zPush, 0);
 
 		MinecartController controller = c.getData(AllAttachmentTypes.MINECART_CONTROLLER);
-		if (controller != MinecartController.EMPTY)
+		if (controller.isPresent())
 			return !controller.isStalled();
 		return true;
 	}


### PR DESCRIPTION
When a minecart controller is loaded from disk, the controller's cart reference is [initialized as null](https://github.com/Creators-of-Create/Create/blob/abcfbaf9ba4d27e91f0e83c96bd135c0b9e6eb63/src/main/java/com/simibubi/create/content/contraptions/minecart/capability/MinecartController.java#L600C5-L600C8). However, the stalling logic checks if `controller != MinecartController.EMPTY`. Changing it to `controller.isPresent()` ensures that null references work as expected. 

fixes #8031 

Before:

https://github.com/user-attachments/assets/86a6bd05-dacf-4dcc-a573-b5397060004e

After:

https://github.com/user-attachments/assets/d0a00e3f-c58b-42a5-9603-7531a865f219


