### PR TITLE
Significantly Optimize Funnel Item Extraction and MountedItemStorageWrapper

### DIFF
--- a/src/main/java/com/simibubi/create/api/contraption/storage/item/MountedItemStorageWrapper.java
+++ b/src/main/java/com/simibubi/create/api/contraption/storage/item/MountedItemStorageWrapper.java
@@ -10,12 +10,48 @@ import net.neoforged.neoforge.items.wrapper.CombinedInvWrapper;
 /**
  * Wrapper around many MountedItemStorages, providing access to all of them as one storage.
  * They can still be accessed individually through the map.
+ * 
+ * Uses O(1) lookup arrays instead of O(n) linear scan.
  */
 public class MountedItemStorageWrapper extends CombinedInvWrapper {
 	public final ImmutableMap<BlockPos, MountedItemStorage> storages;
+	
+	// Lookup arrays
+	private final int[] slotToStorage;   // Maps each slot to its storage index
+	private final int[] slotOffsets;     // Starting slot for each storage
 
 	public MountedItemStorageWrapper(ImmutableMap<BlockPos, MountedItemStorage> storages) {
 		super(storages.values().toArray(IItemHandlerModifiable[]::new));
 		this.storages = storages;
+		
+		// Build lookup arrays
+		int totalSlots = getSlots();
+		this.slotToStorage = new int[totalSlots];
+		this.slotOffsets = new int[itemHandler.length];
+		
+		int currentSlot = 0;
+		for (int storageIdx = 0; storageIdx < itemHandler.length; storageIdx++) {
+			slotOffsets[storageIdx] = currentSlot;
+			int slotsInStorage = itemHandler[storageIdx].getSlots();
+			
+			for (int i = 0; i < slotsInStorage; i++) {
+				slotToStorage[currentSlot + i] = storageIdx;
+			}
+			
+			currentSlot += slotsInStorage;
+		}
+	}
+	
+	@Override
+	protected int getIndexForSlot(int slot) {
+		if (slot < 0 || slot >= slotToStorage.length) {
+			return -1;
+		}
+		return slotToStorage[slot];
+	}
+	
+	@Override
+	protected int getSlotFromIndex(int slot, int index) {
+		return slot - slotOffsets[index];
 	}
 }

--- a/src/main/java/com/simibubi/create/content/logistics/funnel/FunnelBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/funnel/FunnelBlockEntity.java
@@ -127,25 +127,15 @@ public class FunnelBlockEntity extends SmartBlockEntity implements IHaveHovering
 		if (facing == null)
 			return;
 
-		boolean trackingEntityPresent = true;
-		AABB area = getEntityOverflowScanningArea();
-
 		// Check if last item is still blocking the extractor
-		if (lastObserved == null) {
-			trackingEntityPresent = false;
-		} else {
-			Entity lastEntity = lastObserved.get();
-			if (lastEntity == null || !lastEntity.isAlive() || !lastEntity.getBoundingBox()
-				.intersects(area)) {
-				trackingEntityPresent = false;
-				lastObserved = null;
-			}
+		Entity lastEntity = lastObserved != null ? lastObserved.get() : null;
+		if (lastEntity != null && lastEntity.isAlive()) {
+			AABB area = getEntityOverflowScanningArea();
+			if (lastEntity.getBoundingBox().intersects(area))
+				return;
+			lastObserved = null;
 		}
 
-		if (trackingEntityPresent)
-			return;
-
-		// Find other entities blocking the extract (only if necessary)
 		int amountToExtract = getAmountToExtract();
 		ExtractionCountMode mode = getModeToExtract();
 		ItemStack stack = invManipulation.simulate()
@@ -154,6 +144,9 @@ public class FunnelBlockEntity extends SmartBlockEntity implements IHaveHovering
 			invVersionTracker.awaitNewVersion(invManipulation);
 			return;
 		}
+
+		// Only scan for blocking entities if there's something to extract
+		AABB area = getEntityOverflowScanningArea();
 		for (Entity entity : level.getEntities(null, area)) {
 			if (entity instanceof ItemEntity || entity instanceof PackageEntity) {
 				lastObserved = new WeakReference<>(entity);

--- a/src/main/java/com/simibubi/create/foundation/blockEntity/behaviour/inventory/InvManipulationBehaviour.java
+++ b/src/main/java/com/simibubi/create/foundation/blockEntity/behaviour/inventory/InvManipulationBehaviour.java
@@ -81,10 +81,7 @@ public class InvManipulationBehaviour extends CapManipulationBehaviourBase<IItem
 			return ItemStack.EMPTY;
 
 		Predicate<ItemStack> test = getFilterTest(filter);
-		ItemStack simulatedItems = ItemHelper.extract(inventory, test, mode, amount, true);
-		if (shouldSimulate || simulatedItems.isEmpty())
-			return simulatedItems;
-		return ItemHelper.extract(inventory, test, mode, amount, false);
+		return ItemHelper.extract(inventory, test, mode, amount, shouldSimulate);
 	}
 
 	public ItemStack insert(ItemStack stack) {

--- a/src/main/java/com/simibubi/create/foundation/item/ItemHelper.java
+++ b/src/main/java/com/simibubi/create/foundation/item/ItemHelper.java
@@ -194,9 +194,11 @@ public class ItemHelper {
 			extracting = ItemStack.EMPTY;
 
 			for (int slot = 0; slot < inv.getSlots(); slot++) {
+				ItemStack slotStack = inv.getStackInSlot(slot);
+				if (slotStack.isEmpty())
+					continue;
 				int amountToExtractFromThisSlot =
-					Math.min(maxExtractionCount - extracting.getCount(), inv.getStackInSlot(slot)
-						.getMaxStackSize());
+					Math.min(maxExtractionCount - extracting.getCount(), slotStack.getMaxStackSize());
 				ItemStack stack = inv.extractItem(slot, amountToExtractFromThisSlot, true);
 
 				if (stack.isEmpty())


### PR DESCRIPTION
fixes: #9248

- Removed redundant simulated extraction in InvManipulationBehaviour.java
- Optimized AABB creation in FunnelBlockEntity.java to only when necessary.
- Implemented a lookup table for MountedItemStorageWrapper instead of an O(n) linear scan.
- Applies faster continue statement in ItemHelper.java to skip over empty slots

### Improvements
The two full-sized vaults were empty in the following examples. The optimization also works exceptionally well while extracting items.
**Before**
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/28d5b7a2-81a0-4327-9aab-0aad3a0fd6d4" />
**Spark report:**
<img width="1854" height="284" alt="image" src="https://github.com/user-attachments/assets/de1ee351-5dc3-409a-8eca-49865a30aec0" />
[Download link](https://www.dropbox.com/scl/fi/zg3jveft8x6dll5g6pliz/optimized.sparkprofile?rlkey=0omyeh2lm7nwj5k3xsjpdo028&e=1&st=i744xj99&dl=1)


**After**
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0d5cee60-9074-418f-b114-6f8464285fad" />
**Spark report:**
<img width="1830" height="211" alt="image" src="https://github.com/user-attachments/assets/0f6fd1e4-1ff4-4858-990a-3c3247a4a097" />
[Download link](https://www.dropbox.com/scl/fi/hoxgq20h9hz4ftsxi28y3/unoptimized.sparkprofile?rlkey=ky2ploe81rkv817wzn6hgsuyu&st=dnrqe4gc&dl=1)
