### PR TITLE
Refactor Basin's behaviour on Contraptions

### DIFF
--- a/src/main/java/com/simibubi/create/AllBlocks.java
+++ b/src/main/java/com/simibubi/create/AllBlocks.java
@@ -209,6 +209,7 @@ import com.simibubi.create.content.processing.AssemblyOperatorBlockItem;
 import com.simibubi.create.content.processing.basin.BasinBlock;
 import com.simibubi.create.content.processing.basin.BasinGenerator;
 import com.simibubi.create.content.processing.basin.BasinMovementBehaviour;
+import com.simibubi.create.content.processing.basin.MountedBasinInteractionBehaviour;
 import com.simibubi.create.content.processing.burner.BlazeBurnerBlock;
 import com.simibubi.create.content.processing.burner.BlazeBurnerBlockItem;
 import com.simibubi.create.content.processing.burner.BlazeBurnerMovementBehaviour;
@@ -740,6 +741,7 @@ public class AllBlocks {
 		.blockstate(new BasinGenerator()::generate)
 		.addLayer(() -> RenderType::cutoutMipped)
 		.onRegister(movementBehaviour(new BasinMovementBehaviour()))
+		.onRegister(interactionBehaviour(new MountedBasinInteractionBehaviour()))
 		.transform(mountedItemStorage(AllMountedStorageTypes.BASIN_ITEM))
 		.item()
 		.transform(customItemModel("_", "block"))

--- a/src/main/java/com/simibubi/create/AllBlocks.java
+++ b/src/main/java/com/simibubi/create/AllBlocks.java
@@ -743,6 +743,7 @@ public class AllBlocks {
 		.onRegister(movementBehaviour(new BasinMovementBehaviour()))
 		.onRegister(interactionBehaviour(new MountedBasinInteractionBehaviour()))
 		.transform(mountedItemStorage(AllMountedStorageTypes.BASIN_ITEM))
+		.transform(mountedFluidStorage(AllMountedStorageTypes.BASIN_FLUID))
 		.item()
 		.transform(customItemModel("_", "block"))
 		.register();

--- a/src/main/java/com/simibubi/create/AllBlocks.java
+++ b/src/main/java/com/simibubi/create/AllBlocks.java
@@ -740,6 +740,7 @@ public class AllBlocks {
 		.blockstate(new BasinGenerator()::generate)
 		.addLayer(() -> RenderType::cutoutMipped)
 		.onRegister(movementBehaviour(new BasinMovementBehaviour()))
+		.transform(mountedItemStorage(AllMountedStorageTypes.BASIN_ITEM))
 		.item()
 		.transform(customItemModel("_", "block"))
 		.register();

--- a/src/main/java/com/simibubi/create/AllMountedStorageTypes.java
+++ b/src/main/java/com/simibubi/create/AllMountedStorageTypes.java
@@ -13,6 +13,7 @@ import com.simibubi.create.content.fluids.tank.storage.creative.CreativeFluidTan
 import com.simibubi.create.content.logistics.crate.CreativeCrateMountedStorageType;
 import com.simibubi.create.content.logistics.depot.storage.DepotMountedStorageType;
 import com.simibubi.create.content.logistics.vault.ItemVaultMountedStorageType;
+import com.simibubi.create.content.processing.basin.BasinMountedItemStorageType;
 import com.simibubi.create.foundation.data.CreateRegistrate;
 import com.simibubi.create.impl.contraption.storage.FallbackMountedStorageType;
 import com.tterrag.registrate.util.entry.RegistryEntry;
@@ -26,6 +27,7 @@ public class AllMountedStorageTypes {
 	public static final RegistryEntry<MountedItemStorageType<?>, FallbackMountedStorageType> FALLBACK = simpleItem("fallback", FallbackMountedStorageType::new);
 
 	// registrations for these are handled by the blocks, not the types
+	public static final RegistryEntry<MountedItemStorageType<?>, BasinMountedItemStorageType> BASIN_ITEM = simpleItem("basin", BasinMountedItemStorageType::new);
 	public static final RegistryEntry<MountedItemStorageType<?>, CreativeCrateMountedStorageType> CREATIVE_CRATE = simpleItem("creative_crate", CreativeCrateMountedStorageType::new);
 	public static final RegistryEntry<MountedItemStorageType<?>, ItemVaultMountedStorageType> VAULT = simpleItem("vault", ItemVaultMountedStorageType::new);
 	public static final RegistryEntry<MountedItemStorageType<?>, ToolboxMountedStorageType> TOOLBOX = simpleItem("toolbox", ToolboxMountedStorageType::new);

--- a/src/main/java/com/simibubi/create/AllMountedStorageTypes.java
+++ b/src/main/java/com/simibubi/create/AllMountedStorageTypes.java
@@ -13,6 +13,7 @@ import com.simibubi.create.content.fluids.tank.storage.creative.CreativeFluidTan
 import com.simibubi.create.content.logistics.crate.CreativeCrateMountedStorageType;
 import com.simibubi.create.content.logistics.depot.storage.DepotMountedStorageType;
 import com.simibubi.create.content.logistics.vault.ItemVaultMountedStorageType;
+import com.simibubi.create.content.processing.basin.BasinMountedFluidStorageType;
 import com.simibubi.create.content.processing.basin.BasinMountedItemStorageType;
 import com.simibubi.create.foundation.data.CreateRegistrate;
 import com.simibubi.create.impl.contraption.storage.FallbackMountedStorageType;
@@ -28,6 +29,7 @@ public class AllMountedStorageTypes {
 
 	// registrations for these are handled by the blocks, not the types
 	public static final RegistryEntry<MountedItemStorageType<?>, BasinMountedItemStorageType> BASIN_ITEM = simpleItem("basin", BasinMountedItemStorageType::new);
+	public static final RegistryEntry<MountedFluidStorageType<?>, BasinMountedFluidStorageType> BASIN_FLUID = simpleFluid("basin", BasinMountedFluidStorageType::new);
 	public static final RegistryEntry<MountedItemStorageType<?>, CreativeCrateMountedStorageType> CREATIVE_CRATE = simpleItem("creative_crate", CreativeCrateMountedStorageType::new);
 	public static final RegistryEntry<MountedItemStorageType<?>, ItemVaultMountedStorageType> VAULT = simpleItem("vault", ItemVaultMountedStorageType::new);
 	public static final RegistryEntry<MountedItemStorageType<?>, ToolboxMountedStorageType> TOOLBOX = simpleItem("toolbox", ToolboxMountedStorageType::new);

--- a/src/main/java/com/simibubi/create/content/processing/basin/BasinBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/processing/basin/BasinBlockEntity.java
@@ -6,6 +6,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
+import com.simibubi.create.foundation.utility.InventoryUtil;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -790,6 +792,11 @@ public class BasinBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 			cachedHeatLevel = getHeatLevelOf(level.getBlockState(getBlockPos().below(1)));
 		}
 		return cachedHeatLevel;
+	}
+
+	public void applyInventories(BasinInventory inputInventory, SmartInventory outputInventory) {
+		InventoryUtil.copyInventoryToFrom(this.inputInventory, inputInventory);
+		InventoryUtil.copyInventoryToFrom(this.outputInventory, outputInventory);
 	}
 
 	static class BasinValueBox extends ValueBoxTransform.Sided {

--- a/src/main/java/com/simibubi/create/content/processing/basin/BasinBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/processing/basin/BasinBlockEntity.java
@@ -6,6 +6,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
+import com.simibubi.create.content.processing.basin.BasinMountedFluidStorage.MountedBasinTankHalf;
 import com.simibubi.create.foundation.utility.InventoryUtil;
 
 import org.jetbrains.annotations.NotNull;
@@ -797,6 +798,16 @@ public class BasinBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 	public void applyInventories(BasinInventory inputInventory, SmartInventory outputInventory) {
 		InventoryUtil.copyInventoryToFrom(this.inputInventory, inputInventory);
 		InventoryUtil.copyInventoryToFrom(this.outputInventory, outputInventory);
+	}
+
+	public void applyTanks(MountedBasinTankHalf inputTank, MountedBasinTankHalf outputTank) {
+		TankSegment[] inputSegments = this.inputTank.getTanks();
+		inputSegments[0].getTank().setFluid(inputTank.firstStack());
+		inputSegments[1].getTank().setFluid(inputTank.secondStack());
+
+		TankSegment[] outputSegments = this.outputTank.getTanks();
+		outputSegments[0].getTank().setFluid(outputTank.firstStack());
+		outputSegments[1].getTank().setFluid(outputTank.secondStack());
 	}
 
 	static class BasinValueBox extends ValueBoxTransform.Sided {

--- a/src/main/java/com/simibubi/create/content/processing/basin/BasinInventory.java
+++ b/src/main/java/com/simibubi/create/content/processing/basin/BasinInventory.java
@@ -3,24 +3,31 @@ package com.simibubi.create.content.processing.basin;
 import com.simibubi.create.foundation.item.SmartInventory;
 
 import net.minecraft.world.item.ItemStack;
-import net.neoforged.neoforge.items.ItemHandlerHelper;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class BasinInventory extends SmartInventory {
 
-	private BasinBlockEntity blockEntity;
-	
+	private final @Nullable BasinBlockEntity blockEntity;
+
 	public boolean packagerMode;
 
-	public BasinInventory(int slots, BasinBlockEntity be) {
+	public BasinInventory(int slots, @Nullable BasinBlockEntity be) {
 		super(slots, be, 64, true);
 		this.blockEntity = be;
 	}
 
+	public BasinInventory(int slots) {
+		this(slots, null);
+	}
+
 	@Override
+	@NotNull
 	public ItemStack insertItem(int slot, ItemStack stack, boolean simulate) {
 		if (packagerMode) // Unique stack insertion only matters for belt setups
 			return inv.insertItem(slot, stack, simulate);
-		
+
 		int firstFreeSlot = -1;
 
 		for (int i = 0; i < getSlots(); i++) {
@@ -42,9 +49,10 @@ public class BasinInventory extends SmartInventory {
 	}
 
 	@Override
+	@NotNull
 	public ItemStack extractItem(int slot, int amount, boolean simulate) {
 		ItemStack extractItem = super.extractItem(slot, amount, simulate);
-		if (!simulate && !extractItem.isEmpty())
+		if (!simulate && blockEntity != null && !extractItem.isEmpty())
 			blockEntity.notifyChangeOfContents();
 		return extractItem;
 	}

--- a/src/main/java/com/simibubi/create/content/processing/basin/BasinMountedFluidStorage.java
+++ b/src/main/java/com/simibubi/create/content/processing/basin/BasinMountedFluidStorage.java
@@ -37,10 +37,8 @@ public class BasinMountedFluidStorage extends MountedFluidStorage implements Syn
 		super(AllMountedStorageTypes.BASIN_FLUID.get());
 
 		this.inputTankHalf = input;
-		this.inputTankHalf.setUpdateCallback(this::onFluidStackChange);
 
 		this.outputTankHalf = output;
-		this.outputTankHalf.setUpdateCallback(this::onFluidStackChange);
 
 		this.bothTanks = new CombinedTankWrapper(input, output);
 	}
@@ -65,12 +63,10 @@ public class BasinMountedFluidStorage extends MountedFluidStorage implements Syn
 	@Override
 	public void markClean() { this.dirty = false; }
 
+	public void markDirty() { this.dirty = true; }
+
 	@Override
 	public void afterSync(Contraption contraption, BlockPos localPos) {}
-
-	public void onFluidStackChange(FluidStack stack) {
-		this.dirty = true;
-	}
 
 	public void tickChasers() {
 		this.inputTankHalf.tickChasers();
@@ -90,7 +86,7 @@ public class BasinMountedFluidStorage extends MountedFluidStorage implements Syn
 
 	@Override
 	public void unmount(Level level, BlockState state, BlockPos pos, @Nullable BlockEntity be) {
-		if(be instanceof BasinBlockEntity basin) {
+		if (be instanceof BasinBlockEntity basin) {
 			basin.applyTanks(this.inputTankHalf, this.outputTankHalf);
 		}
 	}
@@ -138,17 +134,25 @@ public class BasinMountedFluidStorage extends MountedFluidStorage implements Syn
 			Codec.BOOL.fieldOf("insertionAllowed").forGetter(MountedBasinTankHalf::insertionAllowed),
 			FluidStack.OPTIONAL_CODEC.fieldOf("firstTank").forGetter(MountedBasinTankHalf::firstStack),
 			FluidStack.OPTIONAL_CODEC.fieldOf("secondTank").forGetter(MountedBasinTankHalf::secondStack),
-			Codec.FLOAT.fieldOf("optionalFirst").forGetter(t -> t.firstLevel.getValue(1)),
-			Codec.FLOAT.fieldOf("optionalSecond").forGetter(t -> t.secondLevel.getValue(1))
+			Codec.FLOAT.fieldOf("previousFirstValue").forGetter(MountedBasinTankHalf::previousFirstValue),
+			Codec.FLOAT.fieldOf("previousSecondValue").forGetter(MountedBasinTankHalf::previousSecondValue)
 		).apply(i, MountedBasinTankHalf::fromStacks));
 
  		private final boolean insertionAllowed;
 		private final LerpedFloat firstLevel;
 		private final LerpedFloat secondLevel;
+
+		private float previousFirstValue;
+		private float previousSecondValue;
+		private float currentFirstValue;
+		private float currentSecondValue;
 		private Consumer<FluidStack> updateCallback;
 
 		public MountedBasinTankHalf(boolean insertionAllowed, IFluidHandler firstTank, IFluidHandler secondTank) {
 			super(firstTank, secondTank);
+
+			previousFirstValue = 0;
+			previousSecondValue = 0;
 
 			firstLevel = LerpedFloat.linear()
 				.startWithValue(0)
@@ -162,19 +166,27 @@ public class BasinMountedFluidStorage extends MountedFluidStorage implements Syn
 			enforceVariety();
 		}
 
-		public static MountedBasinTankHalf fromStacks(boolean insertionAllowed, FluidStack first, FluidStack second, float previousFirst, float previousSecond) {
+		public static MountedBasinTankHalf fromStacks(boolean insertionAllowed, FluidStack first, FluidStack second, float previousFirstValue, float previousSecondValue) {
 			SmartFluidTank firstTank = new SmartFluidTank(getTankCapacity(), s -> {});
 			SmartFluidTank secondTank = new SmartFluidTank(getTankCapacity(), s -> {});
 
 			MountedBasinTankHalf tankHalf = new MountedBasinTankHalf(insertionAllowed, firstTank, secondTank);
-			tankHalf.fillTank(0, first);
-			tankHalf.fillTank(1, second);
+			tankHalf.fillTank(0, first.copy());
+			tankHalf.fillTank(1, second.copy());
 
-			tankHalf.firstLevel.setValue(previousFirst);
- 			tankHalf.firstLevel.chase(tankHalf.firstStack().getAmount() / (float) getTankCapacity(), .25, Chaser.EXP);
+			float firstFill = first.getAmount() / (float) getTankCapacity();
+			float secondFill = second.getAmount() / (float) getTankCapacity();
 
-			tankHalf.secondLevel.setValue(previousSecond);
-			tankHalf.secondLevel.chase(tankHalf.secondStack().getAmount() / (float) getTankCapacity(), .25, Chaser.EXP);
+//			LogUtils.getLogger().info("first: {} -> {}", previousFirstValue, firstFill);
+//			LogUtils.getLogger().info("second: {} -> {}", previousSecondValue, secondFill);
+
+			tankHalf.currentFirstValue = firstFill;
+			tankHalf.currentSecondValue = secondFill;
+
+			tankHalf.firstLevel.setValue(previousFirstValue);
+			tankHalf.secondLevel.setValue(previousSecondValue);
+			tankHalf.firstLevel.chase(firstFill, .25, Chaser.EXP);
+			tankHalf.secondLevel.chase(secondFill, .25, Chaser.EXP);
 
 			firstTank.setUpdateCallback(tankHalf::onFluidStackChanged);
 			secondTank.setUpdateCallback(tankHalf::onFluidStackChanged);
@@ -183,10 +195,12 @@ public class BasinMountedFluidStorage extends MountedFluidStorage implements Syn
 		}
 
 		public void onFluidStackChanged(FluidStack stack) {
-			firstLevel.chase(firstStack().getAmount() / (float) getTankCapacity(), .25, Chaser.EXP);
-			secondLevel.chase(secondStack().getAmount() / (float) getTankCapacity(), .25, Chaser.EXP);
+			this.previousFirstValue = this.currentFirstValue;
+			this.previousSecondValue = this.currentSecondValue;
+			this.currentFirstValue = firstStack().getAmount() / (float) getTankCapacity();
+			this.currentSecondValue = secondStack().getAmount() / (float) getTankCapacity();
 
-			if(this.updateCallback != null) this.updateCallback.accept(stack);
+			if (this.updateCallback != null) this.updateCallback.accept(stack);
 		}
 
 		public void tickChasers() {
@@ -196,11 +210,19 @@ public class BasinMountedFluidStorage extends MountedFluidStorage implements Syn
 
 		public int getRenderedFluids() {
 			int total = 0;
-			for(int i = 0; i < this.getTanks(); i++) {
-				if(!this.getFluidInTank(i).isEmpty()) total++;
+			for (int i = 0; i < this.getTanks(); i++) {
+				if (!this.getFluidInTank(i).isEmpty()) total++;
 			}
 
 			return total;
+		}
+
+		public float previousFirstValue() {
+			return this.previousFirstValue;
+		}
+
+		public float previousSecondValue() {
+			return this.previousSecondValue;
 		}
 
 		public FluidStack firstStack() {
@@ -212,7 +234,7 @@ public class BasinMountedFluidStorage extends MountedFluidStorage implements Syn
 		}
 
 		public float getTotalUnits(float partialTicks, int tank) {
-			if(tank == 0) return firstLevel.getValue(partialTicks) * 1000;
+			if (tank == 0) return firstLevel.getValue(partialTicks) * 1000;
 			else return secondLevel.getValue(partialTicks) * 1000;
 		}
 

--- a/src/main/java/com/simibubi/create/content/processing/basin/BasinMountedFluidStorage.java
+++ b/src/main/java/com/simibubi/create/content/processing/basin/BasinMountedFluidStorage.java
@@ -1,0 +1,252 @@
+package com.simibubi.create.content.processing.basin;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import com.simibubi.create.AllMountedStorageTypes;
+import com.simibubi.create.api.contraption.storage.SyncedMountedStorage;
+import com.simibubi.create.api.contraption.storage.fluid.MountedFluidStorage;
+
+import com.simibubi.create.content.contraptions.Contraption;
+import com.simibubi.create.foundation.fluid.CombinedTankWrapper;
+import com.simibubi.create.foundation.fluid.SmartFluidTank;
+
+import net.createmod.catnip.animation.LerpedFloat;
+import net.createmod.catnip.animation.LerpedFloat.Chaser;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+
+import net.neoforged.neoforge.fluids.FluidStack;
+
+import net.neoforged.neoforge.fluids.capability.IFluidHandler;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Consumer;
+
+public class BasinMountedFluidStorage extends MountedFluidStorage implements SyncedMountedStorage {
+	public static final MapCodec<BasinMountedFluidStorage> CODEC = RecordCodecBuilder.mapCodec(i -> i.group(
+		MountedBasinTankHalf.CODEC.fieldOf("inputTank").forGetter(BasinMountedFluidStorage::inputTank),
+		MountedBasinTankHalf.CODEC.fieldOf("outputTank").forGetter(BasinMountedFluidStorage::outputTank)
+	).apply(i, BasinMountedFluidStorage::new));
+
+	protected BasinMountedFluidStorage(MountedBasinTankHalf input, MountedBasinTankHalf output) {
+		super(AllMountedStorageTypes.BASIN_FLUID.get());
+
+		this.inputTankHalf = input;
+		this.inputTankHalf.setUpdateCallback(this::onFluidStackChange);
+		this.inputTankHalf.initializeLevels();
+
+		this.outputTankHalf = output;
+		this.outputTankHalf.setUpdateCallback(this::onFluidStackChange);
+		this.outputTankHalf.initializeLevels();
+
+		this.bothTanks = new CombinedTankWrapper(input, output);
+	}
+
+	final MountedBasinTankHalf inputTankHalf;
+	final MountedBasinTankHalf outputTankHalf;
+	final CombinedTankWrapper bothTanks;
+
+	private boolean dirty;
+
+	public MountedBasinTankHalf inputTank() {
+		return this.inputTankHalf;
+	}
+
+	public MountedBasinTankHalf outputTank() {
+		return this.outputTankHalf;
+	}
+
+	@Override
+	public boolean isDirty() { return this.dirty; }
+
+	@Override
+	public void markClean() { this.dirty = false; }
+
+	@Override
+	public void afterSync(Contraption contraption, BlockPos localPos) {}
+
+	public void onFluidStackChange(FluidStack stack) {
+		this.dirty = true;
+	}
+
+	public void tickChasers() {
+		this.inputTankHalf.tickChasers();
+		this.outputTankHalf.tickChasers();
+	}
+
+	public float getTotalFluidUnits(float partialTicks) {
+		float fluidUnits = this.inputTankHalf.getTotalUnits(partialTicks) +
+						   this.outputTankHalf.getTotalUnits(partialTicks);
+		int totalRendered = this.inputTankHalf.getRenderedFluids() +
+							this.outputTankHalf.getRenderedFluids();
+
+		if (totalRendered == 0) return 0;
+		if (fluidUnits < 1) return 0;
+		return fluidUnits;
+	}
+
+	@Override
+	public void unmount(Level level, BlockState state, BlockPos pos, @Nullable BlockEntity be) {
+		if(be instanceof BasinBlockEntity basin) {
+			basin.applyTanks(this.inputTankHalf, this.outputTankHalf);
+		}
+	}
+
+	@Override
+	public int getTanks() {
+		return this.bothTanks.getTanks();
+	}
+
+	@Override
+	@NotNull
+	public FluidStack getFluidInTank(int tank) {
+		return this.bothTanks.getFluidInTank(tank);
+	}
+
+	@Override
+	public int getTankCapacity(int tank) {
+		return 1000;
+	}
+
+	@Override
+	public boolean isFluidValid(int tank, @NotNull FluidStack fluidStack) {
+		return this.bothTanks.isFluidValid(tank, fluidStack);
+	}
+
+	@Override
+	public int fill(@NotNull FluidStack fluidStack, @NotNull FluidAction fluidAction) {
+		return this.inputTankHalf.fill(fluidStack, fluidAction);
+	}
+
+	@Override
+	@NotNull
+	public FluidStack drain(@NotNull FluidStack fluidStack, @NotNull FluidAction fluidAction) {
+		return this.bothTanks.drain(fluidStack, fluidAction);
+	}
+
+	@Override
+	@NotNull
+	public FluidStack drain(int tank, @NotNull FluidAction fluidAction) {
+		return this.bothTanks.drain(tank, fluidAction);
+	}
+
+	public static class MountedBasinTankHalf extends CombinedTankWrapper {
+		public static final MapCodec<MountedBasinTankHalf> CODEC = RecordCodecBuilder.mapCodec(i -> i.group(
+			Codec.BOOL.fieldOf("insertionAllowed").forGetter(MountedBasinTankHalf::insertionAllowed),
+			FluidStack.OPTIONAL_CODEC.fieldOf("firstTank").forGetter(MountedBasinTankHalf::firstStack),
+			FluidStack.OPTIONAL_CODEC.fieldOf("secondTank").forGetter(MountedBasinTankHalf::secondStack)
+		).apply(i, MountedBasinTankHalf::fromStacks));
+
+ 		private final boolean insertionAllowed;
+		private final LerpedFloat firstLevel;
+		private final LerpedFloat secondLevel;
+		private Consumer<FluidStack> updateCallback;
+
+		public MountedBasinTankHalf(boolean insertionAllowed, IFluidHandler firstTank, IFluidHandler secondTank) {
+			super(firstTank, secondTank);
+
+			firstLevel = LerpedFloat.linear()
+				.startWithValue(0)
+				.chase(0, .25, Chaser.EXP);
+
+			secondLevel = LerpedFloat.linear()
+				.startWithValue(0)
+				.chase(0, .25, Chaser.EXP);
+
+			this.insertionAllowed = insertionAllowed;
+			enforceVariety();
+		}
+
+		public void onFluidStackChanged(FluidStack stack) {
+			IFluidHandler firstTank = this.getHandlerFromIndex(0);
+			firstLevel.chase(firstTank.getFluidInTank(0).getAmount() / (float) firstTank.getTankCapacity(0), .25, Chaser.EXP);
+
+			IFluidHandler secondTank = this.getHandlerFromIndex(1);
+			secondLevel.chase(secondTank.getFluidInTank(0).getAmount() / (float) secondTank.getTankCapacity(0), .25, Chaser.EXP);
+
+			if(this.updateCallback != null) this.updateCallback.accept(stack);
+		}
+
+		public void initializeLevels() {
+			IFluidHandler firstTank = this.getHandlerFromIndex(0);
+			float firstTarget = firstTank.getFluidInTank(0).getAmount() / (float) firstTank.getTankCapacity(0);
+			firstLevel.setValue(firstTarget);
+			firstLevel.chase(firstTarget, .25, Chaser.EXP);
+
+			IFluidHandler secondTank = this.getHandlerFromIndex(1);
+			float secondTarget = secondTank.getFluidInTank(0).getAmount() / (float) secondTank.getTankCapacity(0);
+			secondLevel.setValue(secondTarget);
+			secondLevel.chase(secondTarget, .25, Chaser.EXP);
+		}
+
+		public void setUpdateCallback(Consumer<FluidStack> updateCallback) {
+			this.updateCallback = updateCallback;
+		}
+
+		public static MountedBasinTankHalf fromStacks(boolean insertionAllowed, FluidStack first, FluidStack second) {
+			SmartFluidTank firstTank = new SmartFluidTank(1000, s -> {});
+			SmartFluidTank secondTank = new SmartFluidTank(1000, s -> {});
+
+			MountedBasinTankHalf tankHalf = new MountedBasinTankHalf(insertionAllowed, firstTank, secondTank);
+			tankHalf.fillTank(0, first);
+			tankHalf.fillTank(1, second);
+
+			firstTank.setUpdateCallback(tankHalf::onFluidStackChanged);
+			secondTank.setUpdateCallback(tankHalf::onFluidStackChanged);
+
+			return tankHalf;
+		}
+
+		public boolean insertionAllowed() {
+			return insertionAllowed;
+		}
+
+		public FluidStack firstStack() {
+			return this.getFluidInTank(0);
+		}
+
+		public FluidStack secondStack() {
+			return this.getFluidInTank(1);
+		}
+
+		public float getTotalUnits(float partialTicks, int tank) {
+			if(tank == 0) return firstLevel.getValue(partialTicks) * 1000;
+			else return secondLevel.getValue(partialTicks) * 1000;
+		}
+
+		public float getTotalUnits(float partialTicks) {
+			return firstLevel.getValue(partialTicks) * 1000 +
+				  secondLevel.getValue(partialTicks) * 1000;
+		}
+
+		public void tickChasers() {
+			firstLevel.tickChaser();
+			secondLevel.tickChaser();
+		}
+
+		public int getRenderedFluids() {
+			int total = 0;
+			for(int i = 0; i < this.getTanks(); i++) {
+				if(!this.getFluidInTank(i).isEmpty()) total++;
+			}
+
+			return total;
+		}
+
+		private void fillTank(int tank, FluidStack stack) {
+			this.getHandlerFromIndex(tank).fill(stack, FluidAction.EXECUTE);
+		}
+
+		@Override
+		public int fill(FluidStack resource, FluidAction action) {
+			if (!insertionAllowed)
+				return 0;
+			return super.fill(resource, action);
+		}
+	}
+}

--- a/src/main/java/com/simibubi/create/content/processing/basin/BasinMountedFluidStorage.java
+++ b/src/main/java/com/simibubi/create/content/processing/basin/BasinMountedFluidStorage.java
@@ -38,11 +38,9 @@ public class BasinMountedFluidStorage extends MountedFluidStorage implements Syn
 
 		this.inputTankHalf = input;
 		this.inputTankHalf.setUpdateCallback(this::onFluidStackChange);
-		this.inputTankHalf.initializeLevels();
 
 		this.outputTankHalf = output;
 		this.outputTankHalf.setUpdateCallback(this::onFluidStackChange);
-		this.outputTankHalf.initializeLevels();
 
 		this.bothTanks = new CombinedTankWrapper(input, output);
 	}
@@ -139,7 +137,9 @@ public class BasinMountedFluidStorage extends MountedFluidStorage implements Syn
 		public static final MapCodec<MountedBasinTankHalf> CODEC = RecordCodecBuilder.mapCodec(i -> i.group(
 			Codec.BOOL.fieldOf("insertionAllowed").forGetter(MountedBasinTankHalf::insertionAllowed),
 			FluidStack.OPTIONAL_CODEC.fieldOf("firstTank").forGetter(MountedBasinTankHalf::firstStack),
-			FluidStack.OPTIONAL_CODEC.fieldOf("secondTank").forGetter(MountedBasinTankHalf::secondStack)
+			FluidStack.OPTIONAL_CODEC.fieldOf("secondTank").forGetter(MountedBasinTankHalf::secondStack),
+			Codec.FLOAT.fieldOf("optionalFirst").forGetter(t -> t.firstLevel.getValue(1)),
+			Codec.FLOAT.fieldOf("optionalSecond").forGetter(t -> t.secondLevel.getValue(1))
 		).apply(i, MountedBasinTankHalf::fromStacks));
 
  		private final boolean insertionAllowed;
@@ -162,39 +162,19 @@ public class BasinMountedFluidStorage extends MountedFluidStorage implements Syn
 			enforceVariety();
 		}
 
-		public void onFluidStackChanged(FluidStack stack) {
-			IFluidHandler firstTank = this.getHandlerFromIndex(0);
-			firstLevel.chase(firstTank.getFluidInTank(0).getAmount() / (float) firstTank.getTankCapacity(0), .25, Chaser.EXP);
-
-			IFluidHandler secondTank = this.getHandlerFromIndex(1);
-			secondLevel.chase(secondTank.getFluidInTank(0).getAmount() / (float) secondTank.getTankCapacity(0), .25, Chaser.EXP);
-
-			if(this.updateCallback != null) this.updateCallback.accept(stack);
-		}
-
-		public void initializeLevels() {
-			IFluidHandler firstTank = this.getHandlerFromIndex(0);
-			float firstTarget = firstTank.getFluidInTank(0).getAmount() / (float) firstTank.getTankCapacity(0);
-			firstLevel.setValue(firstTarget);
-			firstLevel.chase(firstTarget, .25, Chaser.EXP);
-
-			IFluidHandler secondTank = this.getHandlerFromIndex(1);
-			float secondTarget = secondTank.getFluidInTank(0).getAmount() / (float) secondTank.getTankCapacity(0);
-			secondLevel.setValue(secondTarget);
-			secondLevel.chase(secondTarget, .25, Chaser.EXP);
-		}
-
-		public void setUpdateCallback(Consumer<FluidStack> updateCallback) {
-			this.updateCallback = updateCallback;
-		}
-
-		public static MountedBasinTankHalf fromStacks(boolean insertionAllowed, FluidStack first, FluidStack second) {
-			SmartFluidTank firstTank = new SmartFluidTank(1000, s -> {});
-			SmartFluidTank secondTank = new SmartFluidTank(1000, s -> {});
+		public static MountedBasinTankHalf fromStacks(boolean insertionAllowed, FluidStack first, FluidStack second, float previousFirst, float previousSecond) {
+			SmartFluidTank firstTank = new SmartFluidTank(getTankCapacity(), s -> {});
+			SmartFluidTank secondTank = new SmartFluidTank(getTankCapacity(), s -> {});
 
 			MountedBasinTankHalf tankHalf = new MountedBasinTankHalf(insertionAllowed, firstTank, secondTank);
 			tankHalf.fillTank(0, first);
 			tankHalf.fillTank(1, second);
+
+			tankHalf.firstLevel.setValue(previousFirst);
+ 			tankHalf.firstLevel.chase(tankHalf.firstStack().getAmount() / (float) getTankCapacity(), .25, Chaser.EXP);
+
+			tankHalf.secondLevel.setValue(previousSecond);
+			tankHalf.secondLevel.chase(tankHalf.secondStack().getAmount() / (float) getTankCapacity(), .25, Chaser.EXP);
 
 			firstTank.setUpdateCallback(tankHalf::onFluidStackChanged);
 			secondTank.setUpdateCallback(tankHalf::onFluidStackChanged);
@@ -202,8 +182,25 @@ public class BasinMountedFluidStorage extends MountedFluidStorage implements Syn
 			return tankHalf;
 		}
 
-		public boolean insertionAllowed() {
-			return insertionAllowed;
+		public void onFluidStackChanged(FluidStack stack) {
+			firstLevel.chase(firstStack().getAmount() / (float) getTankCapacity(), .25, Chaser.EXP);
+			secondLevel.chase(secondStack().getAmount() / (float) getTankCapacity(), .25, Chaser.EXP);
+
+			if(this.updateCallback != null) this.updateCallback.accept(stack);
+		}
+
+		public void tickChasers() {
+			firstLevel.tickChaser();
+			secondLevel.tickChaser();
+		}
+
+		public int getRenderedFluids() {
+			int total = 0;
+			for(int i = 0; i < this.getTanks(); i++) {
+				if(!this.getFluidInTank(i).isEmpty()) total++;
+			}
+
+			return total;
 		}
 
 		public FluidStack firstStack() {
@@ -224,18 +221,16 @@ public class BasinMountedFluidStorage extends MountedFluidStorage implements Syn
 				  secondLevel.getValue(partialTicks) * 1000;
 		}
 
-		public void tickChasers() {
-			firstLevel.tickChaser();
-			secondLevel.tickChaser();
+		public void setUpdateCallback(Consumer<FluidStack> updateCallback) {
+			this.updateCallback = updateCallback;
 		}
 
-		public int getRenderedFluids() {
-			int total = 0;
-			for(int i = 0; i < this.getTanks(); i++) {
-				if(!this.getFluidInTank(i).isEmpty()) total++;
-			}
+		public static int getTankCapacity() {
+			return 1000;
+		}
 
-			return total;
+		public boolean insertionAllowed() {
+			return insertionAllowed;
 		}
 
 		private void fillTank(int tank, FluidStack stack) {

--- a/src/main/java/com/simibubi/create/content/processing/basin/BasinMountedFluidStorageType.java
+++ b/src/main/java/com/simibubi/create/content/processing/basin/BasinMountedFluidStorageType.java
@@ -1,0 +1,43 @@
+package com.simibubi.create.content.processing.basin;
+
+import com.simibubi.create.api.contraption.storage.fluid.MountedFluidStorageType;
+
+import com.simibubi.create.content.processing.basin.BasinMountedFluidStorage.MountedBasinTankHalf;
+
+import com.simibubi.create.foundation.blockEntity.behaviour.fluid.SmartFluidTankBehaviour.TankSegment;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+
+import org.jetbrains.annotations.Nullable;
+
+public class BasinMountedFluidStorageType extends MountedFluidStorageType<BasinMountedFluidStorage> {
+	public BasinMountedFluidStorageType() { super(BasinMountedFluidStorage.CODEC); }
+
+	@Override
+	public @Nullable BasinMountedFluidStorage mount(Level level, BlockState state, BlockPos pos, @Nullable BlockEntity be) {
+		if(be instanceof BasinBlockEntity basin) {
+			TankSegment[] inputTanks = basin.inputTank.getTanks();
+			MountedBasinTankHalf inputTankHalf = MountedBasinTankHalf.fromStacks(
+				true,
+				inputTanks[0].getTank().getFluid(),
+				inputTanks[1].getTank().getFluid()
+			);
+
+			TankSegment[] outputTanks = basin.outputTank.getTanks();
+			MountedBasinTankHalf outputTankHalf = MountedBasinTankHalf.fromStacks(
+				false,
+				outputTanks[0].getTank().getFluid(),
+				outputTanks[1].getTank().getFluid()
+			);
+
+			// i'm just... assuming these input and output tanks have two segments........ since that's how it's hardcoded
+
+			return new BasinMountedFluidStorage(inputTankHalf, outputTankHalf);
+		}
+
+		return null;
+	}
+}

--- a/src/main/java/com/simibubi/create/content/processing/basin/BasinMountedFluidStorageType.java
+++ b/src/main/java/com/simibubi/create/content/processing/basin/BasinMountedFluidStorageType.java
@@ -43,9 +43,14 @@ public class BasinMountedFluidStorageType extends MountedFluidStorageType<BasinM
 				secondOutputStack.getAmount()
 			);
 
+			BasinMountedFluidStorage storage = new BasinMountedFluidStorage(inputTankHalf, outputTankHalf);
+
+			inputTankHalf.setUpdateCallback(s -> storage.markDirty());
+			outputTankHalf.setUpdateCallback(s -> storage.markDirty());
+
 			// i'm just... assuming these input and output tanks have two segments........ since that's how it's hardcoded
 
-			return new BasinMountedFluidStorage(inputTankHalf, outputTankHalf);
+			return storage;
 		}
 
 		return null;

--- a/src/main/java/com/simibubi/create/content/processing/basin/BasinMountedFluidStorageType.java
+++ b/src/main/java/com/simibubi/create/content/processing/basin/BasinMountedFluidStorageType.java
@@ -11,6 +11,8 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 
+import net.neoforged.neoforge.fluids.FluidStack;
+
 import org.jetbrains.annotations.Nullable;
 
 public class BasinMountedFluidStorageType extends MountedFluidStorageType<BasinMountedFluidStorage> {
@@ -20,17 +22,25 @@ public class BasinMountedFluidStorageType extends MountedFluidStorageType<BasinM
 	public @Nullable BasinMountedFluidStorage mount(Level level, BlockState state, BlockPos pos, @Nullable BlockEntity be) {
 		if(be instanceof BasinBlockEntity basin) {
 			TankSegment[] inputTanks = basin.inputTank.getTanks();
+			FluidStack firstInputStack = inputTanks[0].getTank().getFluid();
+			FluidStack secondInputStack = inputTanks[1].getTank().getFluid();
 			MountedBasinTankHalf inputTankHalf = MountedBasinTankHalf.fromStacks(
 				true,
-				inputTanks[0].getTank().getFluid(),
-				inputTanks[1].getTank().getFluid()
+				firstInputStack,
+				secondInputStack,
+				firstInputStack.getAmount(),
+				secondInputStack.getAmount()
 			);
 
 			TankSegment[] outputTanks = basin.outputTank.getTanks();
+			FluidStack firstOutputStack = outputTanks[0].getTank().getFluid();
+			FluidStack secondOutputStack = outputTanks[1].getTank().getFluid();
 			MountedBasinTankHalf outputTankHalf = MountedBasinTankHalf.fromStacks(
 				false,
-				outputTanks[0].getTank().getFluid(),
-				outputTanks[1].getTank().getFluid()
+				firstOutputStack,
+				secondOutputStack,
+				firstOutputStack.getAmount(),
+				secondOutputStack.getAmount()
 			);
 
 			// i'm just... assuming these input and output tanks have two segments........ since that's how it's hardcoded

--- a/src/main/java/com/simibubi/create/content/processing/basin/BasinMountedItemStorage.java
+++ b/src/main/java/com/simibubi/create/content/processing/basin/BasinMountedItemStorage.java
@@ -7,7 +7,6 @@ import com.simibubi.create.api.contraption.storage.item.MountedItemStorage;
 import com.simibubi.create.api.contraption.storage.item.MountedItemStorageType;
 
 import com.simibubi.create.foundation.codec.CreateCodecs;
-import com.simibubi.create.foundation.item.SmartInventory;
 
 import com.simibubi.create.foundation.utility.InventoryUtil;
 
@@ -32,15 +31,26 @@ public class BasinMountedItemStorage extends MountedItemStorage {
 		).apply(i, BasinMountedItemStorage::fromCodec)
 	);
 
+	protected BasinInventory inputInventory;
+	protected BasinInventory outputInventory;
+	protected IItemHandlerModifiable itemCapability;
+
+	private int timesChanged;
+
 	protected BasinMountedItemStorage(MountedItemStorageType<?> type) {
 		super(type);
 
 		inputInventory = new BasinInventory(9, null);
-		outputInventory = new BasinInventory(9, null)
+		inputInventory.whenContentsChanged(i -> timesChanged++);
+
+		outputInventory = new BasinInventory(9, null);
+		outputInventory.whenContentsChanged(i -> timesChanged++)
 			.forbidInsertion()
 			.withMaxStackSize(64);
 
 		itemCapability = new CombinedInvWrapper(inputInventory, outputInventory);
+
+		timesChanged = 0;
 	}
 
 	protected BasinMountedItemStorage() { this(AllMountedStorageTypes.BASIN_ITEM.get()); }
@@ -63,17 +73,10 @@ public class BasinMountedItemStorage extends MountedItemStorage {
 		return basinMountedItemStorage;
 	}
 
-	public BasinInventory inputInventory() {
-		return this.inputInventory;
-	}
+	public BasinInventory inputInventory() { return this.inputInventory; }
+	public BasinInventory outputInventory() { return this.outputInventory; }
 
-	public BasinInventory outputInventory() {
-		return (BasinInventory)this.outputInventory;
-	}
-
-	protected BasinInventory inputInventory;
-	protected SmartInventory outputInventory;
-	protected IItemHandlerModifiable itemCapability;
+	public int getTimesChanged() { return timesChanged; }
 
 	@Override
 	public void unmount(Level level, BlockState state, BlockPos pos, @Nullable BlockEntity be) {

--- a/src/main/java/com/simibubi/create/content/processing/basin/BasinMountedItemStorage.java
+++ b/src/main/java/com/simibubi/create/content/processing/basin/BasinMountedItemStorage.java
@@ -13,10 +13,13 @@ import com.simibubi.create.foundation.codec.CreateCodecs;
 import com.simibubi.create.foundation.utility.InventoryUtil;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
+
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate.StructureBlockInfo;
 
 import net.neoforged.neoforge.items.IItemHandlerModifiable;
 
@@ -54,6 +57,12 @@ public class BasinMountedItemStorage extends MountedItemStorage implements Synce
 	}
 
 	protected BasinMountedItemStorage() { this(AllMountedStorageTypes.BASIN_ITEM.get()); }
+
+	@Override
+	public boolean handleInteraction(ServerPlayer player, Contraption contraption, StructureBlockInfo info) {
+		// interaction is handled in the Interaction Behavior, takes items out from basin
+		return false;
+	}
 
 	protected static BasinMountedItemStorage fromCodec(BasinInventory input, BasinInventory output) {
 		BasinMountedItemStorage basinMountedItemStorage = new BasinMountedItemStorage();

--- a/src/main/java/com/simibubi/create/content/processing/basin/BasinMountedItemStorage.java
+++ b/src/main/java/com/simibubi/create/content/processing/basin/BasinMountedItemStorage.java
@@ -1,0 +1,122 @@
+package com.simibubi.create.content.processing.basin;
+
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import com.simibubi.create.AllMountedStorageTypes;
+import com.simibubi.create.api.contraption.storage.item.MountedItemStorage;
+import com.simibubi.create.api.contraption.storage.item.MountedItemStorageType;
+
+import com.simibubi.create.foundation.codec.CreateCodecs;
+import com.simibubi.create.foundation.item.SmartInventory;
+
+import com.simibubi.create.foundation.utility.InventoryUtil;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+
+import net.neoforged.neoforge.items.IItemHandlerModifiable;
+
+import net.neoforged.neoforge.items.wrapper.CombinedInvWrapper;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class BasinMountedItemStorage extends MountedItemStorage {
+	public static final MapCodec<BasinMountedItemStorage> CODEC = RecordCodecBuilder.mapCodec(
+		i -> i.group(
+			CreateCodecs.BASIN_INVENTORY.fieldOf("inputInventory").forGetter(BasinMountedItemStorage::inputInventory),
+			CreateCodecs.BASIN_INVENTORY.fieldOf("outputInventory").forGetter(BasinMountedItemStorage::outputInventory)
+		).apply(i, BasinMountedItemStorage::fromCodec)
+	);
+
+	protected BasinMountedItemStorage(MountedItemStorageType<?> type) {
+		super(type);
+
+		inputInventory = new BasinInventory(9, null);
+		outputInventory = new BasinInventory(9, null)
+			.forbidInsertion()
+			.withMaxStackSize(64);
+
+		itemCapability = new CombinedInvWrapper(inputInventory, outputInventory);
+	}
+
+	protected BasinMountedItemStorage() { this(AllMountedStorageTypes.BASIN_ITEM.get()); }
+
+	protected static BasinMountedItemStorage fromCodec(BasinInventory input, BasinInventory output) {
+		BasinMountedItemStorage basinMountedItemStorage = new BasinMountedItemStorage();
+
+		InventoryUtil.copyInventoryToFrom(basinMountedItemStorage.inputInventory, input);
+		InventoryUtil.copyInventoryToFrom(basinMountedItemStorage.outputInventory, output);
+
+		return basinMountedItemStorage;
+	}
+
+	public static BasinMountedItemStorage fromBasin(BasinBlockEntity basin) {
+		BasinMountedItemStorage basinMountedItemStorage = new BasinMountedItemStorage();
+
+		InventoryUtil.copyInventoryToFrom(basinMountedItemStorage.inputInventory, basin.inputInventory);
+		InventoryUtil.copyInventoryToFrom(basinMountedItemStorage.outputInventory, basin.outputInventory);
+
+		return basinMountedItemStorage;
+	}
+
+	public BasinInventory inputInventory() {
+		return this.inputInventory;
+	}
+
+	public BasinInventory outputInventory() {
+		return (BasinInventory)this.outputInventory;
+	}
+
+	protected BasinInventory inputInventory;
+	protected SmartInventory outputInventory;
+	protected IItemHandlerModifiable itemCapability;
+
+	@Override
+	public void unmount(Level level, BlockState state, BlockPos pos, @Nullable BlockEntity be) {
+		if(be instanceof BasinBlockEntity basin) {
+			basin.applyInventories(inputInventory, outputInventory);
+		}
+	}
+
+	@Override
+	public void setStackInSlot(int slot, @NotNull ItemStack itemStack) {
+		itemCapability.setStackInSlot(slot, itemStack);
+	}
+
+	@Override
+	public int getSlots() {
+		return itemCapability.getSlots();
+	}
+
+	@Override
+	@NotNull
+	public ItemStack getStackInSlot(int slot) {
+		return itemCapability.getStackInSlot(slot);
+	}
+
+	@Override
+	@NotNull
+	public ItemStack insertItem(int slot, @NotNull ItemStack itemStack, boolean simulate) {
+		return itemCapability.insertItem(slot, itemStack, simulate);
+	}
+
+	@Override
+	@NotNull
+	public ItemStack extractItem(int slot, int amount, boolean simulate) {
+		return itemCapability.extractItem(slot, amount, simulate);
+	}
+
+	@Override
+	public int getSlotLimit(int slot) {
+		return itemCapability.getSlotLimit(slot);
+	}
+
+	@Override
+	public boolean isItemValid(int slot, @NotNull ItemStack itemStack) {
+		return itemCapability.isItemValid(slot, itemStack);
+	}
+}

--- a/src/main/java/com/simibubi/create/content/processing/basin/BasinMountedItemStorage.java
+++ b/src/main/java/com/simibubi/create/content/processing/basin/BasinMountedItemStorage.java
@@ -3,9 +3,11 @@ package com.simibubi.create.content.processing.basin;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.simibubi.create.AllMountedStorageTypes;
+import com.simibubi.create.api.contraption.storage.SyncedMountedStorage;
 import com.simibubi.create.api.contraption.storage.item.MountedItemStorage;
 import com.simibubi.create.api.contraption.storage.item.MountedItemStorageType;
 
+import com.simibubi.create.content.contraptions.Contraption;
 import com.simibubi.create.foundation.codec.CreateCodecs;
 
 import com.simibubi.create.foundation.utility.InventoryUtil;
@@ -23,11 +25,11 @@ import net.neoforged.neoforge.items.wrapper.CombinedInvWrapper;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class BasinMountedItemStorage extends MountedItemStorage {
+public class BasinMountedItemStorage extends MountedItemStorage implements SyncedMountedStorage {
 	public static final MapCodec<BasinMountedItemStorage> CODEC = RecordCodecBuilder.mapCodec(
 		i -> i.group(
-			CreateCodecs.BASIN_INVENTORY.fieldOf("inputInventory").forGetter(BasinMountedItemStorage::inputInventory),
-			CreateCodecs.BASIN_INVENTORY.fieldOf("outputInventory").forGetter(BasinMountedItemStorage::outputInventory)
+			CreateCodecs.BASIN_INVENTORY.fieldOf("inputInventory").forGetter(BasinMountedItemStorage::getInputInventory),
+			CreateCodecs.BASIN_INVENTORY.fieldOf("outputInventory").forGetter(BasinMountedItemStorage::getOutputInventory)
 		).apply(i, BasinMountedItemStorage::fromCodec)
 	);
 
@@ -36,15 +38,16 @@ public class BasinMountedItemStorage extends MountedItemStorage {
 	protected IItemHandlerModifiable itemCapability;
 
 	private int timesChanged;
+	private boolean dirty;
 
 	protected BasinMountedItemStorage(MountedItemStorageType<?> type) {
 		super(type);
 
 		inputInventory = new BasinInventory(9, null);
-		inputInventory.whenContentsChanged(i -> timesChanged++);
+		inputInventory.whenContentsChanged(this::increaseTimesChanged);
 
 		outputInventory = new BasinInventory(9, null);
-		outputInventory.whenContentsChanged(i -> timesChanged++)
+		outputInventory.whenContentsChanged(this::increaseTimesChanged)
 			.forbidInsertion()
 			.withMaxStackSize(64);
 
@@ -73,10 +76,22 @@ public class BasinMountedItemStorage extends MountedItemStorage {
 		return basinMountedItemStorage;
 	}
 
-	public BasinInventory inputInventory() { return this.inputInventory; }
-	public BasinInventory outputInventory() { return this.outputInventory; }
+	public BasinInventory getInputInventory() { return this.inputInventory; }
+	public BasinInventory getOutputInventory() { return this.outputInventory; }
+	public IItemHandlerModifiable getCapability() { return this.itemCapability; }
 
 	public int getTimesChanged() { return timesChanged; }
+
+	@Override
+	public boolean isDirty() { return this.dirty; }
+
+	@Override
+	public void markClean() { this.dirty = false; }
+
+	public void increaseTimesChanged(int $) { this.timesChanged++; }
+
+	@Override
+	public void afterSync(Contraption contraption, BlockPos localPos) {}
 
 	@Override
 	public void unmount(Level level, BlockState state, BlockPos pos, @Nullable BlockEntity be) {

--- a/src/main/java/com/simibubi/create/content/processing/basin/BasinMountedItemStorage.java
+++ b/src/main/java/com/simibubi/create/content/processing/basin/BasinMountedItemStorage.java
@@ -44,12 +44,9 @@ public class BasinMountedItemStorage extends MountedItemStorage implements Synce
 		super(type);
 
 		inputInventory = new BasinInventory(9, null);
-		inputInventory.whenContentsChanged(this::increaseTimesChanged);
 
 		outputInventory = new BasinInventory(9, null);
-		outputInventory.whenContentsChanged(this::increaseTimesChanged)
-			.forbidInsertion()
-			.withMaxStackSize(64);
+		outputInventory.forbidInsertion().withMaxStackSize(64);
 
 		itemCapability = new CombinedInvWrapper(inputInventory, outputInventory);
 
@@ -64,6 +61,8 @@ public class BasinMountedItemStorage extends MountedItemStorage implements Synce
 		InventoryUtil.copyInventoryToFrom(basinMountedItemStorage.inputInventory, input);
 		InventoryUtil.copyInventoryToFrom(basinMountedItemStorage.outputInventory, output);
 
+		basinMountedItemStorage.listenForChanges();
+
 		return basinMountedItemStorage;
 	}
 
@@ -73,7 +72,14 @@ public class BasinMountedItemStorage extends MountedItemStorage implements Synce
 		InventoryUtil.copyInventoryToFrom(basinMountedItemStorage.inputInventory, basin.inputInventory);
 		InventoryUtil.copyInventoryToFrom(basinMountedItemStorage.outputInventory, basin.outputInventory);
 
+		basinMountedItemStorage.listenForChanges();
+
 		return basinMountedItemStorage;
+	}
+
+	protected void listenForChanges() {
+		this.inputInventory.whenContentsChanged(this::increaseTimesChanged);
+		this.outputInventory.whenContentsChanged(this::increaseTimesChanged);
 	}
 
 	public BasinInventory getInputInventory() { return this.inputInventory; }
@@ -88,7 +94,10 @@ public class BasinMountedItemStorage extends MountedItemStorage implements Synce
 	@Override
 	public void markClean() { this.dirty = false; }
 
-	public void increaseTimesChanged(int $) { this.timesChanged++; }
+	public void increaseTimesChanged(int $) {
+		this.timesChanged++;
+		this.dirty = true;
+	}
 
 	@Override
 	public void afterSync(Contraption contraption, BlockPos localPos) {}

--- a/src/main/java/com/simibubi/create/content/processing/basin/BasinMountedItemStorageType.java
+++ b/src/main/java/com/simibubi/create/content/processing/basin/BasinMountedItemStorageType.java
@@ -1,0 +1,21 @@
+package com.simibubi.create.content.processing.basin;
+
+import com.simibubi.create.api.contraption.storage.item.MountedItemStorageType;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+
+import org.jetbrains.annotations.Nullable;
+
+public class BasinMountedItemStorageType extends MountedItemStorageType<BasinMountedItemStorage> {
+	public BasinMountedItemStorageType() {
+		super(BasinMountedItemStorage.CODEC);
+	}
+
+	@Override
+	public @Nullable BasinMountedItemStorage mount(Level level, BlockState state, BlockPos pos, @Nullable BlockEntity be) {
+		return be instanceof BasinBlockEntity basin ? BasinMountedItemStorage.fromBasin(basin) : null;
+	}
+}

--- a/src/main/java/com/simibubi/create/content/processing/basin/BasinMovementBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/processing/basin/BasinMovementBehaviour.java
@@ -6,29 +6,70 @@ import com.simibubi.create.api.contraption.storage.item.MountedItemStorageWrappe
 import com.simibubi.create.content.contraptions.behaviour.MovementContext;
 
 import com.simibubi.create.content.contraptions.render.ContraptionMatrices;
+import com.simibubi.create.content.logistics.box.PackageEntity;
+import com.simibubi.create.foundation.item.ItemHelper;
 import com.simibubi.create.foundation.virtualWorld.VirtualRenderWorld;
 
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.core.Direction;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 
+import net.neoforged.neoforge.items.ItemHandlerHelper;
+
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public class BasinMovementBehaviour implements MovementBehaviour {
 	@Override
 	public void tick(MovementContext context) {
 		BasinMountedItemStorage storage = getMountedItemStorage(context);
-		if(storage == null) return;
+		if (storage == null) return;
 
-		int newTimesChanged = storage.getTimesChanged();
-		if (getLastTimesChanged(context) != newTimesChanged) {
-			Vec3 facingVec = context.rotation.apply(Vec3.atLowerCornerOf(Direction.UP.getNormal()));
-			facingVec.normalize();
-			if (Direction.getNearest(facingVec.x, facingVec.y, facingVec.z) == Direction.DOWN)
+		Vec3 facingVec = context.rotation.apply(Vec3.atLowerCornerOf(Direction.UP.getNormal())).normalize();
+		Direction nearest = Direction.getNearest(facingVec.x, facingVec.y, facingVec.z);
+
+		if (nearest == Direction.DOWN) {
+			int newTimesChanged = storage.getTimesChanged();
+			if (getLastTimesChanged(context) != newTimesChanged) {
 				dump(context, storage, facingVec);
+			}
+		} else if(nearest == Direction.UP) {
+			pickup(context, storage);
+		}
+	}
+
+	private void pickup(MovementContext context, BasinMountedItemStorage storage) {
+		Level world = context.world;
+
+		Vec3 halfBlock = new Vec3(0.4, 0.4, 0.4);
+		Vec3 posTop = context.position.add(halfBlock);
+		Vec3 posBottom = context.position.subtract(halfBlock);
+
+		List<Entity> items = world.getEntities((Entity) null, new AABB(posTop, posBottom),
+			e -> e instanceof ItemEntity || e instanceof PackageEntity);
+
+		for (Entity entity : items) {
+			if (!entity.isAlive())
+				continue;
+			ItemStack toInsert = ItemHelper.fromItemEntity(entity);
+			ItemStack remainder =
+				ItemHandlerHelper.insertItemStacked(storage, toInsert, false);
+			if (remainder.getCount() == toInsert.getCount())
+				continue;
+			if (remainder.isEmpty()) {
+				entity.discard();
+				continue;
+			}
+
+			if (entity instanceof ItemEntity item)
+				item.setItem(remainder);
 		}
 	}
 
@@ -45,13 +86,6 @@ public class BasinMovementBehaviour implements MovementBehaviour {
 		}
 
 		context.temporaryData = storage.getTimesChanged();
-
-		// FIXME: Why are we setting client-side data here?
-//		if (context.contraption.entity.level().isClientSide) {
-//			BlockEntity blockEntity = context.contraption.getBlockEntityClientSide(context.localPos);
-//			if (blockEntity instanceof BasinBlockEntity)
-//				((BasinBlockEntity) blockEntity).readOnlyItems(context.blockEntityData, context.world.registryAccess());
-//		}
 	}
 
 	private int getLastTimesChanged(MovementContext context) {
@@ -75,7 +109,7 @@ public class BasinMovementBehaviour implements MovementBehaviour {
 	@Override
 	public void renderInContraption(MovementContext context, VirtualRenderWorld renderWorld, ContraptionMatrices matrices, MultiBufferSource buffer) {
 		BlockEntity blockEntity = context.contraption.getBlockEntityClientSide(context.localPos);
-		if (blockEntity instanceof BasinBlockEntity basin) {
+		if (blockEntity instanceof BasinBlockEntity) {
 			BasinMountedItemStorage mountedItemStorage = getMountedItemStorage(context);
 			if(mountedItemStorage == null) return;
 

--- a/src/main/java/com/simibubi/create/content/processing/basin/BasinMovementBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/processing/basin/BasinMovementBehaviour.java
@@ -53,4 +53,18 @@ public class BasinMovementBehaviour implements MovementBehaviour {
 //				((BasinBlockEntity) blockEntity).readOnlyItems(context.blockEntityData, context.world.registryAccess());
 //		}
 	}
+
+	private int getLastTimesChanged(MovementContext context) {
+		if(context.temporaryData != null) return (int)context.temporaryData;
+		return 0;
+	}
+
+	private @Nullable BasinMountedItemStorage getMountedItemStorage(MovementContext context) {
+		MountedItemStorageWrapper wrapper = context.contraption.getStorage().getMountedItems();
+		MountedItemStorage storageHere = wrapper.storages.get(context.localPos);
+
+		if(storageHere instanceof BasinMountedItemStorage basin) return basin;
+		return null;
+	}
+
 }

--- a/src/main/java/com/simibubi/create/content/processing/basin/BasinMovementBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/processing/basin/BasinMovementBehaviour.java
@@ -1,6 +1,8 @@
 package com.simibubi.create.content.processing.basin;
 
 import com.simibubi.create.api.behaviour.movement.MovementBehaviour;
+import com.simibubi.create.api.contraption.storage.fluid.MountedFluidStorage;
+import com.simibubi.create.api.contraption.storage.fluid.MountedFluidStorageWrapper;
 import com.simibubi.create.api.contraption.storage.item.MountedItemStorage;
 import com.simibubi.create.api.contraption.storage.item.MountedItemStorageWrapper;
 import com.simibubi.create.content.contraptions.behaviour.MovementContext;
@@ -101,6 +103,14 @@ public class BasinMovementBehaviour implements MovementBehaviour {
 		return null;
 	}
 
+	private @Nullable BasinMountedFluidStorage getMountedFluidStorage(MovementContext context) {
+		MountedFluidStorageWrapper wrapper = context.contraption.getStorage().getFluids();
+		MountedFluidStorage storageHere = wrapper.storages.get(context.localPos);
+
+		if(storageHere instanceof BasinMountedFluidStorage basin) return basin;
+		return null;
+	}
+
 	@Override
 	public boolean disableBlockEntityRendering() {
 		return true;
@@ -113,7 +123,10 @@ public class BasinMovementBehaviour implements MovementBehaviour {
 			BasinMountedItemStorage mountedItemStorage = getMountedItemStorage(context);
 			if(mountedItemStorage == null) return;
 
-			BasinRenderer.renderInContraption(context, renderWorld, matrices, buffer, mountedItemStorage);
+			BasinMountedFluidStorage mountedFluidStorage = getMountedFluidStorage(context);
+
+			BasinRenderer.renderInContraption(context, renderWorld, matrices, buffer,
+				mountedItemStorage, mountedFluidStorage);
 		}
 	}
 }

--- a/src/main/java/com/simibubi/create/content/processing/basin/BasinMovementBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/processing/basin/BasinMovementBehaviour.java
@@ -1,13 +1,14 @@
 package com.simibubi.create.content.processing.basin;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import com.simibubi.create.api.behaviour.movement.MovementBehaviour;
 import com.simibubi.create.api.contraption.storage.item.MountedItemStorage;
 import com.simibubi.create.api.contraption.storage.item.MountedItemStorageWrapper;
 import com.simibubi.create.content.contraptions.behaviour.MovementContext;
 
+import com.simibubi.create.content.contraptions.render.ContraptionMatrices;
+import com.simibubi.create.foundation.virtualWorld.VirtualRenderWorld;
+
+import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.core.Direction;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
@@ -32,7 +33,6 @@ public class BasinMovementBehaviour implements MovementBehaviour {
 	}
 
 	private void dump(MovementContext context, BasinMountedItemStorage storage, Vec3 facingVec) {
-
 		for (int i = 0; i < storage.getSlots(); i++) {
 			if (storage.getStackInSlot(i).isEmpty())
 				continue;
@@ -67,4 +67,19 @@ public class BasinMovementBehaviour implements MovementBehaviour {
 		return null;
 	}
 
+	@Override
+	public boolean disableBlockEntityRendering() {
+		return true;
+	}
+
+	@Override
+	public void renderInContraption(MovementContext context, VirtualRenderWorld renderWorld, ContraptionMatrices matrices, MultiBufferSource buffer) {
+		BlockEntity blockEntity = context.contraption.getBlockEntityClientSide(context.localPos);
+		if (blockEntity instanceof BasinBlockEntity basin) {
+			BasinMountedItemStorage mountedItemStorage = getMountedItemStorage(context);
+			if(mountedItemStorage == null) return;
+
+			BasinRenderer.renderInContraption(context, renderWorld, matrices, buffer, mountedItemStorage);
+		}
+	}
 }

--- a/src/main/java/com/simibubi/create/content/processing/basin/BasinMovementBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/processing/basin/BasinMovementBehaviour.java
@@ -4,6 +4,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.simibubi.create.api.behaviour.movement.MovementBehaviour;
+import com.simibubi.create.api.contraption.storage.item.MountedItemStorage;
+import com.simibubi.create.api.contraption.storage.item.MountedItemStorageWrapper;
 import com.simibubi.create.content.contraptions.behaviour.MovementContext;
 
 import net.minecraft.core.Direction;
@@ -12,48 +14,43 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.phys.Vec3;
 
-import net.neoforged.neoforge.items.ItemStackHandler;
+import org.jetbrains.annotations.Nullable;
 
 public class BasinMovementBehaviour implements MovementBehaviour {
-	public Map<String, ItemStackHandler> getOrReadInventory(MovementContext context) {
-		Map<String, ItemStackHandler> map = new HashMap<>();
-		map.put("InputItems", new ItemStackHandler(9));
-		map.put("OutputItems", new ItemStackHandler(8));
-		map.forEach((s, h) -> h.deserializeNBT(context.world.registryAccess(), context.blockEntityData.getCompound(s)));
-		return map;
-	}
-
 	@Override
 	public void tick(MovementContext context) {
-		MovementBehaviour.super.tick(context);
-		if (context.temporaryData == null || (boolean) context.temporaryData) {
+		BasinMountedItemStorage storage = getMountedItemStorage(context);
+		if(storage == null) return;
+
+		int newTimesChanged = storage.getTimesChanged();
+		if (getLastTimesChanged(context) != newTimesChanged) {
 			Vec3 facingVec = context.rotation.apply(Vec3.atLowerCornerOf(Direction.UP.getNormal()));
 			facingVec.normalize();
 			if (Direction.getNearest(facingVec.x, facingVec.y, facingVec.z) == Direction.DOWN)
-				dump(context, facingVec);
+				dump(context, storage, facingVec);
 		}
 	}
 
-	private void dump(MovementContext context, Vec3 facingVec) {
-		getOrReadInventory(context).forEach((key, itemStackHandler) -> {
-			for (int i = 0; i < itemStackHandler.getSlots(); i++) {
-				if (itemStackHandler.getStackInSlot(i)
-					.isEmpty())
-					continue;
-				ItemEntity itemEntity = new ItemEntity(context.world, context.position.x, context.position.y,
-					context.position.z, itemStackHandler.getStackInSlot(i));
-				itemEntity.setDeltaMovement(facingVec.scale(.05));
-				context.world.addFreshEntity(itemEntity);
-				itemStackHandler.setStackInSlot(i, ItemStack.EMPTY);
-			}
-			context.blockEntityData.put(key, itemStackHandler.serializeNBT(context.world.registryAccess()));
-		});
-		// FIXME: Why are we setting client-side data here?
-		if (context.contraption.entity.level().isClientSide) {
-			BlockEntity blockEntity = context.contraption.getBlockEntityClientSide(context.localPos);
-			if (blockEntity instanceof BasinBlockEntity)
-				((BasinBlockEntity) blockEntity).readOnlyItems(context.blockEntityData, context.world.registryAccess());
+	private void dump(MovementContext context, BasinMountedItemStorage storage, Vec3 facingVec) {
+
+		for (int i = 0; i < storage.getSlots(); i++) {
+			if (storage.getStackInSlot(i).isEmpty())
+				continue;
+
+			ItemEntity itemEntity = new ItemEntity(context.world, context.position.x, context.position.y, context.position.z, storage.getStackInSlot(i));
+			itemEntity.setDeltaMovement(facingVec.scale(.05));
+			context.world.addFreshEntity(itemEntity);
+
+			storage.setStackInSlot(i, ItemStack.EMPTY);
 		}
-		context.temporaryData = false; // did already dump, so can't anymore
+
+		context.temporaryData = storage.getTimesChanged();
+
+		// FIXME: Why are we setting client-side data here?
+//		if (context.contraption.entity.level().isClientSide) {
+//			BlockEntity blockEntity = context.contraption.getBlockEntityClientSide(context.localPos);
+//			if (blockEntity instanceof BasinBlockEntity)
+//				((BasinBlockEntity) blockEntity).readOnlyItems(context.blockEntityData, context.world.registryAccess());
+//		}
 	}
 }

--- a/src/main/java/com/simibubi/create/content/processing/basin/BasinRenderer.java
+++ b/src/main/java/com/simibubi/create/content/processing/basin/BasinRenderer.java
@@ -1,9 +1,14 @@
 package com.simibubi.create.content.processing.basin;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import com.simibubi.create.content.contraptions.behaviour.MovementContext;
+import com.simibubi.create.content.contraptions.render.ContraptionMatrices;
 import com.simibubi.create.foundation.blockEntity.behaviour.fluid.SmartFluidTankBehaviour;
 import com.simibubi.create.foundation.blockEntity.behaviour.fluid.SmartFluidTankBehaviour.TankSegment;
 import com.simibubi.create.foundation.blockEntity.renderer.SmartBlockEntityRenderer;
+
+import com.simibubi.create.foundation.render.BlockEntityRenderHelper;
+import com.simibubi.create.foundation.virtualWorld.VirtualRenderWorld;
 
 import dev.engine_room.flywheel.lib.transform.TransformStack;
 import net.createmod.catnip.animation.AnimationTickHolder;
@@ -14,6 +19,7 @@ import net.createmod.catnip.platform.NeoForgeCatnipServices;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
+import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Direction.Axis;
@@ -21,6 +27,7 @@ import net.minecraft.util.Mth;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
 
@@ -52,22 +59,18 @@ public class BasinRenderer extends SmartBlockEntityRenderer<BasinBlockEntity> {
 		RandomSource r = RandomSource.create(pos.hashCode());
 		Vec3 baseVector = new Vec3(.125, level, 0);
 
-		IItemHandlerModifiable inv = basin.itemCapability;
-		if (inv == null)
-			inv = new ItemStackHandler();
+		IItemHandlerModifiable handler = basin.itemCapability;
+		if (handler == null)
+			handler = new ItemStackHandler();
 
-		int itemCount = 0;
-		for (int slot = 0; slot < inv.getSlots(); slot++)
-			if (!inv.getStackInSlot(slot)
-				.isEmpty())
-				itemCount++;
+		int itemCount = getItemCount(handler);
 
 		if (itemCount == 1)
 			baseVector = new Vec3(0, level, 0);
 
 		float anglePartition = 360f / itemCount;
-		for (int slot = 0; slot < inv.getSlots(); slot++) {
-			ItemStack stack = inv.getStackInSlot(slot);
+		for (int slot = 0; slot < handler.getSlots(); slot++) {
+			ItemStack stack = handler.getStackInSlot(slot);
 			if (stack.isEmpty())
 				continue;
 
@@ -136,7 +139,7 @@ public class BasinRenderer extends SmartBlockEntityRenderer<BasinBlockEntity> {
 		}
 	}
 
-	protected void renderItem(PoseStack ms, MultiBufferSource buffer, int light, int overlay, ItemStack stack) {
+	protected static void renderItem(PoseStack ms, MultiBufferSource buffer, int light, int overlay, ItemStack stack) {
 		Minecraft mc = Minecraft.getInstance();
 		mc.getItemRenderer()
 			.renderStatic(stack, ItemDisplayContext.GROUND, light, overlay, ms, buffer, mc.level, 0);
@@ -183,6 +186,82 @@ public class BasinRenderer extends SmartBlockEntityRenderer<BasinBlockEntity> {
 		}
 
 		return yMax;
+	}
+
+	public static void renderInContraption(MovementContext context, VirtualRenderWorld renderWorld,
+									ContraptionMatrices matrices, MultiBufferSource buffer, BasinMountedItemStorage itemStorage) {
+		PoseStack ms = matrices.getModelViewProjection();
+		ms.pushPose();
+
+		float fluidLevel = 0;
+		float level = .125f;
+
+		BlockEntity blockEntity = context.contraption.getBlockEntityClientSide(context.localPos);
+		if(!(blockEntity instanceof BasinBlockEntity basin)) return;
+
+		BlockPos basinPos = basin.getBlockPos();
+		Vec3 basinCenterPos = Vec3.atLowerCornerOf(basinPos);
+		Vec3 baseVector = new Vec3(.125, level, 0);
+
+		ms.translate(basinCenterPos.x, basinCenterPos.y, basinCenterPos.z);
+		ms.translate(.5, .2f, .5);
+
+		RandomSource random = RandomSource.create(basinPos.hashCode());
+
+		IItemHandlerModifiable handler = itemStorage.itemCapability;
+
+		int itemCount = getItemCount(handler);
+
+		if (itemCount == 1)
+			baseVector = new Vec3(0, level, 0);
+
+		float anglePartition = 360f / itemCount;
+		for (int slot = 0; slot < handler.getSlots(); slot++) {
+			ItemStack stack = handler.getStackInSlot(slot);
+			if (stack.isEmpty())
+				continue;
+
+			ms.pushPose();
+
+			if (fluidLevel > 0) {
+				ms.translate(0,
+					(Mth.sin(
+						AnimationTickHolder.getRenderTime(context.world) / 12f + anglePartition * itemCount) + 1.5f)
+						* 1 / 32f,
+					0);
+			}
+
+			Vec3 itemPosition = VecHelper.rotate(baseVector, anglePartition * itemCount, Axis.Y);
+			ms.translate(itemPosition.x, itemPosition.y, itemPosition.z);
+			TransformStack.of(ms)
+				.rotateYDegrees(anglePartition * itemCount + 35)
+				.rotateXDegrees(65);
+
+			int light = BlockEntityRenderHelper.getLight(context.world, renderWorld, basinPos, matrices.getLight());
+
+			for (int i = 0; i <= stack.getCount() / 8; i++) {
+				ms.pushPose();
+
+				Vec3 vec = VecHelper.offsetRandomly(Vec3.ZERO, random, 1 / 16f);
+
+				ms.translate(vec.x, vec.y, vec.z);
+				renderItem(ms, buffer, light, OverlayTexture.NO_OVERLAY, stack);
+				ms.popPose();
+			}
+			ms.popPose();
+
+			itemCount--;
+		}
+
+		ms.popPose();
+	}
+
+	private static int getItemCount(IItemHandlerModifiable handler) {
+		int itemCount = 0;
+		for (int slot = 0; slot < handler.getSlots(); slot++)
+			if (!handler.getStackInSlot(slot).isEmpty())
+				itemCount++;
+		return itemCount;
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/processing/basin/BasinRenderer.java
+++ b/src/main/java/com/simibubi/create/content/processing/basin/BasinRenderer.java
@@ -3,6 +3,7 @@ package com.simibubi.create.content.processing.basin;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.simibubi.create.content.contraptions.behaviour.MovementContext;
 import com.simibubi.create.content.contraptions.render.ContraptionMatrices;
+import com.simibubi.create.content.processing.basin.BasinMountedFluidStorage.MountedBasinTankHalf;
 import com.simibubi.create.foundation.blockEntity.behaviour.fluid.SmartFluidTankBehaviour;
 import com.simibubi.create.foundation.blockEntity.behaviour.fluid.SmartFluidTankBehaviour.TankSegment;
 import com.simibubi.create.foundation.blockEntity.renderer.SmartBlockEntityRenderer;
@@ -34,6 +35,8 @@ import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.items.IItemHandlerModifiable;
 import net.neoforged.neoforge.items.ItemStackHandler;
+
+import org.jetbrains.annotations.Nullable;
 
 public class BasinRenderer extends SmartBlockEntityRenderer<BasinBlockEntity> {
 
@@ -189,24 +192,28 @@ public class BasinRenderer extends SmartBlockEntityRenderer<BasinBlockEntity> {
 	}
 
 	public static void renderInContraption(MovementContext context, VirtualRenderWorld renderWorld,
-									ContraptionMatrices matrices, MultiBufferSource buffer, BasinMountedItemStorage itemStorage) {
+										   ContraptionMatrices matrices, MultiBufferSource buffer,
+										   BasinMountedItemStorage itemStorage, @Nullable BasinMountedFluidStorage fluidStorage) {
 		PoseStack ms = matrices.getModelViewProjection();
+		int light = BlockEntityRenderHelper.getLight(context.world, renderWorld, context.localPos, matrices.getLight());
+
 		ms.pushPose();
 
-		float fluidLevel = 0;
-		float level = .125f;
-
 		BlockEntity blockEntity = context.contraption.getBlockEntityClientSide(context.localPos);
-		if(!(blockEntity instanceof BasinBlockEntity basin)) return;
+		if(!(blockEntity instanceof BasinBlockEntity)) return;
 
-		BlockPos basinPos = basin.getBlockPos();
-		Vec3 basinCenterPos = Vec3.atLowerCornerOf(basinPos);
-		Vec3 baseVector = new Vec3(.125, level, 0);
 
+		Vec3 basinCenterPos = Vec3.atLowerCornerOf(context.localPos);
 		ms.translate(basinCenterPos.x, basinCenterPos.y, basinCenterPos.z);
+
+		float fluidLevel = 0;
+		if(fluidStorage != null) fluidLevel = renderFluidsInContraption(context, renderWorld, ms, light, buffer, fluidStorage);
+
+		float level = Mth.clamp(fluidLevel - .3f, .125f, .6f);
+		Vec3 baseVector = new Vec3(.125, level, 0);
 		ms.translate(.5, .2f, .5);
 
-		RandomSource random = RandomSource.create(basinPos.hashCode());
+		RandomSource random = RandomSource.create(context.localPos.hashCode());
 
 		IItemHandlerModifiable handler = itemStorage.itemCapability;
 
@@ -237,8 +244,6 @@ public class BasinRenderer extends SmartBlockEntityRenderer<BasinBlockEntity> {
 				.rotateYDegrees(anglePartition * itemCount + 35)
 				.rotateXDegrees(65);
 
-			int light = BlockEntityRenderHelper.getLight(context.world, renderWorld, basinPos, matrices.getLight());
-
 			for (int i = 0; i <= stack.getCount() / 8; i++) {
 				ms.pushPose();
 
@@ -254,6 +259,49 @@ public class BasinRenderer extends SmartBlockEntityRenderer<BasinBlockEntity> {
 		}
 
 		ms.popPose();
+	}
+
+	public static float renderFluidsInContraption(MovementContext context, VirtualRenderWorld renderWorld, PoseStack ms, int light,
+												 MultiBufferSource buffer, BasinMountedFluidStorage mountedFluidStorage) {
+		float partialTicks = AnimationTickHolder.getPartialTicks();
+
+		mountedFluidStorage.tickChasers();
+		float totalUnits = mountedFluidStorage.getTotalFluidUnits(partialTicks);
+		if (totalUnits < 1)
+			return 0;
+
+		float fluidLevel = Mth.clamp(totalUnits / 2000, 0, 1);
+
+		fluidLevel = 1 - ((1 - fluidLevel) * (1 - fluidLevel));
+
+		float xMin = 2 / 16f;
+		float xMax = 2 / 16f;
+		final float yMin = 2 / 16f;
+		final float yMax = yMin + 12 / 16f * fluidLevel;
+		final float zMin = 2 / 16f;
+		final float zMax = 14 / 16f;
+
+		MountedBasinTankHalf[] tankHalves = {mountedFluidStorage.inputTank(), mountedFluidStorage.outputTank()};
+		for (MountedBasinTankHalf mountedBasinTankHalf : tankHalves) {
+			for(int tank : new int[]{0, 1}) {
+				FluidStack renderedFluid = mountedBasinTankHalf.getFluidInTank(tank);
+				if (renderedFluid.isEmpty())
+					continue;
+
+				float units = mountedBasinTankHalf.getTotalUnits(partialTicks, tank);
+				if (units < 1)
+					continue;
+
+				float partial = Mth.clamp(units / totalUnits, 0, 1);
+				xMax += partial * 12 / 16f;
+				NeoForgeCatnipServices.FLUID_RENDERER.renderFluidBox(renderedFluid, xMin, yMin, zMin, xMax, yMax, zMax,
+					buffer, ms, light, false, false);
+
+				xMin = xMax;
+			}
+		}
+
+		return yMax;
 	}
 
 	private static int getItemCount(IItemHandlerModifiable handler) {

--- a/src/main/java/com/simibubi/create/content/processing/basin/MountedBasinInteractionBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/processing/basin/MountedBasinInteractionBehaviour.java
@@ -1,0 +1,48 @@
+package com.simibubi.create.content.processing.basin;
+
+import com.simibubi.create.api.behaviour.interaction.MovingInteractionBehaviour;
+import com.simibubi.create.api.contraption.storage.item.MountedItemStorage;
+import com.simibubi.create.content.contraptions.AbstractContraptionEntity;
+
+import com.simibubi.create.content.contraptions.MountedStorageManager;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
+
+public class MountedBasinInteractionBehaviour extends MovingInteractionBehaviour {
+	@Override
+	public boolean handlePlayerInteraction(Player player, InteractionHand activeHand, BlockPos localPos, AbstractContraptionEntity contraptionEntity) {
+		Level level = player.level();
+		if (level.isClientSide)
+			return true;
+
+		MountedStorageManager manager = contraptionEntity.getContraption().getStorage();
+		MountedItemStorage storage = manager.getAllItemStorages().get(localPos);
+		if (!(storage instanceof BasinMountedItemStorage basin))
+			return false;
+
+		boolean success = false;
+		for (int slot = 0; slot < basin.getSlots(); slot++) {
+			ItemStack stackInSlot = basin.getStackInSlot(slot);
+			if (stackInSlot.isEmpty())
+				continue;
+			player.getInventory()
+				.placeItemBackInInventory(stackInSlot);
+			basin.setStackInSlot(slot, ItemStack.EMPTY);
+			success = true;
+		}
+		if (success) {
+			BlockPos soundPos = BlockPos.containing(contraptionEntity.toGlobalVector(Vec3.atCenterOf(localPos), 0));
+			level.playSound(null, soundPos, SoundEvents.ITEM_PICKUP, SoundSource.PLAYERS, .2f,
+				1f + level.getRandom().nextFloat());
+		}
+
+		return success;
+	}
+}

--- a/src/main/java/com/simibubi/create/foundation/blockEntity/behaviour/fluid/SmartFluidTankBehaviour.java
+++ b/src/main/java/com/simibubi/create/foundation/blockEntity/behaviour/fluid/SmartFluidTankBehaviour.java
@@ -257,6 +257,8 @@ public class SmartFluidTankBehaviour extends BlockEntityBehaviour {
 			return fluidLevel;
 		}
 
+		public SmartFluidTank getTank() { return tank; }
+
 		public float getTotalUnits(float partialTicks) {
 			return fluidLevel.getValue(partialTicks) * tank.getCapacity();
 		}

--- a/src/main/java/com/simibubi/create/foundation/codec/CreateCodecs.java
+++ b/src/main/java/com/simibubi/create/foundation/codec/CreateCodecs.java
@@ -2,6 +2,8 @@ package com.simibubi.create.foundation.codec;
 
 import java.util.function.Function;
 
+import com.simibubi.create.content.processing.basin.BasinInventory;
+
 import org.jetbrains.annotations.ApiStatus.ScheduledForRemoval;
 
 import com.mojang.serialization.Codec;
@@ -32,6 +34,10 @@ public class CreateCodecs {
 
 	public static final Codec<ItemStackHandler> ITEM_STACK_HANDLER = Codec.lazyInitialized(() -> ItemSlots.CODEC.xmap(
 		slots -> slots.toHandler(ItemStackHandler::new), ItemSlots::fromHandler
+	));
+
+	public static final Codec<BasinInventory> BASIN_INVENTORY = Codec.lazyInitialized(() -> ItemSlots.CODEC.xmap(
+		slots -> slots.toHandler(BasinInventory::new), ItemSlots::fromHandler
 	));
 
 	public static Codec<Integer> boundedIntStr(int min) {

--- a/src/main/java/com/simibubi/create/foundation/fluid/SmartFluidTank.java
+++ b/src/main/java/com/simibubi/create/foundation/fluid/SmartFluidTank.java
@@ -25,4 +25,7 @@ public class SmartFluidTank extends FluidTank {
 		updateCallback.accept(stack);
 	}
 
+	public void setUpdateCallback(Consumer<FluidStack> updateCallback) {
+		this.updateCallback = updateCallback;
+	}
 }

--- a/src/main/java/com/simibubi/create/foundation/item/SmartInventory.java
+++ b/src/main/java/com/simibubi/create/foundation/item/SmartInventory.java
@@ -16,6 +16,8 @@ import net.neoforged.neoforge.common.util.INBTSerializable;
 import net.neoforged.neoforge.items.IItemHandlerModifiable;
 import net.neoforged.neoforge.items.ItemStackHandler;
 
+import org.jetbrains.annotations.Nullable;
+
 public class SmartInventory extends ItemHandlerContainer
 	implements IItemHandlerModifiable, INBTSerializable<CompoundTag> {
 
@@ -25,19 +27,19 @@ public class SmartInventory extends ItemHandlerContainer
 	protected SyncedStackHandler wrapped;
 	protected int stackSize;
 
-	public SmartInventory(int slots, SyncedBlockEntity be) {
+	public SmartInventory(int slots, @Nullable SyncedBlockEntity be) {
 		this(slots, be, 64, false);
 	}
 
-	public SmartInventory(int slots, SyncedBlockEntity be, BiPredicate<Integer, ItemStack> isValid) {
+	public SmartInventory(int slots, @Nullable SyncedBlockEntity be, BiPredicate<Integer, ItemStack> isValid) {
 		this(slots, be, 64, false, isValid);
 	}
 
-	public SmartInventory(int slots, SyncedBlockEntity be, int stackSize, boolean stackNonStackables) {
+	public SmartInventory(int slots, @Nullable SyncedBlockEntity be, int stackSize, boolean stackNonStackables) {
 		this(new SyncedStackHandler(slots, be, stackNonStackables, stackSize), stackSize, stackNonStackables);
 	}
 
-	public SmartInventory(int slots, SyncedBlockEntity be, int stackSize, boolean stackNonStackables, BiPredicate<Integer, ItemStack> isValid) {
+	public SmartInventory(int slots, @Nullable SyncedBlockEntity be, int stackSize, boolean stackNonStackables, BiPredicate<Integer, ItemStack> isValid) {
 		this(new SyncedStackHandler(slots, be, stackNonStackables, stackSize, isValid), stackSize, stackNonStackables);
 	}
 
@@ -145,18 +147,18 @@ public class SmartInventory extends ItemHandlerContainer
 
 	protected static class SyncedStackHandler extends ItemStackHandler {
 
-		private SyncedBlockEntity blockEntity;
+		private @Nullable SyncedBlockEntity blockEntity;
 		private boolean stackNonStackables;
 		private int stackSize;
 		private BiPredicate<Integer, ItemStack> isValid = super::isItemValid;
 		private Consumer<Integer> updateCallback;
 
-		public SyncedStackHandler(int slots, SyncedBlockEntity be, boolean stackNonStackables, int stackSize, BiPredicate<Integer, ItemStack> isValid) {
+		public SyncedStackHandler(int slots, @Nullable SyncedBlockEntity be, boolean stackNonStackables, int stackSize, BiPredicate<Integer, ItemStack> isValid) {
 			this(slots, be, stackNonStackables, stackSize);
 			this.isValid = isValid;
 		}
 
-		public SyncedStackHandler(int slots, SyncedBlockEntity be, boolean stackNonStackables, int stackSize) {
+		public SyncedStackHandler(int slots, @Nullable SyncedBlockEntity be, boolean stackNonStackables, int stackSize) {
 			super(slots);
 			this.blockEntity = be;
 			this.stackNonStackables = stackNonStackables;
@@ -168,7 +170,8 @@ public class SmartInventory extends ItemHandlerContainer
 			super.onContentsChanged(slot);
 			if (updateCallback != null)
 				updateCallback.accept(slot);
-			blockEntity.notifyUpdate();
+			if (blockEntity != null)
+				blockEntity.notifyUpdate();
 		}
 
 		@Override

--- a/src/main/java/com/simibubi/create/foundation/render/BlockEntityRenderHelper.java
+++ b/src/main/java/com/simibubi/create/foundation/render/BlockEntityRenderHelper.java
@@ -56,18 +56,9 @@ public class BlockEntityRenderHelper {
 				.translate(pos);
 
 			try {
-				int realLevelLight = LevelRenderer.getLightColor(realLevel, getLightPos(lightTransform, pos));
-
-				int light;
-				if (renderLevel != null) {
-					renderLevel.setExternalLight(realLevelLight);
-					light = LevelRenderer.getLightColor(renderLevel, pos);
-				} else {
-					light = realLevelLight;
-				}
+				int light = getLight(realLevel, renderLevel, pos, lightTransform);
 
 				renderer.render(blockEntity, pt, ms, buffer, light, OverlayTexture.NO_OVERLAY);
-
 			} catch (Exception e) {
 				// Prevent this BE from causing more issues in the future.
 				erroredBEsOut.set(i);
@@ -85,7 +76,18 @@ public class BlockEntityRenderHelper {
 		}
 	}
 
-	private static BlockPos getLightPos(@Nullable Matrix4f lightTransform, BlockPos contraptionPos) {
+	public static int getLight(Level realLevel, VirtualRenderWorld renderLevel, BlockPos pos, @Nullable Matrix4f lightTransform) {
+		int realLevelLight = LevelRenderer.getLightColor(realLevel, getLightPos(lightTransform, pos));
+
+		if (renderLevel != null) {
+			renderLevel.setExternalLight(realLevelLight);
+			return LevelRenderer.getLightColor(renderLevel, pos);
+		}
+
+		return realLevelLight;
+	}
+
+	public static BlockPos getLightPos(@Nullable Matrix4f lightTransform, BlockPos contraptionPos) {
 		if (lightTransform != null) {
 			Vector4f lightVec = new Vector4f(contraptionPos.getX() + .5f, contraptionPos.getY() + .5f, contraptionPos.getZ() + .5f, 1);
 			lightVec.mul(lightTransform);

--- a/src/main/java/com/simibubi/create/foundation/utility/InventoryUtil.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/InventoryUtil.java
@@ -1,0 +1,12 @@
+package com.simibubi.create.foundation.utility;
+
+import net.neoforged.neoforge.items.IItemHandler;
+import net.neoforged.neoforge.items.IItemHandlerModifiable;
+
+public class InventoryUtil {
+	public static void copyInventoryToFrom(IItemHandlerModifiable copy, IItemHandler original) {
+		for (int i = 0; i < original.getSlots(); i++) {
+			copy.setStackInSlot(i, original.getStackInSlot(i).copy());
+		}
+	}
+}


### PR DESCRIPTION
<img width="1708" height="1016" alt="A screenshot of several basins on a rotating contraption, mounted on a mechanical bearing; the basins are filled with fluid." src="https://github.com/user-attachments/assets/5add6bdf-b24d-4cf3-8d7d-1688129c9329" />

This PR refactors how basins work on contraptions.

It adds a MountedItemStorage and a MountedFluidStorage for basins on contraptions, both of which take the basins input/output section into account.

It also adds a BasinInteractionBehaviour that lets players right-click a basin on a contraption to take the items out; just like it would work in-world.

It also refactors BasinMovementBehaviour to use and update these storages accordingly. Additionally, this behaviour checks every tick in order to pick up items.

Finally, this adds methods to render the basin correctly in-contraption, including fluids and items.

# Gameplay Changes
- Basin can now be accessed inside a contraption with a Portable Storage Interface or Portable Fluid Interface
- Basin can now be emptied of items inside a contraption via a player right-clicking it with an empty hand (just like it works outside of a contraption)
- Fluids are now visible inside a basin when on a contraption
- A basin can dump its contents multiple times (if the items inside it are updated) 