### PR TITLE
Improve factory gauge request accuracy

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/factoryBoard/FactoryPanelBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/logistics/factoryBoard/FactoryPanelBehaviour.java
@@ -355,10 +355,15 @@ public class FactoryPanelBehaviour extends FilteringBehaviour implements MenuPro
 
 	private void tickStorageMonitor() {
 		ItemStack filter = getFilter();
+		int unloadedLinkCount = getUnloadedLinks();
+		FactoryPanelBlockEntity panelBE = panelBE();
+		if (!panelBE.restocker && unloadedLinkCount == 0 && lastReportedUnloadedLinks != 0)
+			// All links have been loaded, invalidate cache so we can get an accurate summary!
+			// Otherwise, we will have to wait for 20 ticks and unnecessary packages will be sent!
+			LogisticsManager.SUMMARIES.invalidate(network);
 		int inStorage = getLevelInStorage();
 		int promised = getPromised();
 		int demand = getAmount() * (upTo ? 1 : filter.getMaxStackSize());
-		int unloadedLinkCount = getUnloadedLinks();
 		boolean shouldSatisfy = filter.isEmpty() || inStorage >= demand;
 		boolean shouldPromiseSatisfy = filter.isEmpty() || inStorage + promised >= demand;
 		boolean shouldWait = unloadedLinkCount > 0;

--- a/src/main/java/com/simibubi/create/content/logistics/factoryBoard/FactoryPanelBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/logistics/factoryBoard/FactoryPanelBehaviour.java
@@ -357,10 +357,11 @@ public class FactoryPanelBehaviour extends FilteringBehaviour implements MenuPro
 		ItemStack filter = getFilter();
 		int unloadedLinkCount = getUnloadedLinks();
 		FactoryPanelBlockEntity panelBE = panelBE();
-		if (!panelBE.restocker && unloadedLinkCount == 0 && lastReportedUnloadedLinks != 0)
+		if (!panelBE.restocker && unloadedLinkCount == 0 && lastReportedUnloadedLinks != 0) {
 			// All links have been loaded, invalidate cache so we can get an accurate summary!
 			// Otherwise, we will have to wait for 20 ticks and unnecessary packages will be sent!
 			LogisticsManager.SUMMARIES.invalidate(network);
+		}
 		int inStorage = getLevelInStorage();
 		int promised = getPromised();
 		int demand = getAmount() * (upTo ? 1 : filter.getMaxStackSize());

--- a/src/main/java/com/simibubi/create/content/logistics/packagerLink/LogisticallyLinkedBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/logistics/packagerLink/LogisticallyLinkedBehaviour.java
@@ -137,6 +137,10 @@ public class LogisticallyLinkedBehaviour extends BlockEntityBehaviour {
 		if (!loadedGlobally && global) {
 			loadedGlobally = true;
 			Create.LOGISTICS.linkLoaded(freqId, getGlobalPos());
+			// Call keepAlive regardless of redstone power.
+			// Otherwise, when no redstone power is present
+			// keepAlive won't be called until next lazy tick.
+			keepAlive(this);
 		}
 
 		if (!addedGlobally && global) {


### PR DESCRIPTION
- Fixed keepAlive not being called on initialisation when redstone power is 0.
- Explicitly invalidate network summary cache within the same tick when all links have been loaded to prevent sending unnecessary packages.

Fixes #8245