### PR TITLE
Fix Cart Assembler's Typographical Error In Ponder

### DIFF
--- a/src/generated/resources/assets/create/lang/en_us.json
+++ b/src/generated/resources/assets/create/lang/en_us.json
@@ -1676,7 +1676,7 @@
   "create.ponder.cart_assembler.text_2": "Without a redstone signal, it disassembles passing cart contraptions back into blocks",
   "create.ponder.cart_assembler.text_3": "Using a Wrench on the Minecart will let you carry the Contraption elsewhere",
   "create.ponder.cart_assembler_dual.header": "Assembling Carriage Contraptions",
-  "create.ponder.cart_assembler_dual.text_1": "Whenever two Cart Assembers share an attached structure...",
+  "create.ponder.cart_assembler_dual.text_1": "Whenever two Cart Assemblers share an attached structure...",
   "create.ponder.cart_assembler_dual.text_2": "Powering either of them will create a Carriage Contraption",
   "create.ponder.cart_assembler_dual.text_3": "The carts will behave like those connected via Minecart Coupling",
   "create.ponder.cart_assembler_modes.header": "Orientation Settings for Minecart Contraptions",

--- a/src/main/java/com/simibubi/create/infrastructure/ponder/scenes/CartAssemblerScenes.java
+++ b/src/main/java/com/simibubi/create/infrastructure/ponder/scenes/CartAssemblerScenes.java
@@ -346,7 +346,7 @@ public class CartAssemblerScenes {
 			.colored(PonderPalette.GREEN)
 			.pointAt(util.vector().blockSurface(util.grid().at(2, 2, 4), Direction.NORTH))
 			.placeNearTarget()
-			.text("Whenever two Cart Assembers share an attached structure...")
+			.text("Whenever two Cart Assemblers share an attached structure...")
 			.attachKeyFrame();
 		scene.idle(70);
 

--- a/src/main/resources/assets/create/lang/en_gb.json
+++ b/src/main/resources/assets/create/lang/en_gb.json
@@ -1674,7 +1674,7 @@
   "create.ponder.cart_assembler.text_2": "Without a redstone signal, it disassembles passing cart contraptions back into blocks",
   "create.ponder.cart_assembler.text_3": "Using a Wrench on the Minecart will let you carry the Contraption elsewhere",
   "create.ponder.cart_assembler_dual.header": "Assembling Carriage Contraptions",
-  "create.ponder.cart_assembler_dual.text_1": "Whenever two Cart Assembers share an attached structure...",
+  "create.ponder.cart_assembler_dual.text_1": "Whenever two Cart Assemblers share an attached structure...",
   "create.ponder.cart_assembler_dual.text_2": "Powering either of them will create a Carriage Contraption",
   "create.ponder.cart_assembler_dual.text_3": "The carts will behave like those connected via Minecart Coupling",
   "create.ponder.cart_assembler_modes.header": "Orientation Settings for Minecart Contraptions",


### PR DESCRIPTION
I'm not sure if this is the correct way to do it, but I replaced all instances of the misspelled word.

Fixes - #9650 

<img width="850" height="477" alt="image" src="https://github.com/user-attachments/assets/bc66c9c6-3c47-48ab-b605-9e48ed3bbcad" />
