### PR TITLE
Fix attribute filter insert

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/filter/AttributeFilterMenu.java
+++ b/src/main/java/com/simibubi/create/content/logistics/filter/AttributeFilterMenu.java
@@ -112,7 +112,8 @@ public class AttributeFilterMenu extends AbstractFilterMenu {
 			return ItemStack.EMPTY;
 		}
 		if (index < 36) {
-			ItemStack stackToInsert = playerInventory.getItem(index);
+			Slot slot = this.slots.get(index);
+			ItemStack stackToInsert = slot.getItem();
 			ItemStack copy = stackToInsert.copy();
 			copy.setCount(1);
 			ghostInventory.setStackInSlot(0, copy);


### PR DESCRIPTION
Related #9724 
Before stackToInsert was getting item from inventory. Now stackToInsert gets item from slot.

After Change:

https://github.com/user-attachments/assets/cd6e2e5c-6a0b-4a9f-b6e4-b8862d7cc505



