### PR TITLE
Add the Controller Rail to ItemTags.RAILS

### DIFF
--- a/src/generated/resources/.cache/82992cbf8f2794d83ac94034835eac0acd7915b9
+++ b/src/generated/resources/.cache/82992cbf8f2794d83ac94034835eac0acd7915b9
@@ -1,4 +1,4 @@
-// 1.21.1	2025-11-02T10:48:42.643836944	Create's Standard Recipes
+// 1.21.1	2025-12-10T08:26:45.219015	Create's Standard Recipes
 489f0a3e3d8571c4897f49eada95a23290a472dc data/create/advancement/recipes/combat/crafting/appliances/netherite_backtank.json
 b024ae44179c47b9be8fa35acc763c22b7b01b2e data/create/advancement/recipes/combat/crafting/appliances/netherite_backtank_from_netherite.json
 41d2909fcf45f9098c0ee306810c16168d4e8ae4 data/create/advancement/recipes/combat/crafting/appliances/netherite_diving_boots.json
@@ -488,7 +488,7 @@ a5c159b421d293d78c3eff019a0c4679ee7b27f6 data/create/recipe/crafting/logistics/s
 1fb9b09ffee15f90f7c5f40ca0bd091bb478111e data/create/recipe/crafting/materials/andesite_alloy_block.json
 156eb4e2b4751735a4fde6c19909c2c1a176b100 data/create/recipe/crafting/materials/andesite_alloy_from_block.json
 e2dc9c6465a56670f7faa24863f278e8acbfbdd1 data/create/recipe/crafting/materials/andesite_alloy_from_zinc.json
-72d826d64a65796e2d4806f756bd7a1f7513164e data/create/recipe/crafting/materials/bound_cardboard_block.json
+20f9ea9b3eea2ad83b946548d9643525a9f9505c data/create/recipe/crafting/materials/bound_cardboard_block.json
 f90e384c97e6de444d7b77bc1742fdc5297b09b1 data/create/recipe/crafting/materials/brass_block_from_compacting.json
 9791c35874f96fdb3d96be6c2c9d03bdba7871a8 data/create/recipe/crafting/materials/brass_ingot_from_compacting.json
 319647782ae788242af731daa11d550ad73f0660 data/create/recipe/crafting/materials/brass_ingot_from_decompacting.json

--- a/src/generated/resources/.cache/af1b4964b4b67530aeb67585e9573385e8cab38a
+++ b/src/generated/resources/.cache/af1b4964b4b67530aeb67585e9573385e8cab38a
@@ -1,4 +1,4 @@
-// 1.21.1	2025-11-02T10:48:42.585872441	Registrate Provider for create [Registries, Data Maps, Recipes, Advancements, Loot Tables, Tags (blocks), Tags (enchantments), Tags (items), Tags (fluids), Tags (entity_types), generic_server_provider, Blockstates, Item models, Lang (en_us/en_ud), generic_client_provider]
+// 1.21.1	2025-12-10T08:26:45.206866	Registrate Provider for create [Registries, Data Maps, Recipes, Advancements, Loot Tables, Tags (blocks), Tags (enchantments), Tags (items), Tags (fluids), Tags (entity_types), generic_server_provider, Blockstates, Item models, Lang (en_us/en_ud), generic_client_provider]
 60bbdf92d2ac9824ea6144955c74043a6005f79d assets/create/blockstates/acacia_window.json
 6a67703c2697d81b7dc83e9d72a66f9c9ff08383 assets/create/blockstates/acacia_window_pane.json
 c3ae87b62e81d8e9476eccd793bb1548d74c66a1 assets/create/blockstates/adjustable_chain_gearshift.json
@@ -4847,6 +4847,7 @@ cd2613a4722ce79366433181095c27463e7c61b8 data/minecraft/tags/block/stairs.json
 9eb6474e9336c2c378100b7e2577a6ba9c62e403 data/minecraft/tags/item/head_armor.json
 afdac448376ff5624f49cbf31feedf691ecbc4c5 data/minecraft/tags/item/leg_armor.json
 0fd9f0786777d613ba7186ec00f9f972d0317c3f data/minecraft/tags/item/piglin_loved.json
+155f948811409d40c1e4e6b3c1fc8524693135d1 data/minecraft/tags/item/rails.json
 1ac7c46815461cbec0d4d97f25c085fdc8375dab data/minecraft/tags/item/slabs.json
 dafa3bdb72fef5e6c0201c05846db3f2b214e587 data/minecraft/tags/item/stairs.json
 11427a72e181857e22ec37a22462bc652e127cc5 data/minecraft/tags/item/trapdoors.json

--- a/src/generated/resources/data/create/recipe/crafting/materials/bound_cardboard_block.json
+++ b/src/generated/resources/data/create/recipe/crafting/materials/bound_cardboard_block.json
@@ -6,7 +6,7 @@
       "item": "create:cardboard_block"
     },
     {
-      "item": "minecraft:string"
+      "tag": "c:strings"
     }
   ],
   "result": {

--- a/src/generated/resources/data/minecraft/tags/item/rails.json
+++ b/src/generated/resources/data/minecraft/tags/item/rails.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "create:controller_rail"
+  ]
+}

--- a/src/main/java/com/simibubi/create/AllBlocks.java
+++ b/src/main/java/com/simibubi/create/AllBlocks.java
@@ -1270,6 +1270,7 @@ public class AllBlocks {
 				.getColorForPower(pos != null && world != null ? state.getValue(BlockStateProperties.POWER) : 0))
 			.tag(BlockTags.RAILS)
 			.item()
+			.tag(ItemTags.RAILS)
 			.model((c, p) -> p.generated(c, Create.asResource("block/" + c.getName())))
 			.build()
 			.register();


### PR DESCRIPTION
Original PR made by Mickeon in #9684

This PR adds the Controller Rail item to the ItemTags.RAILS tag. The block was already in there. I didn't add the Cart Assembler into there, as I assumed that the item is distanced enough from rails and the block tag was in there for functionality.

Funnily, running datagen seems to have generated a recipe for a commit that changed the `minecraft:string` in the Bound Cardboard recipe to `#c:strings`, so that's in here too :P