### PR TITLE
Config option to translate tags in attribute filter

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/item/filter/attribute/attributes/InTagAttribute.java
+++ b/src/main/java/com/simibubi/create/content/logistics/item/filter/attribute/attributes/InTagAttribute.java
@@ -9,9 +9,11 @@ import com.mojang.serialization.MapCodec;
 import com.simibubi.create.content.logistics.item.filter.attribute.AllItemAttributeTypes;
 import com.simibubi.create.content.logistics.item.filter.attribute.ItemAttribute;
 import com.simibubi.create.content.logistics.item.filter.attribute.ItemAttributeType;
+import com.simibubi.create.infrastructure.config.AllConfigs;
 
 import io.netty.buffer.ByteBuf;
 import net.createmod.catnip.codecs.stream.CatnipStreamCodecBuilders;
+import net.minecraft.client.resources.language.I18n;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
@@ -41,7 +43,13 @@ public record InTagAttribute(TagKey<Item> tag) implements ItemAttribute {
 
 	@Override
 	public Object[] getTranslationParameters() {
-		return new Object[]{"#" + tag.location()};
+		String fallback = "#" + tag.location();
+		if (AllConfigs.client().translateTags.get()) {
+			String tagKey = "tag.item." + tag.location().getNamespace() + "." + tag.location().getPath().replace('/', '.');
+			if (I18n.exists(tagKey))
+				return new Object[] { "'" + I18n.get(tagKey) + "'" };
+		}
+		return new Object[] { fallback };
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/infrastructure/config/CClient.java
+++ b/src/main/java/com/simibubi/create/infrastructure/config/CClient.java
@@ -34,6 +34,8 @@ public class CClient extends ConfigBase {
 		Comments.ignoreFabulousWarning);
 	public final ConfigBool rotateWhenSeated = b(true, "rotateWhenSeated",
 		Comments.rotatewhenSeated);
+	public final ConfigBool translateTags = b(false, "translateTags",
+		Comments.translateTags);
 
 	// custom fluid fog
 	public final ConfigGroup fluidFogSettings = group(1, "fluidFogSettings", Comments.fluidFogSettings);
@@ -122,6 +124,7 @@ public class CClient extends ConfigBase {
 		};
 		static String ignoreFabulousWarning = "Setting this to true will prevent Create from sending you a warning when playing with Fabulous graphics enabled";
 		static String rotatewhenSeated = "Disable to prevent being rotated while seated on a Moving Contraption";
+		static String translateTags = "Translate tags in attribute filters when possible";
 		static String overlay = "Settings for the Goggle Overlay";
 		static String overlayOffset = "Offset the overlay from goggle- and hover- information by this many pixels on the respective axis; Use /create overlay";
 		static String overlayCustomColor = "Enable this to use your custom colors for the Goggle- and Hover- Overlay";


### PR DESCRIPTION
PR adds a config option (disabled by default) to translate tags in attribute filters. If a tag does not have a translation, default to the usual `#mod:tag_name`

In the below example, `#forge:ingots/zinc` and `#create:create_ingots` have English translations so they are translated. The other tags do not have translations so they are left unchanged.

Current case:
<img width="675" height="219" alt="image" src="https://github.com/user-attachments/assets/79d2eb05-351e-404a-9918-cfb25c941d43" />

With translate tags config option enabled:
<img width="642" height="221" alt="image" src="https://github.com/user-attachments/assets/a621d9fa-3b6b-4721-a732-bdb4d4217fab" />

Also shows in the item description:
<img width="371" height="134" alt="image" src="https://github.com/user-attachments/assets/3577bc75-5a40-414b-8341-a7201f5adf07" />
