### PR TITLE
Capabilities and goggle information expanded to blocks

### DIFF
--- a/src/main/java/com/simibubi/create/compat/tconstruct/SpoutCasting.java
+++ b/src/main/java/com/simibubi/create/compat/tconstruct/SpoutCasting.java
@@ -8,7 +8,6 @@ import com.simibubi.create.infrastructure.config.AllConfigs;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.entity.BlockEntity;
 
 import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.fluids.FluidStack;
@@ -23,11 +22,7 @@ public enum SpoutCasting implements BlockSpoutingBehaviour {
 		if (!enabled())
 			return 0;
 
-		BlockEntity blockEntity = level.getBlockEntity(pos);
-		if (blockEntity == null)
-			return 0;
-
-		IFluidHandler handler = level.getCapability(Capabilities.FluidHandler.BLOCK, blockEntity.getBlockPos(), Direction.UP);
+		IFluidHandler handler = level.getCapability(Capabilities.FluidHandler.BLOCK, pos, Direction.UP);
 		if (handler == null)
 			return 0;
 		if (handler.getTanks() != 1)

--- a/src/main/java/com/simibubi/create/content/contraptions/piston/PistonExtensionPoleBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/piston/PistonExtensionPoleBlock.java
@@ -4,15 +4,20 @@ import static com.simibubi.create.content.contraptions.piston.MechanicalPistonBl
 import static com.simibubi.create.content.contraptions.piston.MechanicalPistonBlock.isPiston;
 import static com.simibubi.create.content.contraptions.piston.MechanicalPistonBlock.isPistonHead;
 
+import java.util.List;
 import java.util.function.Predicate;
 
 import com.simibubi.create.AllBlocks;
 import com.simibubi.create.AllShapes;
+import com.simibubi.create.api.equipment.goggles.IHaveGoggleInformation;
 import com.simibubi.create.content.contraptions.piston.MechanicalPistonBlock.PistonState;
 import com.simibubi.create.content.equipment.wrench.IWrenchable;
 import com.simibubi.create.foundation.block.WrenchableDirectionalBlock;
 import com.simibubi.create.foundation.placement.PoleHelper;
 
+import com.simibubi.create.foundation.utility.CreateLang;
+
+import net.createmod.catnip.data.Iterate;
 import net.createmod.catnip.placement.IPlacementHelper;
 import net.createmod.catnip.placement.PlacementHelpers;
 import net.minecraft.MethodsReturnNonnullByDefault;
@@ -20,6 +25,8 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Direction.Axis;
 import net.minecraft.core.Direction.AxisDirection;
+import net.minecraft.network.chat.CommonComponents;
+import net.minecraft.network.chat.Component;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.ItemInteractionResult;
@@ -44,7 +51,7 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
 
-public class PistonExtensionPoleBlock extends WrenchableDirectionalBlock implements IWrenchable, SimpleWaterloggedBlock {
+public class PistonExtensionPoleBlock extends WrenchableDirectionalBlock implements IWrenchable, SimpleWaterloggedBlock, IHaveGoggleInformation {
 
 	private static final int placementHelperId = PlacementHelpers.register(PlacementHelper.get());
 
@@ -178,5 +185,27 @@ public class PistonExtensionPoleBlock extends WrenchableDirectionalBlock impleme
 		public Predicate<ItemStack> getItemPredicate() {
 			return AllBlocks.PISTON_EXTENSION_POLE::isIn;
 		}
+	}
+
+	@Override
+	public boolean addToGoggleTooltip(Level level, BlockPos pos, BlockState state, List<Component> tooltip, boolean isPlayerSneaking) {
+		Direction[] directions = Iterate.directionsInAxis(state.getValue(PistonExtensionPoleBlock.FACING)
+			.getAxis());
+		int poles = 1;
+		boolean pistonFound = false;
+		for (Direction dir : directions) {
+			int attachedPoles = PistonExtensionPoleBlock.PlacementHelper.get()
+				.attachedPoles(level, pos, dir);
+			poles += attachedPoles;
+			pistonFound |= level.getBlockState(pos.relative(dir, attachedPoles + 1))
+				.getBlock() instanceof MechanicalPistonBlock;
+		}
+		if (!tooltip.isEmpty())
+			tooltip.add(CommonComponents.EMPTY);
+
+		CreateLang.translate("gui.goggles.pole_length")
+			.text(" " + poles)
+			.forGoggles(tooltip);
+		return pistonFound;
 	}
 }

--- a/src/main/java/com/simibubi/create/content/equipment/goggles/GoggleOverlayRenderer.java
+++ b/src/main/java/com/simibubi/create/content/equipment/goggles/GoggleOverlayRenderer.java
@@ -103,6 +103,9 @@ public class GoggleOverlayRenderer {
 		ItemStack item = AllItems.GOGGLES.asStack();
 		List<Component> tooltip = new ArrayList<>();
 
+		if(!hasGoggleInformation && world.getBlockState(pos).getBlock() instanceof IHaveCustomOverlayIcon info)
+			item = info.getIcon(isShifting);
+
 		if (be instanceof IHaveCustomOverlayIcon customOverlayIcon)
 			item = customOverlayIcon.getIcon(isShifting);
 
@@ -121,6 +124,9 @@ public class GoggleOverlayRenderer {
 				tooltip.remove(tooltip.size() - 1);
 		}
 
+		if(world.getBlockState(pos).getBlock() instanceof IHaveGoggleInformation info)
+			goggleAddedInformation |= info.addToGoggleTooltip(world, pos, world.getBlockState(pos), tooltip, isShifting);
+
 		if (be instanceof IDisplayAssemblyExceptions) {
 			boolean exceptionAdded = ((IDisplayAssemblyExceptions) be).addExceptionToTooltip(tooltip);
 			if (exceptionAdded) {
@@ -138,33 +144,6 @@ public class GoggleOverlayRenderer {
 		if ((hasGoggleInformation && !goggleAddedInformation) && (hasHoveringInformation && !hoverAddedInformation)) {
 			hoverTicks = 0;
 			return;
-		}
-
-		// check for piston poles if goggles are worn
-		BlockState state = world.getBlockState(pos);
-		if (wearingGoggles && AllBlocks.PISTON_EXTENSION_POLE.has(state)) {
-			Direction[] directions = Iterate.directionsInAxis(state.getValue(PistonExtensionPoleBlock.FACING)
-				.getAxis());
-			int poles = 1;
-			boolean pistonFound = false;
-			for (Direction dir : directions) {
-				int attachedPoles = PistonExtensionPoleBlock.PlacementHelper.get()
-					.attachedPoles(world, pos, dir);
-				poles += attachedPoles;
-				pistonFound |= world.getBlockState(pos.relative(dir, attachedPoles + 1))
-					.getBlock() instanceof MechanicalPistonBlock;
-			}
-
-			if (!pistonFound) {
-				hoverTicks = 0;
-				return;
-			}
-			if (!tooltip.isEmpty())
-				tooltip.add(CommonComponents.EMPTY);
-
-			CreateLang.translate("gui.goggles.pole_length")
-				.text(" " + poles)
-				.forGoggles(tooltip);
 		}
 
 		if (tooltip.isEmpty()) {

--- a/src/main/java/com/simibubi/create/content/fluids/FlowSource.java
+++ b/src/main/java/com/simibubi/create/content/fluids/FlowSource.java
@@ -80,24 +80,21 @@ public abstract class FlowSource {
 
 		public void manageSource(Level level, BlockEntity networkBE) {
 			if (fluidHandlerCache == null) {
-				BlockEntity blockEntity = level.getBlockEntity(location.getConnectedPos());
-				if (blockEntity != null) {
-					if (level instanceof ServerLevel serverLevel) {
-						fluidHandlerCache = ICapabilityProvider.of(BlockCapabilityCache.create(
-							Capabilities.FluidHandler.BLOCK,
-							serverLevel,
-							blockEntity.getBlockPos(),
-							location.getOppositeFace(),
-							() -> !networkBE.isRemoved(),
-							() -> fluidHandlerCache = EMPTY
-						));
-					} else if (level instanceof PonderLevel) {
-						fluidHandlerCache = ICapabilityProvider.of(() -> level.getCapability(
-							Capabilities.FluidHandler.BLOCK,
-							blockEntity.getBlockPos(),
-							location.getOppositeFace()
-						));
-					}
+				if(level instanceof ServerLevel serverLevel) {
+					fluidHandlerCache = ICapabilityProvider.of(BlockCapabilityCache.create(
+						Capabilities.FluidHandler.BLOCK,
+						serverLevel,
+						location.getConnectedPos(),
+						location.getOppositeFace(),
+						() -> !networkBE.isRemoved(),
+						() -> fluidHandlerCache = EMPTY
+					));
+				} else if(level instanceof PonderLevel) {
+					fluidHandlerCache = ICapabilityProvider.of(() -> level.getCapability(
+						Capabilities.FluidHandler.BLOCK,
+						location.getConnectedPos(),
+						location.getOppositeFace()
+					));
 				}
 			}
 		}

--- a/src/main/java/com/simibubi/create/content/fluids/FluidPropagator.java
+++ b/src/main/java/com/simibubi/create/content/fluids/FluidPropagator.java
@@ -5,6 +5,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import net.neoforged.neoforge.common.extensions.ILevelExtension;
+
 import org.jetbrains.annotations.Nullable;
 
 import com.simibubi.create.AllBlocks;
@@ -22,7 +24,6 @@ import com.simibubi.create.foundation.utility.BlockHelper;
 import com.simibubi.create.infrastructure.config.AllConfigs;
 
 import net.neoforged.neoforge.capabilities.Capabilities;
-import net.neoforged.neoforge.fluids.capability.IFluidHandler;
 
 import net.createmod.catnip.data.Iterate;
 import net.createmod.catnip.data.Pair;
@@ -200,12 +201,8 @@ public class FluidPropagator {
 	}
 
 	public static boolean hasFluidCapability(BlockGetter world, BlockPos pos, Direction side) {
-		BlockEntity blockEntity = world.getBlockEntity(pos);
-		if (blockEntity == null || blockEntity.getLevel() == null)
-			return false;
-		IFluidHandler capability =
-			blockEntity.getLevel().getCapability(Capabilities.FluidHandler.BLOCK, blockEntity.getBlockPos(), side);
-		return capability != null;
+		if(!(world instanceof ILevelExtension level)) return false; //Maybe we can just pass a ILevelExtension as parameter instead of returning false here
+		return level.getCapability(Capabilities.FluidHandler.BLOCK, pos, side) != null;
 	}
 
 	@Nullable

--- a/src/main/java/com/simibubi/create/content/fluids/pump/PumpBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/fluids/pump/PumpBlockEntity.java
@@ -9,6 +9,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import net.neoforged.neoforge.common.extensions.ILevelExtension;
+
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.core.HolderLookup;
@@ -287,10 +289,9 @@ public class PumpBlockEntity extends KineticBlockEntity {
 			return false;
 
 		// fluid handler endpoint
-		if (blockEntity != null) {
-			IFluidHandler capability = blockEntity.getLevel().getCapability(Capabilities.FluidHandler.BLOCK, blockEntity.getBlockPos(), face.getOpposite());
-			if (capability != null)
-				return true;
+		if(level instanceof ILevelExtension ext) {
+			IFluidHandler capability = ext.getCapability(Capabilities.FluidHandler.BLOCK, connectedPos, face.getOpposite());
+			if(capability != null) return true;
 		}
 
 		// open endpoint

--- a/src/main/java/com/simibubi/create/content/fluids/pump/PumpBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/fluids/pump/PumpBlockEntity.java
@@ -289,7 +289,7 @@ public class PumpBlockEntity extends KineticBlockEntity {
 			return false;
 
 		// fluid handler endpoint
-		if(level instanceof ILevelExtension ext) {
+		if(level instanceof ILevelExtension ext) { // Instead of this check we can just pass a ILevelExtension as parameter for this method
 			IFluidHandler capability = ext.getCapability(Capabilities.FluidHandler.BLOCK, connectedPos, face.getOpposite());
 			if(capability != null) return true;
 		}

--- a/src/main/java/com/simibubi/create/content/processing/basin/BasinBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/processing/basin/BasinBlockEntity.java
@@ -6,6 +6,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
+import net.neoforged.neoforge.capabilities.Capabilities.FluidHandler;
+import net.neoforged.neoforge.capabilities.Capabilities.ItemHandler;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -368,8 +371,8 @@ public class BasinBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 		if (!(blockState.getBlock() instanceof BasinBlock))
 			return;
 		Direction direction = blockState.getValue(BasinBlock.FACING);
-		BlockEntity be = level.getBlockEntity(worldPosition.below()
-			.relative(direction));
+		BlockPos out = worldPosition.below().relative(direction);
+		BlockEntity be = level.getBlockEntity(out);
 
 		FilteringBehaviour filter = null;
 		InvManipulationBehaviour inserter = null;
@@ -381,12 +384,10 @@ public class BasinBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 		if (filter != null && filter.isRecipeFilter())
 			filter = null; // Do not test spout outputs against the recipe filter
 
-		IItemHandler targetInv = be == null ? null
-			: Optional.ofNullable(level.getCapability(Capabilities.ItemHandler.BLOCK, be.getBlockPos(), direction.getOpposite()))
-			.orElse(inserter == null ? null : inserter.getInventory());
+		IItemHandler targetInv = level.getCapability(ItemHandler.BLOCK, out, direction.getOpposite());
+		if(targetInv == null && inserter != null) targetInv = inserter.getInventory();
 
-		IFluidHandler targetTank = be == null ? null
-			: level.getCapability(Capabilities.FluidHandler.BLOCK, be.getBlockPos(), direction.getOpposite());
+		IFluidHandler targetTank = level.getCapability(FluidHandler.BLOCK, out, direction.getOpposite());
 
 		boolean update = false;
 
@@ -527,16 +528,15 @@ public class BasinBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 		Direction direction = blockState.getValue(BasinBlock.FACING);
 		if (direction != Direction.DOWN) {
 
-			BlockEntity be = level.getBlockEntity(worldPosition.below()
-				.relative(direction));
+			BlockPos out = worldPosition.below().relative(direction);
+			BlockEntity be = level.getBlockEntity(out);
 
 			InvManipulationBehaviour inserter =
 				be == null ? null : BlockEntityBehaviour.get(level, be.getBlockPos(), InvManipulationBehaviour.TYPE);
-			IItemHandler targetInv = be == null ? null
-				: Optional.ofNullable(level.getCapability(Capabilities.ItemHandler.BLOCK, be.getBlockPos(), direction.getOpposite()))
-				.orElse(inserter == null ? null : inserter.getInventory());
-			IFluidHandler targetTank = be == null ? null
-				: level.getCapability(Capabilities.FluidHandler.BLOCK, be.getBlockPos(), direction.getOpposite());
+
+			IItemHandler targetInv = level.getCapability(ItemHandler.BLOCK, out, direction.getOpposite());
+			if(targetInv == null && inserter != null) targetInv = inserter.getInventory();
+			IFluidHandler targetTank = level.getCapability(Capabilities.FluidHandler.BLOCK, out, direction.getOpposite());
 			boolean externalTankNotPresent = targetTank == null;
 
 			if (!outputItems.isEmpty() && targetInv == null)

--- a/src/main/java/com/simibubi/create/content/redstone/smartObserver/SmartObserverBlock.java
+++ b/src/main/java/com/simibubi/create/content/redstone/smartObserver/SmartObserverBlock.java
@@ -62,10 +62,10 @@ public class SmartObserverBlock extends DirectedDirectionalBlock implements IBE<
 				canDetect = true;
 			else if (BlockEntityBehaviour.get(blockEntity, FluidTransportBehaviour.TYPE) != null)
 				canDetect = true;
-			else if (blockEntity != null && (
-					context.getLevel().getCapability(Capabilities.ItemHandler.BLOCK, blockEntity.getBlockPos(), null) != null ||
-					context.getLevel().getCapability(Capabilities.FluidHandler.BLOCK, blockEntity.getBlockPos(), null) != null
-			))
+			else if (
+					context.getLevel().getCapability(Capabilities.ItemHandler.BLOCK, offsetPos, null) != null ||
+					context.getLevel().getCapability(Capabilities.FluidHandler.BLOCK, offsetPos, null) != null
+			)
 				canDetect = true;
 			else if (blockEntity instanceof FunnelBlockEntity)
 				canDetect = true;

--- a/src/main/java/com/simibubi/create/content/redstone/thresholdSwitch/ThresholdSwitchBlock.java
+++ b/src/main/java/com/simibubi/create/content/redstone/thresholdSwitch/ThresholdSwitchBlock.java
@@ -97,14 +97,15 @@ public class ThresholdSwitchBlock extends DirectedDirectionalBlock implements IB
 	@Override
 	public BlockState getStateForPlacement(BlockPlaceContext context) {
 		BlockState state = defaultBlockState();
+		Level level = context.getLevel();
+
 
 		Direction preferredFacing = null;
 		for (Direction face : context.getNearestLookingDirections()) {
-			BlockEntity be = context.getLevel()
-				.getBlockEntity(context.getClickedPos()
-					.relative(face));
-			if (be != null && (be.getLevel().getCapability(Capabilities.ItemHandler.BLOCK, be.getBlockPos(), null) != null ||
-					be.getLevel().getCapability(Capabilities.FluidHandler.BLOCK, be.getBlockPos(), null) != null)) {
+			BlockPos pos = context.getClickedPos()
+				.relative(face);
+			if (level.getCapability(Capabilities.ItemHandler.BLOCK, pos, null) != null ||
+					level.getCapability(Capabilities.FluidHandler.BLOCK, pos, null) != null) {
 				preferredFacing = face;
 				break;
 			}

--- a/src/main/java/com/simibubi/create/infrastructure/gametest/CreateGameTestHelper.java
+++ b/src/main/java/com/simibubi/create/infrastructure/gametest/CreateGameTestHelper.java
@@ -4,6 +4,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import net.minecraft.world.level.Level;
+
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -247,10 +249,8 @@ public class CreateGameTestHelper extends GameTestHelper {
 	// transfer - fluids
 
 	public IFluidHandler fluidStorageAt(BlockPos pos) {
-		BlockEntity be = getBlockEntity(pos);
-		if (be == null)
-			fail("BlockEntity not present");
-		IFluidHandler handler = be.getLevel().getCapability(Capabilities.FluidHandler.BLOCK, be.getBlockPos(), null);
+		Level level = getLevel();
+		IFluidHandler handler = level.getCapability(Capabilities.FluidHandler.BLOCK, pos, null);
 		if (handler == null)
 			fail("handler not present");
 		return handler;


### PR DESCRIPTION
## Capabilities
Since [20.3](https://neoforged.net/news/20.3capability-rework/) neoforge capabilities are not anymore block-entity related, but can be also queried on normal blocks. I know it's a very advanced topic and won't affect 90% of mods because almost every fluid/item providing block is always attached with a block entity, but I was working on a create addon when encountered this issue, so I was hoping to solve this without several bad-looking mixins in my mod.

## Goggle information
The second idea is to allow blocks to extend IHaveGoggleInformation. This allows to remove the special case for piston extension poles which are hard coded and allow any developer to implement the interface on blocks, rather than requiring a block entity. A new method has been added to the IHaveGoggleInformation interface to pass world data (block state, block position and level) when creating the goggle tooltip

Thanks for reading, have a nice day ;)