### PR TITLE
Fix Create's rails not in `minecraft:rails` item tag

### DIFF
--- a/src/generated/resources/data/minecraft/tags/item/rails.json
+++ b/src/generated/resources/data/minecraft/tags/item/rails.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "create:cart_assembler",
+    "create:controller_rail"
+  ]
+}


### PR DESCRIPTION
Due to an oversight, Create's own new rails were included in the `minecraft:rails` **block** tag, but not its corresponding **item** tag. This PR fixes that.