### PR TITLE
Fix bug where packages were being sent when players enters range between simulation distance and chunk loading distance.

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/factoryBoard/FactoryPanelBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/logistics/factoryBoard/FactoryPanelBehaviour.java
@@ -116,6 +116,7 @@ public class FactoryPanelBehaviour extends FilteringBehaviour implements MenuPro
 	private boolean promisePrimedForMarkDirty;
 
 	private int lastReportedUnloadedLinks;
+	private int lastReportedNotTickingLinks;
 	private int lastReportedLevelInStorage;
 	private int lastReportedPromises;
 	private int timer;
@@ -356,8 +357,10 @@ public class FactoryPanelBehaviour extends FilteringBehaviour implements MenuPro
 	private void tickStorageMonitor() {
 		ItemStack filter = getFilter();
 		int unloadedLinkCount = getUnloadedLinks();
+		int notTickingLinkCount = getNotTickingLinks();
 		FactoryPanelBlockEntity panelBE = panelBE();
-		if (!panelBE.restocker && unloadedLinkCount == 0 && lastReportedUnloadedLinks != 0) {
+		if (!panelBE.restocker && ((unloadedLinkCount == 0 && lastReportedUnloadedLinks != 0)
+			|| (notTickingLinkCount == 0 && lastReportedNotTickingLinks != 0))) {
 			// All links have been loaded, invalidate cache so we can get an accurate summary!
 			// Otherwise, we will have to wait for 20 ticks and unnecessary packages will be sent!
 			LogisticsManager.SUMMARIES.invalidate(network);
@@ -367,11 +370,12 @@ public class FactoryPanelBehaviour extends FilteringBehaviour implements MenuPro
 		int demand = getAmount() * (upTo ? 1 : filter.getMaxStackSize());
 		boolean shouldSatisfy = filter.isEmpty() || inStorage >= demand;
 		boolean shouldPromiseSatisfy = filter.isEmpty() || inStorage + promised >= demand;
-		boolean shouldWait = unloadedLinkCount > 0;
+		boolean shouldWait = unloadedLinkCount > 0 || notTickingLinkCount > 0;
 
 		if (lastReportedLevelInStorage == inStorage && lastReportedPromises == promised
-			&& lastReportedUnloadedLinks == unloadedLinkCount && satisfied == shouldSatisfy
-			&& promisedSatisfied == shouldPromiseSatisfy && waitingForNetwork == shouldWait)
+			&& lastReportedUnloadedLinks == unloadedLinkCount && lastReportedNotTickingLinks == notTickingLinkCount
+			&& satisfied == shouldSatisfy && promisedSatisfied == shouldPromiseSatisfy
+			&& waitingForNetwork == shouldWait)
 			return;
 
 		if (!satisfied && shouldSatisfy && demand > 0) {
@@ -385,6 +389,7 @@ public class FactoryPanelBehaviour extends FilteringBehaviour implements MenuPro
 		lastReportedPromises = promised;
 		promisedSatisfied = shouldPromiseSatisfy;
 		lastReportedUnloadedLinks = unloadedLinkCount;
+		lastReportedNotTickingLinks = notTickingLinkCount;
 		waitingForNetwork = shouldWait;
 		if (!getWorld().isClientSide)
 			blockEntity.sendData();
@@ -731,6 +736,16 @@ public class FactoryPanelBehaviour extends FilteringBehaviour implements MenuPro
 		return Create.LOGISTICS.getUnloadedLinkCount(network);
 	}
 
+	public int getNotTickingLinks() {
+		if (getWorld().isClientSide())
+			return lastReportedNotTickingLinks;
+		if (panelBE().restocker) {
+			PackagerBlockEntity pbe = panelBE().getRestockedPackager();
+			return pbe == null || !pbe.isTicking() ? 1 : 0;
+		}
+		return Create.LOGISTICS.getNotTickingLinks(network, getWorld());
+	}
+
 	public int getLevelInStorage() {
 		if (blockEntity.isVirtual())
 			return 1;
@@ -835,6 +850,7 @@ public class FactoryPanelBehaviour extends FilteringBehaviour implements MenuPro
 		panelTag.putInt("LastLevel", lastReportedLevelInStorage);
 		panelTag.putInt("LastPromised", lastReportedPromises);
 		panelTag.putInt("LastUnloadedLinks", lastReportedUnloadedLinks);
+		panelTag.putInt("LastNotTickingLinks", lastReportedNotTickingLinks);
 		panelTag.putBoolean("Satisfied", satisfied);
 		panelTag.putBoolean("PromisedSatisfied", promisedSatisfied);
 		panelTag.putBoolean("Waiting", waitingForNetwork);
@@ -870,6 +886,7 @@ public class FactoryPanelBehaviour extends FilteringBehaviour implements MenuPro
 		lastReportedLevelInStorage = panelTag.getInt("LastLevel");
 		lastReportedPromises = panelTag.getInt("LastPromised");
 		lastReportedUnloadedLinks = panelTag.getInt("LastUnloadedLinks");
+		lastReportedNotTickingLinks = panelTag.getInt("LastNotTickingLinks");
 		satisfied = panelTag.getBoolean("Satisfied");
 		promisedSatisfied = panelTag.getBoolean("PromisedSatisfied");
 		waitingForNetwork = panelTag.getBoolean("Waiting");

--- a/src/main/java/com/simibubi/create/content/logistics/packagerLink/GlobalLogisticsManager.java
+++ b/src/main/java/com/simibubi/create/content/logistics/packagerLink/GlobalLogisticsManager.java
@@ -88,6 +88,17 @@ public class GlobalLogisticsManager {
 		return logisticsNetwork.totalLinks.size() - logisticsNetwork.loadedLinks.size();
 	}
 
+	public int getNotTickingLinks(UUID networkId, Level level) {
+		LogisticsNetwork logisticsNetwork = logisticsNetworks.get(networkId);
+		if (logisticsNetwork == null || level == null)
+			return 0;
+		return Math.toIntExact(logisticsNetwork.loadedLinks.stream()
+			.filter(pos -> pos.dimension() == level.dimension()
+				&& level.getBlockEntity(pos.pos()) instanceof PackagerLinkBlockEntity plbe
+				&& !plbe.isTicking())
+			.count());
+	}
+
 	@Nullable
 	public RequestPromiseQueue getQueuedPromises(UUID networkId) {
 		return !logisticsNetworks.containsKey(networkId) ? null : logisticsNetworks.get(networkId).panelPromises;

--- a/src/main/java/com/simibubi/create/content/logistics/packagerLink/PackagerLinkBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/packagerLink/PackagerLinkBlockEntity.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import net.minecraft.world.level.Level;
+
 import org.jetbrains.annotations.Nullable;
 
 import org.apache.commons.lang3.mutable.MutableBoolean;
@@ -32,6 +34,8 @@ import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.AttachFace;
 import net.minecraft.world.phys.Vec3;
+
+import static com.simibubi.create.content.logistics.packagerLink.LogisticallyLinkedBehaviour.keepAlive;
 
 public class PackagerLinkBlockEntity extends LinkWithBulbBlockEntity {
 
@@ -158,4 +162,22 @@ public class PackagerLinkBlockEntity extends LinkWithBulbBlockEntity {
 		});
 	}
 
+	@Override
+	public void tick() {
+		Level level = this.getLevel();
+		if (level == null) {
+			super.tick();
+			return;
+		}
+		// Block has been out of ticking range, without chunk unloading.
+		// If lastTick == 0, we can assume the block entity has just been loaded.
+		// When the block entity loads we have the same behaviour in initialize.
+		if (lastTick != 0 && !isTicking()) {
+			// Revive the behaviour
+			keepAlive(behaviour);
+		}
+		// Super ticks behaviours and updates lastTick.
+		// isTicking should be true again after this.
+		super.tick();
+	}
 }

--- a/src/main/java/com/simibubi/create/foundation/blockEntity/SmartBlockEntity.java
+++ b/src/main/java/com/simibubi/create/foundation/blockEntity/SmartBlockEntity.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
+import net.minecraft.world.level.Level;
+
 import org.jetbrains.annotations.NotNull;
 
 import com.simibubi.create.api.event.BlockEntityBehaviourEvent;
@@ -38,6 +40,7 @@ public abstract class SmartBlockEntity extends CachedRenderBBBlockEntity
 	private boolean firstNbtRead = true;
 	protected int lazyTickRate;
 	protected int lazyTickCounter;
+	protected long lastTick;
 	private boolean chunkUnloaded;
 
 	// Used for simulating this BE in a client-only setting
@@ -81,11 +84,17 @@ public abstract class SmartBlockEntity extends CachedRenderBBBlockEntity
 			lazyTickCounter = lazyTickRate;
 			lazyTick();
 		}
+		if (getLevel() != null) lastTick = getLevel().getGameTime();
 
 		forEachBehaviour(BlockEntityBehaviour::tick);
 	}
 
 	public void lazyTick() {}
+
+	public boolean isTicking() {
+		Level level = getLevel();
+		return level != null && level.getGameTime() - lastTick < 10;
+	}
 
 	/**
 	 * Hook only these in future subclasses of STE


### PR DESCRIPTION
- [Add isTicking to SmartBlockEntity](https://github.com/Creators-of-Create/Create/commit/b996be6fe4050f9e199e287a3350b35005839db0)

- Fix bug where packages were being sent when players enters range between simulation distance and chunk loading distance.
- When links were not ticking, but were still loaded. keepAlive was not being called. When entering the area within simulation distance, this caused sending random packages.
- Fixed by keeping track of ticking block entities.