### PR TITLE
fix: use config max for rpm cap (fixes #6609)

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/motor/CreativeMotorBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/motor/CreativeMotorBlockEntity.java
@@ -9,6 +9,7 @@ import com.simibubi.create.compat.Mods;
 import com.simibubi.create.compat.computercraft.AbstractComputerBehaviour;
 import com.simibubi.create.compat.computercraft.ComputerCraftProxy;
 import com.simibubi.create.content.kinetics.base.GeneratingKineticBlockEntity;
+import com.simibubi.create.infrastructure.config.AllConfigs;
 import com.simibubi.create.foundation.blockEntity.behaviour.BlockEntityBehaviour;
 import com.simibubi.create.foundation.blockEntity.behaviour.ValueBoxTransform;
 import com.simibubi.create.foundation.blockEntity.behaviour.scrollValue.ScrollValueBehaviour;
@@ -53,7 +54,8 @@ public class CreativeMotorBlockEntity extends GeneratingKineticBlockEntity {
 	@Override
 	public void addBehaviours(List<BlockEntityBehaviour> behaviours) {
 		super.addBehaviours(behaviours);
-		int max = MAX_SPEED;
+		Integer max = AllConfigs.server().kinetics.maxRotationSpeed.get();
+
 		generatedSpeed = new KineticScrollValueBehaviour(CreateLang.translateDirect("kinetics.creative_motor.rotation_speed"),
 			this, new MotorValueBox());
 		generatedSpeed.between(-max, max);

--- a/src/main/java/com/simibubi/create/content/kinetics/motor/KineticScrollValueBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/motor/KineticScrollValueBehaviour.java
@@ -23,12 +23,11 @@ public class KineticScrollValueBehaviour extends ScrollValueBehaviour {
 
 	@Override
 	public ValueSettingsBoard createBoard(Player player, BlockHitResult hitResult) {
-		ImmutableList<Component> rows = ImmutableList.of(Component.literal("\u27f3")
-			.withStyle(ChatFormatting.BOLD),
-			Component.literal("\u27f2")
-				.withStyle(ChatFormatting.BOLD));
+		ImmutableList<Component> rows = ImmutableList.of(
+			Component.literal("\u27f3").withStyle(ChatFormatting.BOLD),
+			Component.literal("\u27f2").withStyle(ChatFormatting.BOLD));
 		ValueSettingsFormatter formatter = new ValueSettingsFormatter(this::formatSettings);
-		return new ValueSettingsBoard(label, 256, 32, rows, formatter);
+		return new ValueSettingsBoard(label, max, max / 8, rows, formatter);
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/foundation/blockEntity/behaviour/ValueSettingsScreen.java
+++ b/src/main/java/com/simibubi/create/foundation/blockEntity/behaviour/ValueSettingsScreen.java
@@ -54,19 +54,33 @@ public class ValueSettingsScreen extends AbstractSimiScreen {
 		this.milestoneSize = iconMode ? 8 : 4;
 	}
 
+	protected float getScale(int max) {
+		if (max <= 256) {
+			return  max > 128 ? 1 : 2;
+		}
+
+		max--;
+		max >>= 8;
+		float scale = 1f;
+		while (max > 0) {
+			scale /= 2f;
+			max >>= 1;
+		}
+		return scale;
+	}
+
 	@Override
 	protected void init() {
 		int maxValue = board.maxValue();
 		maxLabelWidth = 0;
 		int milestoneCount = maxValue / board.milestoneInterval() + 1;
-		int scale = maxValue > 128 ? 1 : 2;
 
 		for (Component component : board.rows())
 			maxLabelWidth = Math.max(maxLabelWidth, font.width(component));
 		if (iconMode)
 			maxLabelWidth = -18;
 
-		valueBarWidth = (maxValue + 1) * scale + 1 + milestoneCount * milestoneSize;
+		valueBarWidth = (int) ((maxValue + 1) * getScale(maxValue) + 1 + milestoneCount * milestoneSize);
 		int width = (maxLabelWidth + 14) + (valueBarWidth + 10);
 		int height = (board.rows()
 			.size() * 11);
@@ -116,9 +130,8 @@ public class ValueSettingsScreen extends AbstractSimiScreen {
 	}
 
 	public Vec2 getCoordinateOfValue(int row, int column) {
-		int scale = board.maxValue() > 128 ? 1 : 2;
 		float xOut =
-			guiLeft + ((Math.max(1, column) - 1) / board.milestoneInterval()) * milestoneSize + column * scale + 1.5f;
+			guiLeft + ((Math.max(1, column) - 1) / board.milestoneInterval()) * milestoneSize + column * getScale(board.maxValue()) + 1.5f;
 		xOut += maxLabelWidth + 14 + 4;
 
 		if (column % board.milestoneInterval() == 0)
@@ -135,7 +148,6 @@ public class ValueSettingsScreen extends AbstractSimiScreen {
 		int x = guiLeft;
 		int y = guiTop;
 		int milestoneCount = board.maxValue() / board.milestoneInterval() + 1;
-		int scale = board.maxValue() > 128 ? 1 : 2;
 
 		Component title = board.title();
         Component tip =
@@ -194,7 +206,7 @@ public class ValueSettingsScreen extends AbstractSimiScreen {
 					AllGuiTextures.VALUE_SETTINGS_WIDE_MILESTONE.render(graphics, milestoneX, y + 1);
 				else
 					AllGuiTextures.VALUE_SETTINGS_MILESTONE.render(graphics, milestoneX, y + 1);
-				milestoneX += milestoneSize + board.milestoneInterval() * scale;
+				milestoneX += (int) (milestoneSize + board.milestoneInterval() * getScale(board.maxValue()));
 			}
 
 			y += 11;

--- a/src/main/java/com/simibubi/create/foundation/blockEntity/behaviour/ValueSettingsScreen.java
+++ b/src/main/java/com/simibubi/create/foundation/blockEntity/behaviour/ValueSettingsScreen.java
@@ -54,19 +54,20 @@ public class ValueSettingsScreen extends AbstractSimiScreen {
 		this.milestoneSize = iconMode ? 8 : 4;
 	}
 
-	protected float getScale(int max) {
+	float getScale(int max) {
 		if (max <= 256) {
 			return  max > 128 ? 1 : 2;
 		}
 
-		max--;
-		max >>= 8;
-		float scale = 1f;
-		while (max > 0) {
-			scale /= 2f;
-			max >>= 1;
-		}
-		return scale;
+		// same thing as
+		// 257~512  -> 0.5
+		// 513~1024 -> 0.25
+		// 1025~2048 -> 0.125
+		// ...
+
+		// 127: exponent offset, 8: 2^8 = 256
+		// -1: offset for being power of 2 inclusive, 23: mantissa offset
+		return Float.intBitsToFloat((127 - Integer.SIZE + 8 + Integer.numberOfLeadingZeros(max - 1)) << 23);
 	}
 
 	@Override


### PR DESCRIPTION
- changed `CreativeMotorBE` to have same structure as `SpeedControllerBE`
- use max speed of base class in `KineticScrollValueBehavior`
- dynamically calculate milestones instead of fixing it as 32 (div by 8)
- use dynamic scale with some math tricks in `ValueSettingsScreen` and introduce protected method `#getScale(int max)`