### PR TITLE
Added registry / accessible API for adding new casing types to the belts

### DIFF
--- a/src/main/java/com/simibubi/create/AllBlocks.java
+++ b/src/main/java/com/simibubi/create/AllBlocks.java
@@ -111,6 +111,7 @@ import com.simibubi.create.content.fluids.tank.FluidTankGenerator;
 import com.simibubi.create.content.fluids.tank.FluidTankItem;
 import com.simibubi.create.content.fluids.tank.FluidTankModel;
 import com.simibubi.create.content.fluids.tank.FluidTankMovementBehavior;
+import com.simibubi.create.content.kinetics.belt.AllBeltCasingTypes;
 import com.simibubi.create.content.kinetics.belt.BeltBlock;
 import com.simibubi.create.content.kinetics.belt.BeltGenerator;
 import com.simibubi.create.content.kinetics.belt.BeltModel;
@@ -1777,7 +1778,7 @@ public class AllBlocks {
 	public static final BlockEntry<BeltTunnelBlock> ANDESITE_TUNNEL =
 		REGISTRATE.block("andesite_tunnel", BeltTunnelBlock::new)
 			.properties(p -> p.mapColor(MapColor.STONE))
-			.transform(BuilderTransformers.beltTunnel("andesite", ResourceLocation.withDefaultNamespace("block/polished_andesite")))
+			.transform(BuilderTransformers.beltTunnel("andesite", ResourceLocation.withDefaultNamespace("block/polished_andesite"), () -> AllBeltCasingTypes.ANDESITE))
 			.transform(displaySource(AllDisplaySources.ACCUMULATE_ITEMS))
 			.transform(displaySource(AllDisplaySources.ITEM_THROUGHPUT))
 			.register();
@@ -1785,7 +1786,7 @@ public class AllBlocks {
 	public static final BlockEntry<BrassTunnelBlock> BRASS_TUNNEL =
 		REGISTRATE.block("brass_tunnel", BrassTunnelBlock::new)
 			.properties(p -> p.mapColor(MapColor.TERRACOTTA_YELLOW))
-			.transform(BuilderTransformers.beltTunnel("brass", Create.asResource("block/brass_block")))
+			.transform(BuilderTransformers.beltTunnel("brass", Create.asResource("block/brass_block"), () ->  AllBeltCasingTypes.BRASS))
 			.transform(displaySource(AllDisplaySources.ACCUMULATE_ITEMS))
 			.transform(displaySource(AllDisplaySources.ITEM_THROUGHPUT))
 			.onRegister(connectedTextures(BrassTunnelCTBehaviour::new))

--- a/src/main/java/com/simibubi/create/Create.java
+++ b/src/main/java/com/simibubi/create/Create.java
@@ -2,6 +2,8 @@ package com.simibubi.create;
 
 import java.util.Random;
 
+import com.simibubi.create.content.kinetics.belt.AllBeltCasingTypes;
+
 import org.slf4j.Logger;
 
 import com.google.gson.Gson;
@@ -195,6 +197,7 @@ public class Create {
 		AllPotatoProjectileRenderModes.init();
 		AllPotatoProjectileEntityHitActions.init();
 		AllPotatoProjectileBlockHitActions.init();
+		AllBeltCasingTypes.init();
 
 		if (event.getRegistry() == BuiltInRegistries.TRIGGER_TYPES) {
 			AllAdvancements.register();

--- a/src/main/java/com/simibubi/create/api/registry/CreateBuiltInRegistries.java
+++ b/src/main/java/com/simibubi/create/api/registry/CreateBuiltInRegistries.java
@@ -1,5 +1,7 @@
 package com.simibubi.create.api.registry;
 
+import com.simibubi.create.content.kinetics.belt.BeltCasingType;
+
 import org.jetbrains.annotations.ApiStatus.Internal;
 
 import com.mojang.serialization.MapCodec;
@@ -43,6 +45,7 @@ public class CreateBuiltInRegistries {
 	public static final Registry<MapCodec<? extends PotatoProjectileRenderMode>> POTATO_PROJECTILE_RENDER_MODE = simple(CreateRegistries.POTATO_PROJECTILE_RENDER_MODE);
 	public static final Registry<MapCodec<? extends PotatoProjectileEntityHitAction>> POTATO_PROJECTILE_ENTITY_HIT_ACTION = simple(CreateRegistries.POTATO_PROJECTILE_ENTITY_HIT_ACTION);
 	public static final Registry<MapCodec<? extends PotatoProjectileBlockHitAction>> POTATO_PROJECTILE_BLOCK_HIT_ACTION = simple(CreateRegistries.POTATO_PROJECTILE_BLOCK_HIT_ACTION);
+	public static final Registry<BeltCasingType> BELT_CASING_TYPE = withIntrusiveHolders(CreateRegistries.BELT_CASING_TYPE);
 
 	private static <T> Registry<T> simple(ResourceKey<Registry<T>> key) {
 		return register(key, false, () -> {});

--- a/src/main/java/com/simibubi/create/api/registry/CreateRegistries.java
+++ b/src/main/java/com/simibubi/create/api/registry/CreateRegistries.java
@@ -1,6 +1,9 @@
 package com.simibubi.create.api.registry;
 
 import com.mojang.serialization.MapCodec;
+import com.simibubi.create.content.kinetics.belt.BeltCasingType;
+import com.simibubi.create.content.logistics.packagePort.PackagePortTargetType;
+
 import com.simibubi.create.Create;
 import com.simibubi.create.api.behaviour.display.DisplaySource;
 import com.simibubi.create.api.behaviour.display.DisplayTarget;
@@ -38,6 +41,7 @@ public class CreateRegistries {
 	public static final ResourceKey<Registry<MapCodec<? extends PotatoProjectileRenderMode>>> POTATO_PROJECTILE_RENDER_MODE = key("potato_projectile/render_mode");
 	public static final ResourceKey<Registry<MapCodec<? extends PotatoProjectileEntityHitAction>>> POTATO_PROJECTILE_ENTITY_HIT_ACTION = key("potato_projectile/entity_hit_action");
 	public static final ResourceKey<Registry<MapCodec<? extends PotatoProjectileBlockHitAction>>> POTATO_PROJECTILE_BLOCK_HIT_ACTION = key("potato_projectile/block_hit_action");
+	public static final ResourceKey<Registry<BeltCasingType>> BELT_CASING_TYPE = key("belt_casing_type");
 
 	private static <T> ResourceKey<Registry<T>> key(String name) {
 		return ResourceKey.createRegistryKey(Create.asResource(name));

--- a/src/main/java/com/simibubi/create/content/kinetics/belt/AllBeltCasingTypes.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/AllBeltCasingTypes.java
@@ -1,0 +1,71 @@
+package com.simibubi.create.content.kinetics.belt;
+
+import com.simibubi.create.AllBlocks;
+import com.simibubi.create.AllPartialModels;
+import com.simibubi.create.AllSpriteShifts;
+import com.simibubi.create.Create;
+import com.simibubi.create.api.registry.CreateBuiltInRegistries;
+
+import net.minecraft.core.Holder;
+
+import net.minecraft.core.Registry;
+
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.registries.DeferredRegister;
+
+import org.jetbrains.annotations.ApiStatus.Internal;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Supplier;
+
+public class AllBeltCasingTypes {
+
+	public static final BeltCasingType ANDESITE = register("andesite", new BeltCasingType(AllBlocks.ANDESITE_CASING,
+		() -> new BeltCasingRenderInfo(
+			AllPartialModels.ANDESITE_BELT_COVER_X,
+			AllPartialModels.ANDESITE_BELT_COVER_Z,
+			AllSpriteShifts.ANDESIDE_BELT_CASING
+		)));
+
+	public static final BeltCasingType BRASS = register("brass", new BeltCasingType(AllBlocks.BRASS_CASING,
+		() -> new BeltCasingRenderInfo(
+			AllPartialModels.BRASS_BELT_COVER_X,
+			AllPartialModels.BRASS_BELT_COVER_Z,
+			null
+		)));
+
+	private static BeltCasingType register(String name, BeltCasingType beltCasingType) {
+		return Registry.register(CreateBuiltInRegistries.BELT_CASING_TYPE, Create.asResource(name), beltCasingType);
+	}
+
+	@Internal
+	public static void init() {
+	}
+
+	/**
+	 * Migrations for legacy CasingType enum, since new system uses resource keys.
+	 * */
+	public enum LegacyCasingType {
+		NONE(null), ANDESITE(() -> AllBeltCasingTypes.ANDESITE), BRASS(() -> AllBeltCasingTypes.BRASS);
+
+		@Nullable
+		private final Supplier<BeltCasingType> casingType;
+
+		LegacyCasingType(@Nullable Supplier<BeltCasingType> casingType) {
+			this.casingType = casingType;
+		}
+
+		public BeltCasingType getCasingType() {
+			return casingType == null ? null : casingType.get();
+		}
+
+		public static @Nullable BeltCasingType fromId(String id) {
+			try {
+				return LegacyCasingType.valueOf(id.toUpperCase()).getCasingType();
+			} catch (IllegalArgumentException ignored) {
+				return null;
+			}
+		}
+	}
+
+}

--- a/src/main/java/com/simibubi/create/content/kinetics/belt/BeltBlock.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/BeltBlock.java
@@ -6,6 +6,12 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
+import com.simibubi.create.api.registry.CreateBuiltInRegistries;
+
+import net.minecraft.core.Holder;
+
+import net.minecraft.core.Holder.Reference;
+
 import org.apache.commons.lang3.mutable.MutableBoolean;
 
 import com.simibubi.create.AllBlockEntityTypes;
@@ -18,7 +24,6 @@ import com.simibubi.create.content.equipment.armor.DivingBootsItem;
 import com.simibubi.create.content.fluids.transfer.GenericItemEmptying;
 import com.simibubi.create.content.kinetics.base.HorizontalKineticBlock;
 import com.simibubi.create.content.kinetics.base.KineticBlockEntity;
-import com.simibubi.create.content.kinetics.belt.BeltBlockEntity.CasingType;
 import com.simibubi.create.content.kinetics.belt.BeltSlicer.Feedback;
 import com.simibubi.create.content.kinetics.belt.behaviour.TransportedItemStackHandlerBehaviour.TransportedResult;
 import com.simibubi.create.content.kinetics.belt.transport.BeltMovementHandler.TransportedEntityInfo;
@@ -311,23 +316,17 @@ public class BeltBlock extends HorizontalKineticBlock
 			return ItemInteractionResult.SUCCESS;
 		}
 
-		if (AllBlocks.BRASS_CASING.isIn(stack)) {
-			withBlockEntityDo(level, pos, be -> be.setCasingType(CasingType.BRASS));
+		BeltCasingType casing = CreateBuiltInRegistries.BELT_CASING_TYPE.holders()
+			.filter(type -> type.value().getCasingBlockItem().equals(stack.getItem()))
+			.findFirst()
+			.map(Reference::value)
+			.orElse(null);
+
+		if (casing != null) {
+			withBlockEntityDo(level, pos, be -> be.setCasingType(casing));
 			updateCoverProperty(level, pos, level.getBlockState(pos));
 
-			SoundType soundType = AllBlocks.BRASS_CASING.getDefaultState()
-				.getSoundType(level, pos, player);
-			level.playSound(null, pos, soundType.getPlaceSound(), SoundSource.BLOCKS,
-				(soundType.getVolume() + 1.0F) / 2.0F, soundType.getPitch() * 0.8F);
-
-			return ItemInteractionResult.SUCCESS;
-		}
-
-		if (AllBlocks.ANDESITE_CASING.isIn(stack)) {
-			withBlockEntityDo(level, pos, be -> be.setCasingType(CasingType.ANDESITE));
-			updateCoverProperty(level, pos, level.getBlockState(pos));
-
-			SoundType soundType = AllBlocks.ANDESITE_CASING.getDefaultState()
+			SoundType soundType = casing.getCasingBlockItem().getBlock().defaultBlockState()
 				.getSoundType(level, pos, player);
 			level.playSound(null, pos, soundType.getPlaceSound(), SoundSource.BLOCKS,
 				(soundType.getVolume() + 1.0F) / 2.0F, soundType.getPitch() * 0.8F);
@@ -347,7 +346,7 @@ public class BeltBlock extends HorizontalKineticBlock
 		if (state.getValue(CASING)) {
 			if (world.isClientSide)
 				return InteractionResult.SUCCESS;
-			withBlockEntityDo(world, pos, be -> be.setCasingType(CasingType.NONE));
+			withBlockEntityDo(world, pos, be -> be.setCasingType(null));
 			return InteractionResult.SUCCESS;
 		}
 

--- a/src/main/java/com/simibubi/create/content/kinetics/belt/BeltBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/BeltBlockEntity.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
 import com.simibubi.create.AllBlockEntityTypes;
@@ -36,6 +37,7 @@ import net.minecraft.core.Direction.Axis;
 import net.minecraft.core.Holder;
 import net.minecraft.core.Holder.Reference;
 import net.minecraft.core.HolderLookup;
+import net.minecraft.core.HolderLookup.Provider;
 import net.minecraft.core.Vec3i;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtUtils;
@@ -224,6 +226,12 @@ public class BeltBlockEntity extends KineticBlockEntity implements Clearable {
 	}
 
 	@Override
+	public void writeSafe(CompoundTag tag, Provider registries) {
+		super.writeSafe(tag, registries);
+		BeltCasingType.write(tag, "Casing", casing);
+	}
+
+	@Override
 	protected void read(CompoundTag compound, HolderLookup.Provider registries, boolean clientPacket) {
 		super.read(compound, registries, clientPacket);
 
@@ -247,6 +255,7 @@ public class BeltBlockEntity extends KineticBlockEntity implements Clearable {
 		BeltCasingType casingBefore = casing;
 		boolean coverBefore = covered;
 		casing = BeltCasingType.read(compound, "Casing");
+		System.out.println("Read casing " + casing + " from string " + compound.getString("Casing"));
 		covered = compound.getBoolean("Covered");
 
 		if (!clientPacket)
@@ -544,12 +553,11 @@ public class BeltBlockEntity extends KineticBlockEntity implements Clearable {
 	}
 
 	@Override
-	public @NotNull ModelData getModelData() {
+	public ModelData getModelData() {
 		Builder builder = ModelData.builder();
-		if (casing != null)
-			builder.with(BeltModel.CASING_PROPERTY, casing);
 		return builder
 			.with(BeltModel.COVER_PROPERTY, covered)
+			.with(BeltModel.CASING_PROPERTY, Optional.ofNullable(casing == null ? null : casing.getModelInfo()))
 			.build();
 	}
 

--- a/src/main/java/com/simibubi/create/content/kinetics/belt/BeltBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/BeltBlockEntity.java
@@ -33,6 +33,8 @@ import net.createmod.catnip.nbt.NBTHelper;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Direction.Axis;
+import net.minecraft.core.Holder;
+import net.minecraft.core.Holder.Reference;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.Vec3i;
 import net.minecraft.nbt.CompoundTag;
@@ -42,6 +44,7 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.LevelEvent;
 import net.minecraft.world.level.block.LevelEvent;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
@@ -53,7 +56,11 @@ import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
 import net.neoforged.neoforge.client.model.data.ModelData;
+import net.neoforged.neoforge.client.model.data.ModelData.Builder;
 import net.neoforged.neoforge.items.IItemHandler;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class BeltBlockEntity extends KineticBlockEntity implements Clearable {
 	public Map<Entity, TransportedEntityInfo> passengers;
@@ -61,7 +68,7 @@ public class BeltBlockEntity extends KineticBlockEntity implements Clearable {
 	public int beltLength;
 	public int index;
 	public Direction lastInsert;
-	public CasingType casing;
+	public @Nullable BeltCasingType casing;
 	public boolean covered;
 
 	protected BlockPos controller;
@@ -71,15 +78,11 @@ public class BeltBlockEntity extends KineticBlockEntity implements Clearable {
 
 	public CompoundTag trackerUpdateTag;
 
-	public static enum CasingType {
-		NONE, ANDESITE, BRASS;
-	}
-
 	public BeltBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
 		super(type, pos, state);
 		controller = BlockPos.ZERO;
 		itemHandler = null;
-		casing = CasingType.NONE;
+		casing = null;
 		color = Optional.empty();
 	}
 
@@ -210,7 +213,7 @@ public class BeltBlockEntity extends KineticBlockEntity implements Clearable {
 		compound.putBoolean("IsController", isController());
 		compound.putInt("Length", beltLength);
 		compound.putInt("Index", index);
-		NBTHelper.writeEnum(compound, "Casing", casing);
+		BeltCasingType.write(compound, "Casing", casing);
 		compound.putBoolean("Covered", covered);
 
 		color.ifPresent(dyeColor -> NBTHelper.writeEnum(compound, "Dye", dyeColor));
@@ -241,9 +244,9 @@ public class BeltBlockEntity extends KineticBlockEntity implements Clearable {
 		if (isController())
 			getInventory().read(compound.getCompound("Inventory"), registries);
 
-		CasingType casingBefore = casing;
+		BeltCasingType casingBefore = casing;
 		boolean coverBefore = covered;
-		casing = NBTHelper.readEnum(compound, "Casing", CasingType.class);
+		casing = BeltCasingType.read(compound, "Casing");
 		covered = compound.getBoolean("Covered");
 
 		if (!clientPacket)
@@ -419,12 +422,12 @@ public class BeltBlockEntity extends KineticBlockEntity implements Clearable {
 		return BeltHelper.getVectorForOffset(controllerBE, transported.beltPosition);
 	}
 
-	public void setCasingType(CasingType type) {
+	public void setCasingType(BeltCasingType type) {
 		if (casing == type)
 			return;
 
 		BlockState blockState = getBlockState();
-		boolean shouldBlockHaveCasing = type != CasingType.NONE;
+		boolean shouldBlockHaveCasing = type != null;
 
 		if (level.isClientSide) {
 			casing = type;
@@ -434,10 +437,9 @@ public class BeltBlockEntity extends KineticBlockEntity implements Clearable {
 			return;
 		}
 
-		if (casing != CasingType.NONE)
+		if (casing != null)
 			level.levelEvent(LevelEvent.PARTICLES_DESTROY_BLOCK, worldPosition,
-				Block.getId(casing == CasingType.ANDESITE ? AllBlocks.ANDESITE_CASING.getDefaultState()
-					: AllBlocks.BRASS_CASING.getDefaultState()));
+				Block.getId(casing.getCasingBlockItem().getBlock().defaultBlockState()));
 		if (blockState.getValue(BeltBlock.CASING) != shouldBlockHaveCasing)
 			KineticBlockEntity.switchToBlockState(level, worldPosition,
 				blockState.setValue(BeltBlock.CASING, shouldBlockHaveCasing));
@@ -542,9 +544,11 @@ public class BeltBlockEntity extends KineticBlockEntity implements Clearable {
 	}
 
 	@Override
-	public ModelData getModelData() {
-		return ModelData.builder()
-			.with(BeltModel.CASING_PROPERTY, casing)
+	public @NotNull ModelData getModelData() {
+		Builder builder = ModelData.builder();
+		if (casing != null)
+			builder.with(BeltModel.CASING_PROPERTY, casing);
+		return builder
 			.with(BeltModel.COVER_PROPERTY, covered)
 			.build();
 	}

--- a/src/main/java/com/simibubi/create/content/kinetics/belt/BeltBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/BeltBlockEntity.java
@@ -555,9 +555,10 @@ public class BeltBlockEntity extends KineticBlockEntity implements Clearable {
 	@Override
 	public ModelData getModelData() {
 		Builder builder = ModelData.builder();
+		if (casing != null)
+			builder.with(BeltModel.CASING_PROPERTY, casing.getModelInfo());
 		return builder
 			.with(BeltModel.COVER_PROPERTY, covered)
-			.with(BeltModel.CASING_PROPERTY, Optional.ofNullable(casing == null ? null : casing.getModelInfo()))
 			.build();
 	}
 

--- a/src/main/java/com/simibubi/create/content/kinetics/belt/BeltBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/BeltBlockEntity.java
@@ -553,7 +553,7 @@ public class BeltBlockEntity extends KineticBlockEntity implements Clearable {
 	}
 
 	@Override
-	public ModelData getModelData() {
+	public @NotNull ModelData getModelData() {
 		Builder builder = ModelData.builder();
 		if (casing != null)
 			builder.with(BeltModel.CASING_PROPERTY, casing.getModelInfo());

--- a/src/main/java/com/simibubi/create/content/kinetics/belt/BeltBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/BeltBlockEntity.java
@@ -255,7 +255,6 @@ public class BeltBlockEntity extends KineticBlockEntity implements Clearable {
 		BeltCasingType casingBefore = casing;
 		boolean coverBefore = covered;
 		casing = BeltCasingType.read(compound, "Casing");
-		System.out.println("Read casing " + casing + " from string " + compound.getString("Casing"));
 		covered = compound.getBoolean("Covered");
 
 		if (!clientPacket)

--- a/src/main/java/com/simibubi/create/content/kinetics/belt/BeltCasingRenderInfo.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/BeltCasingRenderInfo.java
@@ -1,0 +1,16 @@
+package com.simibubi.create.content.kinetics.belt;
+
+import dev.engine_room.flywheel.lib.model.baked.PartialModel;
+import net.createmod.catnip.render.SpriteShiftEntry;
+
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Represents the client rendering information for belt casings, including cover models and texture shifts. (null sprite shift results in brass textures)
+ */
+public record BeltCasingRenderInfo(
+	PartialModel coverModelX,
+	PartialModel coverModelZ,
+	@Nullable SpriteShiftEntry spriteShift
+) {
+}

--- a/src/main/java/com/simibubi/create/content/kinetics/belt/BeltCasingType.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/BeltCasingType.java
@@ -55,7 +55,7 @@ public class BeltCasingType {
 	public static void write(CompoundTag tag, String key, @Nullable BeltCasingType casingType) {
 		if (casingType == null)
 			return;
-		NBTHelper.writeResourceLocation(tag, key, casingType.holder.key().location());
+		tag.putString(key, casingType.holder.key().location().toString());
 	}
 
 	public BlockItem getCasingBlockItem() {

--- a/src/main/java/com/simibubi/create/content/kinetics/belt/BeltCasingType.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/BeltCasingType.java
@@ -1,0 +1,69 @@
+package com.simibubi.create.content.kinetics.belt;
+
+import com.simibubi.create.api.registry.CreateBuiltInRegistries;
+import com.simibubi.create.api.registry.CreateRegistries;
+import com.simibubi.create.content.kinetics.belt.AllBeltCasingTypes.LegacyCasingType;
+import com.tterrag.registrate.util.entry.BlockEntry;
+
+import net.createmod.catnip.nbt.NBTHelper;
+import net.minecraft.core.Holder;
+import net.minecraft.core.Holder.Reference;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.BlockItem;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Supplier;
+
+public class BeltCasingType {
+
+	public final Holder.Reference<BeltCasingType> holder = CreateBuiltInRegistries.BELT_CASING_TYPE.createIntrusiveHolder(this);
+
+	private final Supplier<BlockItem> itemSupplier;
+	private final Supplier<BeltCasingRenderInfo> renderInfoSupplier;
+
+	public BeltCasingType(BlockEntry<?> casingBlockSupplier, Supplier<BeltCasingRenderInfo> renderInfoSupplier) {
+		this(() -> (BlockItem) casingBlockSupplier.get().asItem(), renderInfoSupplier);
+	}
+
+	public BeltCasingType(Supplier<BlockItem> casingItemSupplier, Supplier<BeltCasingRenderInfo> renderInfoSupplier) {
+		this.itemSupplier = casingItemSupplier;
+		this.renderInfoSupplier = renderInfoSupplier;
+	}
+
+	/**
+	 * Read a BeltCasingType from NBT tag in a way that is compatible with legacy enum IDs.
+	 * */
+	public static @Nullable BeltCasingType read(CompoundTag tag, String key) {
+		if (!tag.contains(key))
+			return null;
+		String id = tag.getString(key);
+
+		BeltCasingType convertedLegacy = LegacyCasingType.fromId(id);
+		if (convertedLegacy != null)
+			return convertedLegacy;
+
+		ResourceKey<BeltCasingType> resourceKey = ResourceKey.create(CreateRegistries.BELT_CASING_TYPE, ResourceLocation.parse(id.toLowerCase()));
+
+		return CreateBuiltInRegistries.BELT_CASING_TYPE.getHolder(resourceKey)
+			.map(Reference::value)
+			.orElse(null);
+	}
+
+	public static void write(CompoundTag tag, String key, @Nullable BeltCasingType casingType) {
+		if (casingType == null)
+			return;
+		NBTHelper.writeResourceLocation(tag, key, casingType.holder.key().location());
+	}
+
+	public BlockItem getCasingBlockItem() {
+		return itemSupplier.get();
+	}
+
+	public BeltCasingRenderInfo getModelInfo() {
+		return renderInfoSupplier.get();
+	}
+
+}

--- a/src/main/java/com/simibubi/create/content/kinetics/belt/BeltModel.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/BeltModel.java
@@ -3,9 +3,7 @@ package com.simibubi.create.content.kinetics.belt;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.simibubi.create.AllPartialModels;
 import com.simibubi.create.AllSpriteShifts;
-import com.simibubi.create.content.kinetics.belt.BeltBlockEntity.CasingType;
 import com.simibubi.create.foundation.model.BakedQuadHelper;
 
 import net.createmod.catnip.render.SpriteShiftEntry;
@@ -21,9 +19,11 @@ import net.neoforged.neoforge.client.model.BakedModelWrapper;
 import net.neoforged.neoforge.client.model.data.ModelData;
 import net.neoforged.neoforge.client.model.data.ModelProperty;
 
+import org.jetbrains.annotations.NotNull;
+
 public class BeltModel extends BakedModelWrapper<BakedModel> {
 
-	public static final ModelProperty<CasingType> CASING_PROPERTY = new ModelProperty<>();
+	public static final ModelProperty<BeltCasingType> CASING_PROPERTY = new ModelProperty<>();
 	public static final ModelProperty<Boolean> COVER_PROPERTY = new ModelProperty<>();
 
 	private static final SpriteShiftEntry SPRITE_SHIFT = AllSpriteShifts.ANDESIDE_BELT_CASING;
@@ -33,13 +33,17 @@ public class BeltModel extends BakedModelWrapper<BakedModel> {
 	}
 
 	@Override
-	public TextureAtlasSprite getParticleIcon(ModelData data) {
+	public @NotNull TextureAtlasSprite getParticleIcon(ModelData data) {
 		if (!data.has(CASING_PROPERTY))
 			return super.getParticleIcon(data);
-		CasingType type = data.get(CASING_PROPERTY);
-		if (type == CasingType.NONE || type == CasingType.BRASS)
+
+		BeltCasingType type = data.get(CASING_PROPERTY);
+		if (type == null)
 			return super.getParticleIcon(data);
-		return AllSpriteShifts.ANDESITE_CASING.getOriginal();
+
+		BeltCasingRenderInfo modelInfo = type.getModelInfo();
+		return modelInfo.spriteShift() == null ? super.getParticleIcon(data) :
+			modelInfo.spriteShift().getTarget();
 	}
 
 	@Override
@@ -49,10 +53,15 @@ public class BeltModel extends BakedModelWrapper<BakedModel> {
 			return quads;
 
 		boolean cover = extraData.get(COVER_PROPERTY);
-		CasingType type = extraData.get(CASING_PROPERTY);
-		boolean brassCasing = type == CasingType.BRASS;
+		BeltCasingType type = extraData.get(CASING_PROPERTY);
 
-		if (type == CasingType.NONE || brassCasing && !cover)
+		if (type == null)
+			return quads;
+
+		BeltCasingRenderInfo modelInfo = type.getModelInfo();
+		boolean noSpriteShift = modelInfo.spriteShift() == null;
+
+		if (noSpriteShift && !cover)
 			return quads;
 
 		quads = new ArrayList<>(quads);
@@ -60,13 +69,11 @@ public class BeltModel extends BakedModelWrapper<BakedModel> {
 		if (cover) {
 			boolean alongX = state.getValue(BeltBlock.HORIZONTAL_FACING)
 				.getAxis() == Axis.X;
-			BakedModel coverModel =
-				(brassCasing ? alongX ? AllPartialModels.BRASS_BELT_COVER_X : AllPartialModels.BRASS_BELT_COVER_Z
-					: alongX ? AllPartialModels.ANDESITE_BELT_COVER_X : AllPartialModels.ANDESITE_BELT_COVER_Z).get();
+			BakedModel coverModel = (alongX ? modelInfo.coverModelX() : modelInfo.coverModelZ()).get();
 			quads.addAll(coverModel.getQuads(state, side, rand, extraData, renderType));
 		}
 
-		if (brassCasing)
+		if (noSpriteShift)
 			return quads;
 
 		for (int i = 0; i < quads.size(); i++) {

--- a/src/main/java/com/simibubi/create/content/kinetics/belt/BeltModel.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/BeltModel.java
@@ -25,10 +25,8 @@ import org.jetbrains.annotations.Nullable;
 
 public class BeltModel extends BakedModelWrapper<BakedModel> {
 
-	public static final ModelProperty<Optional<BeltCasingRenderInfo>> CASING_PROPERTY = new ModelProperty<>();
+	public static final ModelProperty<BeltCasingRenderInfo> CASING_PROPERTY = new ModelProperty<>();
 	public static final ModelProperty<Boolean> COVER_PROPERTY = new ModelProperty<>();
-
-	private static final SpriteShiftEntry SPRITE_SHIFT = AllSpriteShifts.ANDESIDE_BELT_CASING;
 
 	public BeltModel(BakedModel template) {
 		super(template);
@@ -39,11 +37,10 @@ public class BeltModel extends BakedModelWrapper<BakedModel> {
 		if (!data.has(CASING_PROPERTY))
 			return super.getParticleIcon(data);
 
-		Optional<BeltCasingRenderInfo> type = data.get(CASING_PROPERTY);
-		if (type == null || type.isEmpty())
+		BeltCasingRenderInfo modelInfo = data.get(CASING_PROPERTY);
+		if (modelInfo == null)
 			return super.getParticleIcon(data);
 
-		BeltCasingRenderInfo modelInfo = type.get();
 		return modelInfo.spriteShift() == null ? super.getParticleIcon(data) :
 			modelInfo.spriteShift().getTarget();
 	}
@@ -55,12 +52,11 @@ public class BeltModel extends BakedModelWrapper<BakedModel> {
 			return quads;
 
 		boolean cover = extraData.get(COVER_PROPERTY);
-		@Nullable Optional<BeltCasingRenderInfo> type = extraData.get(CASING_PROPERTY);
+		@Nullable BeltCasingRenderInfo modelInfo = extraData.get(CASING_PROPERTY);
 
-		if (type == null || type.isEmpty())
+		if (modelInfo == null)
 			return quads;
 
-		BeltCasingRenderInfo modelInfo = type.get();
 		boolean noSpriteShift = modelInfo.spriteShift() == null;
 
 		if (noSpriteShift && !cover)
@@ -78,10 +74,12 @@ public class BeltModel extends BakedModelWrapper<BakedModel> {
 		if (noSpriteShift)
 			return quads;
 
+		final SpriteShiftEntry spriteShift = modelInfo.spriteShift();
+
 		for (int i = 0; i < quads.size(); i++) {
 			BakedQuad quad = quads.get(i);
 			TextureAtlasSprite original = quad.getSprite();
-			if (original != SPRITE_SHIFT.getOriginal())
+			if (original != spriteShift.getOriginal())
 				continue;
 
 			BakedQuad newQuad = BakedQuadHelper.clone(quad);
@@ -90,8 +88,8 @@ public class BeltModel extends BakedModelWrapper<BakedModel> {
 			for (int vertex = 0; vertex < 4; vertex++) {
 				float u = BakedQuadHelper.getU(vertexData, vertex);
 				float v = BakedQuadHelper.getV(vertexData, vertex);
-				BakedQuadHelper.setU(vertexData, vertex, SPRITE_SHIFT.getTargetU(u));
-				BakedQuadHelper.setV(vertexData, vertex, SPRITE_SHIFT.getTargetV(v));
+				BakedQuadHelper.setU(vertexData, vertex, spriteShift.getTargetU(u));
+				BakedQuadHelper.setV(vertexData, vertex, spriteShift.getTargetV(v));
 			}
 
 			quads.set(i, newQuad);

--- a/src/main/java/com/simibubi/create/content/kinetics/belt/BeltModel.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/BeltModel.java
@@ -2,6 +2,7 @@ package com.simibubi.create.content.kinetics.belt;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import com.simibubi.create.AllSpriteShifts;
 import com.simibubi.create.foundation.model.BakedQuadHelper;
@@ -20,10 +21,11 @@ import net.neoforged.neoforge.client.model.data.ModelData;
 import net.neoforged.neoforge.client.model.data.ModelProperty;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class BeltModel extends BakedModelWrapper<BakedModel> {
 
-	public static final ModelProperty<BeltCasingType> CASING_PROPERTY = new ModelProperty<>();
+	public static final ModelProperty<Optional<BeltCasingRenderInfo>> CASING_PROPERTY = new ModelProperty<>();
 	public static final ModelProperty<Boolean> COVER_PROPERTY = new ModelProperty<>();
 
 	private static final SpriteShiftEntry SPRITE_SHIFT = AllSpriteShifts.ANDESIDE_BELT_CASING;
@@ -37,11 +39,11 @@ public class BeltModel extends BakedModelWrapper<BakedModel> {
 		if (!data.has(CASING_PROPERTY))
 			return super.getParticleIcon(data);
 
-		BeltCasingType type = data.get(CASING_PROPERTY);
-		if (type == null)
+		Optional<BeltCasingRenderInfo> type = data.get(CASING_PROPERTY);
+		if (type == null || type.isEmpty())
 			return super.getParticleIcon(data);
 
-		BeltCasingRenderInfo modelInfo = type.getModelInfo();
+		BeltCasingRenderInfo modelInfo = type.get();
 		return modelInfo.spriteShift() == null ? super.getParticleIcon(data) :
 			modelInfo.spriteShift().getTarget();
 	}
@@ -53,12 +55,12 @@ public class BeltModel extends BakedModelWrapper<BakedModel> {
 			return quads;
 
 		boolean cover = extraData.get(COVER_PROPERTY);
-		BeltCasingType type = extraData.get(CASING_PROPERTY);
+		@Nullable Optional<BeltCasingRenderInfo> type = extraData.get(CASING_PROPERTY);
 
-		if (type == null)
+		if (type == null || type.isEmpty())
 			return quads;
 
-		BeltCasingRenderInfo modelInfo = type.getModelInfo();
+		BeltCasingRenderInfo modelInfo = type.get();
 		boolean noSpriteShift = modelInfo.spriteShift() == null;
 
 		if (noSpriteShift && !cover)

--- a/src/main/java/com/simibubi/create/content/kinetics/belt/BeltSlicer.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/BeltSlicer.java
@@ -8,7 +8,6 @@ import java.util.Optional;
 import com.simibubi.create.AllBlocks;
 import com.simibubi.create.AllItems;
 import com.simibubi.create.content.kinetics.base.KineticBlockEntity;
-import com.simibubi.create.content.kinetics.belt.BeltBlockEntity.CasingType;
 import com.simibubi.create.content.kinetics.belt.item.BeltConnectorItem;
 import com.simibubi.create.content.kinetics.belt.transport.BeltInventory;
 import com.simibubi.create.content.kinetics.belt.transport.TransportedItemStack;
@@ -93,7 +92,7 @@ public class BeltSlicer {
 			BlockState replacedState = world.getBlockState(next);
 			BeltBlockEntity segmentBE = BeltHelper.getSegmentBE(world, next);
 			KineticBlockEntity.switchToBlockState(world, next, ProperWaterloggedBlock.withWater(world,
-				state.setValue(BeltBlock.CASING, segmentBE != null && segmentBE.casing != CasingType.NONE), next));
+				state.setValue(BeltBlock.CASING, segmentBE != null && segmentBE.casing != null), next));
 			world.setBlock(pos, ProperWaterloggedBlock.withWater(world, Blocks.AIR.defaultBlockState(), pos),
 				Block.UPDATE_ALL | Block.UPDATE_MOVE_BY_PISTON);
 			world.removeBlockEntity(pos);
@@ -350,7 +349,7 @@ public class BeltSlicer {
 					player == null ? SoundSource.BLOCKS : SoundSource.PLAYERS, 0.5F, 1.3F);
 				BeltBlockEntity segmentBE = BeltHelper.getSegmentBE(world, next);
 				KineticBlockEntity.switchToBlockState(world, next,
-					state.setValue(BeltBlock.CASING, segmentBE != null && segmentBE.casing != CasingType.NONE)
+					state.setValue(BeltBlock.CASING, segmentBE != null && segmentBE.casing != null)
 						.setValue(BeltBlock.PART, BeltPart.MIDDLE));
 
 				if (!creative) {

--- a/src/main/java/com/simibubi/create/content/logistics/tunnel/BeltTunnelItem.java
+++ b/src/main/java/com/simibubi/create/content/logistics/tunnel/BeltTunnelItem.java
@@ -1,11 +1,14 @@
 package com.simibubi.create.content.logistics.tunnel;
 
 import com.simibubi.create.AllBlocks;
+import com.simibubi.create.content.kinetics.belt.AllBeltCasingTypes;
 import com.simibubi.create.content.kinetics.belt.BeltBlockEntity;
-import com.simibubi.create.content.kinetics.belt.BeltBlockEntity.CasingType;
+import com.simibubi.create.content.kinetics.belt.BeltCasingType;
 import com.simibubi.create.content.kinetics.belt.BeltHelper;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
+import net.minecraft.core.Holder.Reference;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemStack;
@@ -15,10 +18,15 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.shapes.CollisionContext;
 
+import java.util.function.Supplier;
+
 public class BeltTunnelItem extends BlockItem {
 
-	public BeltTunnelItem(Block p_i48527_1_, Properties p_i48527_2_) {
+	Supplier<BeltCasingType> casingType;
+
+	public BeltTunnelItem(Block p_i48527_1_, Properties p_i48527_2_, Supplier<BeltCasingType> casingType) {
 		super(p_i48527_1_, p_i48527_2_);
+		this.casingType = casingType;
 	}
 
 	@Override
@@ -38,8 +46,8 @@ public class BeltTunnelItem extends BlockItem {
 		boolean flag = super.updateCustomBlockEntityTag(pos, world, p_195943_3_, p_195943_4_, state);
 		if (!world.isClientSide) {
 			BeltBlockEntity belt = BeltHelper.getSegmentBE(world, pos.below());
-			if (belt != null && belt.casing == CasingType.NONE)
-				belt.setCasingType(AllBlocks.ANDESITE_TUNNEL.has(state) ? CasingType.ANDESITE : CasingType.BRASS);
+			if (belt != null && belt.casing == null)
+				belt.setCasingType(casingType.get());
 		}
 		return flag;
 	}

--- a/src/main/java/com/simibubi/create/content/schematics/cannon/LaunchedItem.java
+++ b/src/main/java/com/simibubi/create/content/schematics/cannon/LaunchedItem.java
@@ -142,7 +142,7 @@ public abstract class LaunchedItem {
 
 	public static class ForBelt extends ForBlockState {
 		public int length;
-		public List<BeltCasingType> casings;
+		public BeltCasingType[] casings;
 
 		public ForBelt() {}
 
@@ -151,8 +151,8 @@ public abstract class LaunchedItem {
 			CompoundTag serializeNBT = super.serializeNBT(registries);
 			serializeNBT.putInt("Length", length);
 
-			for (int i = 0; i < casings.size(); i++) {
-				BeltCasingType casing = casings.get(i);
+			for (int i = 0; i < length; i++) {
+				BeltCasingType casing = casings[i];
 				if (casing == null)
 					continue;
 				ResourceKey<BeltCasingType> key = casing.holder.key();
@@ -172,9 +172,9 @@ public abstract class LaunchedItem {
 				casings = Arrays.stream(intArray)
 					.mapToObj(i -> LegacyCasingType.values()[Mth.clamp(i, 0, LegacyCasingType.values().length - 1)])
 					.map(LegacyCasingType::getCasingType)
-					.toList();
+					.toArray(BeltCasingType[]::new);
 			} else {
-				 casings = new ArrayList<>(length);
+				 casings = new BeltCasingType[length];
 				 for (int i = 0; i < length; i++) {
 					 if (!nbt.contains("CasingKey_" + i)) //Null value means no casing
 						 continue;
@@ -184,17 +184,17 @@ public abstract class LaunchedItem {
 					 Optional<Reference<BeltCasingType>> holder = CreateBuiltInRegistries.BELT_CASING_TYPE.getHolder(resourceKey);
 
 					 final int insertIndex = i;
-					 holder.ifPresent(reference -> casings.set(insertIndex, reference.value()));
+					 holder.ifPresent(reference -> casings[insertIndex] = reference.value());
 				 }
 			}
 
 			super.readNBT(nbt, registries, holderGetter);
 		}
 
-		public ForBelt(BlockPos start, BlockPos target, ItemStack stack, BlockState state, List<BeltCasingType> casings) {
+		public ForBelt(BlockPos start, BlockPos target, ItemStack stack, BlockState state, BeltCasingType[] casings) {
 			super(start, target, stack, state, null);
 			this.casings = casings;
-			this.length = casings.size();
+			this.length = casings.length;
 		}
 
 		@Override
@@ -212,12 +212,12 @@ public abstract class LaunchedItem {
 				target.offset(offset.getX() * i, offset.getY() * i, offset.getZ() * i));
 
 			for (int segment = 0; segment < length; segment++) {
-				if (casings.get(segment) == null)
+				if (casings[segment] == null)
 					continue;
 				BlockPos casingTarget =
 					target.offset(offset.getX() * segment, offset.getY() * segment, offset.getZ() * segment);
 				if (world.getBlockEntity(casingTarget) instanceof BeltBlockEntity bbe)
-					bbe.setCasingType(casings.get(segment));
+					bbe.setCasingType(casings[segment]);
 			}
 		}
 

--- a/src/main/java/com/simibubi/create/content/schematics/cannon/LaunchedItem.java
+++ b/src/main/java/com/simibubi/create/content/schematics/cannon/LaunchedItem.java
@@ -1,12 +1,17 @@
 package com.simibubi.create.content.schematics.cannon;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import com.simibubi.create.AllBlocks;
+import com.simibubi.create.api.registry.CreateBuiltInRegistries;
+import com.simibubi.create.api.registry.CreateRegistries;
+import com.simibubi.create.content.kinetics.belt.AllBeltCasingTypes.LegacyCasingType;
 import com.simibubi.create.content.kinetics.belt.BeltBlock;
 import com.simibubi.create.content.kinetics.belt.BeltBlockEntity;
-import com.simibubi.create.content.kinetics.belt.BeltBlockEntity.CasingType;
+import com.simibubi.create.content.kinetics.belt.BeltCasingType;
 import com.simibubi.create.content.kinetics.belt.BeltPart;
 import com.simibubi.create.content.kinetics.belt.BeltSlope;
 import com.simibubi.create.content.kinetics.belt.item.BeltConnectorItem;
@@ -16,11 +21,14 @@ import com.simibubi.create.foundation.utility.BlockHelper;
 import net.createmod.catnip.nbt.NBTHelper;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction.Axis;
+import net.minecraft.core.Holder.Reference;
 import net.minecraft.core.HolderGetter;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtUtils;
 import net.minecraft.nbt.Tag;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
@@ -134,7 +142,7 @@ public abstract class LaunchedItem {
 
 	public static class ForBelt extends ForBlockState {
 		public int length;
-		public CasingType[] casings;
+		public List<BeltCasingType> casings;
 
 		public ForBelt() {}
 
@@ -142,27 +150,51 @@ public abstract class LaunchedItem {
 		public CompoundTag serializeNBT(HolderLookup.Provider registries) {
 			CompoundTag serializeNBT = super.serializeNBT(registries);
 			serializeNBT.putInt("Length", length);
-			serializeNBT.putIntArray("Casing", Arrays.stream(casings)
-				.map(CasingType::ordinal)
-				.toList());
+
+			for (int i = 0; i < casings.size(); i++) {
+				BeltCasingType casing = casings.get(i);
+				if (casing == null)
+					continue;
+				ResourceKey<BeltCasingType> key = casing.holder.key();
+				serializeNBT.putString("CasingKey_" + i, key.location().toString());
+			}
+
 			return serializeNBT;
 		}
 
 		@Override
 		void readNBT(CompoundTag nbt, HolderLookup.Provider registries, HolderGetter<Block> holderGetter) {
 			length = nbt.getInt("Length");
-			int[] intArray = nbt.getIntArray("Casing");
-			casings = new CasingType[length];
-			for (int i = 0; i < casings.length; i++)
-				casings[i] = i >= intArray.length ? CasingType.NONE
-					: CasingType.values()[Mth.clamp(intArray[i], 0, CasingType.values().length - 1)];
+
+			//Read legacy "Casing" int array vs "CasingKeys" resource key array
+ 			if (nbt.contains("Casing", Tag.TAG_INT_ARRAY)) {
+				int[] intArray = nbt.getIntArray("Casing");
+				casings = Arrays.stream(intArray)
+					.mapToObj(i -> LegacyCasingType.values()[Mth.clamp(i, 0, LegacyCasingType.values().length - 1)])
+					.map(LegacyCasingType::getCasingType)
+					.toList();
+			} else {
+				 casings = new ArrayList<>(length);
+				 for (int i = 0; i < length; i++) {
+					 if (!nbt.contains("CasingKey_" + i)) //Null value means no casing
+						 continue;
+					 String key = nbt.getString("CasingKey_" + i);
+
+					 ResourceKey<BeltCasingType> resourceKey = ResourceKey.create(CreateRegistries.BELT_CASING_TYPE, ResourceLocation.parse(key));
+					 Optional<Reference<BeltCasingType>> holder = CreateBuiltInRegistries.BELT_CASING_TYPE.getHolder(resourceKey);
+
+					 final int insertIndex = i;
+					 holder.ifPresent(reference -> casings.set(insertIndex, reference.value()));
+				 }
+			}
+
 			super.readNBT(nbt, registries, holderGetter);
 		}
 
-		public ForBelt(BlockPos start, BlockPos target, ItemStack stack, BlockState state, CasingType[] casings) {
+		public ForBelt(BlockPos start, BlockPos target, ItemStack stack, BlockState state, List<BeltCasingType> casings) {
 			super(start, target, stack, state, null);
 			this.casings = casings;
-			this.length = casings.length;
+			this.length = casings.size();
 		}
 
 		@Override
@@ -180,12 +212,12 @@ public abstract class LaunchedItem {
 				target.offset(offset.getX() * i, offset.getY() * i, offset.getZ() * i));
 
 			for (int segment = 0; segment < length; segment++) {
-				if (casings[segment] == CasingType.NONE)
+				if (casings.get(segment) == null)
 					continue;
 				BlockPos casingTarget =
 					target.offset(offset.getX() * segment, offset.getY() * segment, offset.getZ() * segment);
 				if (world.getBlockEntity(casingTarget) instanceof BeltBlockEntity bbe)
-					bbe.setCasingType(casings[segment]);
+					bbe.setCasingType(casings.get(segment));
 			}
 		}
 

--- a/src/main/java/com/simibubi/create/content/schematics/cannon/LaunchedItem.java
+++ b/src/main/java/com/simibubi/create/content/schematics/cannon/LaunchedItem.java
@@ -166,7 +166,7 @@ public abstract class LaunchedItem {
 		void readNBT(CompoundTag nbt, HolderLookup.Provider registries, HolderGetter<Block> holderGetter) {
 			length = nbt.getInt("Length");
 
-			//Read legacy "Casing" int array vs "CasingKeys" resource key array
+			//Read legacy "Casing" int array vs modern "CasingKeys" resource key array
  			if (nbt.contains("Casing", Tag.TAG_INT_ARRAY)) {
 				int[] intArray = nbt.getIntArray("Casing");
 				casings = Arrays.stream(intArray)

--- a/src/main/java/com/simibubi/create/content/schematics/cannon/SchematicannonBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/schematics/cannon/SchematicannonBlockEntity.java
@@ -793,7 +793,7 @@ public class SchematicannonBlockEntity extends SmartBlockEntity implements MenuP
 		if (AllBlocks.BELT.has(blockState)) {
 			blockState = stripBeltIfNotLast(blockState);
 			if (blockEntity instanceof BeltBlockEntity bbe && AllBlocks.BELT.has(blockState)) {
-				List<BeltCasingType> casings = new ArrayList<>(bbe.beltLength);
+				BeltCasingType[] casings = new BeltCasingType[bbe.beltLength];
 				BlockPos currentPos = target;
 				for (int i = 0; i < bbe.beltLength; i++) {
 					BlockState currentState = bbe.getLevel()
@@ -803,11 +803,11 @@ public class SchematicannonBlockEntity extends SmartBlockEntity implements MenuP
 					if (!(bbe.getLevel()
 						.getBlockEntity(currentPos) instanceof BeltBlockEntity beltAtSegment))
 						break;
-					casings.set(i, beltAtSegment.casing);
+					casings[i] = beltAtSegment.casing;
 					currentPos = BeltBlock.nextSegmentPosition(currentState, currentPos,
 						blockState.getValue(BeltBlock.PART) != BeltPart.END);
 				}
-				launchBelt(target, blockState, bbe.beltLength, casings);
+				launchBelt(target, blockState, casings);
 			} else if (blockState != Blocks.AIR.defaultBlockState())
 				launchBlock(target, icon, blockState, null);
 			return;
@@ -817,7 +817,7 @@ public class SchematicannonBlockEntity extends SmartBlockEntity implements MenuP
 		launchBlock(target, icon, blockState, data);
 	}
 
-	protected void launchBelt(BlockPos target, BlockState state, int length, List<BeltCasingType> casings) {
+	protected void launchBelt(BlockPos target, BlockState state, BeltCasingType[] casings) {
 		blocksPlaced++;
 		ItemStack connector = AllItems.BELT_CONNECTOR.asStack();
 		flyingBlocks.add(new LaunchedItem.ForBelt(this.getBlockPos(), target, connector, state, casings));

--- a/src/main/java/com/simibubi/create/content/schematics/cannon/SchematicannonBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/schematics/cannon/SchematicannonBlockEntity.java
@@ -1,5 +1,6 @@
 package com.simibubi.create.content.schematics.cannon;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -16,7 +17,7 @@ import com.simibubi.create.AllItems;
 import com.simibubi.create.AllSoundEvents;
 import com.simibubi.create.content.kinetics.belt.BeltBlock;
 import com.simibubi.create.content.kinetics.belt.BeltBlockEntity;
-import com.simibubi.create.content.kinetics.belt.BeltBlockEntity.CasingType;
+import com.simibubi.create.content.kinetics.belt.BeltCasingType;
 import com.simibubi.create.content.kinetics.belt.BeltPart;
 import com.simibubi.create.content.kinetics.belt.BeltSlope;
 import com.simibubi.create.content.kinetics.simpleRelays.AbstractSimpleShaftBlock;
@@ -40,6 +41,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Direction.Axis;
 import net.minecraft.core.Direction.AxisDirection;
+import net.minecraft.core.Holder.Reference;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.component.DataComponentMap.Builder;
 import net.minecraft.nbt.CompoundTag;
@@ -791,8 +793,7 @@ public class SchematicannonBlockEntity extends SmartBlockEntity implements MenuP
 		if (AllBlocks.BELT.has(blockState)) {
 			blockState = stripBeltIfNotLast(blockState);
 			if (blockEntity instanceof BeltBlockEntity bbe && AllBlocks.BELT.has(blockState)) {
-				CasingType[] casings = new CasingType[bbe.beltLength];
-				Arrays.fill(casings, CasingType.NONE);
+				List<BeltCasingType> casings = new ArrayList<>(bbe.beltLength);
 				BlockPos currentPos = target;
 				for (int i = 0; i < bbe.beltLength; i++) {
 					BlockState currentState = bbe.getLevel()
@@ -802,7 +803,7 @@ public class SchematicannonBlockEntity extends SmartBlockEntity implements MenuP
 					if (!(bbe.getLevel()
 						.getBlockEntity(currentPos) instanceof BeltBlockEntity beltAtSegment))
 						break;
-					casings[i] = beltAtSegment.casing;
+					casings.set(i, beltAtSegment.casing);
 					currentPos = BeltBlock.nextSegmentPosition(currentState, currentPos,
 						blockState.getValue(BeltBlock.PART) != BeltPart.END);
 				}
@@ -816,7 +817,7 @@ public class SchematicannonBlockEntity extends SmartBlockEntity implements MenuP
 		launchBlock(target, icon, blockState, data);
 	}
 
-	protected void launchBelt(BlockPos target, BlockState state, int length, CasingType[] casings) {
+	protected void launchBelt(BlockPos target, BlockState state, int length, List<BeltCasingType> casings) {
 		blocksPlaced++;
 		ItemStack connector = AllItems.BELT_CONNECTOR.asStack();
 		flyingBlocks.add(new LaunchedItem.ForBelt(this.getBlockPos(), target, connector, state, casings));

--- a/src/main/java/com/simibubi/create/foundation/data/BuilderTransformers.java
+++ b/src/main/java/com/simibubi/create/foundation/data/BuilderTransformers.java
@@ -33,6 +33,8 @@ import com.simibubi.create.content.decoration.encasing.EncasedCTBehaviour;
 import com.simibubi.create.content.decoration.slidingDoor.SlidingDoorBlock;
 import com.simibubi.create.content.decoration.slidingDoor.SlidingDoorMovementBehaviour;
 import com.simibubi.create.content.kinetics.base.RotatedPillarKineticBlock;
+import com.simibubi.create.content.kinetics.belt.AllBeltCasingTypes;
+import com.simibubi.create.content.kinetics.belt.BeltCasingType;
 import com.simibubi.create.content.kinetics.crank.ValveHandleBlock;
 import com.simibubi.create.content.kinetics.simpleRelays.encased.EncasedCogCTBehaviour;
 import com.simibubi.create.content.kinetics.simpleRelays.encased.EncasedCogwheelBlock;
@@ -63,6 +65,8 @@ import net.createmod.catnip.registry.RegisteredObjectsHelper;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.core.Direction.Axis;
 import net.minecraft.core.Direction.AxisDirection;
+import net.minecraft.core.Holder;
+import net.minecraft.core.Holder.Reference;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.data.recipes.RecipeCategory;
 import net.minecraft.data.recipes.ShapelessRecipeBuilder;
@@ -339,7 +343,7 @@ public class BuilderTransformers {
 	}
 
 	public static <B extends BeltTunnelBlock> NonNullUnaryOperator<BlockBuilder<B, CreateRegistrate>> beltTunnel(
-		String type, ResourceLocation particleTexture) {
+		String type, ResourceLocation particleTexture, Supplier<BeltCasingType> beltCasingType) {
 		String prefix = "block/tunnel/" + type + "_tunnel";
 		String funnel_prefix = "block/funnel/" + type + "_funnel";
 		return b -> b.initialProperties(SharedProperties::stone)
@@ -364,7 +368,7 @@ public class BuilderTransformers {
 						.rotationY(state.getValue(BeltTunnelBlock.HORIZONTAL_AXIS) == Axis.X ? 0 : 90)
 						.build();
 				}))
-			.item(BeltTunnelItem::new)
+			.item((t, p) -> new BeltTunnelItem(t, p, beltCasingType))
 			.model((c, p) -> {
 				p.withExistingParent("item/" + type + "_tunnel", p.modLoc("block/belt_tunnel/item"))
 					.texture("top", p.modLoc(prefix + "_top"))

--- a/src/main/java/com/simibubi/create/infrastructure/ponder/scenes/BeltScenes.java
+++ b/src/main/java/com/simibubi/create/infrastructure/ponder/scenes/BeltScenes.java
@@ -7,6 +7,7 @@ import java.util.List;
 import com.simibubi.create.AllBlocks;
 import com.simibubi.create.AllItems;
 import com.simibubi.create.content.fluids.spout.SpoutBlockEntity;
+import com.simibubi.create.content.kinetics.belt.AllBeltCasingTypes.LegacyCasingType;
 import com.simibubi.create.content.kinetics.belt.BeltBlock;
 import com.simibubi.create.content.kinetics.belt.BeltBlockEntity;
 import com.simibubi.create.content.kinetics.belt.BeltPart;
@@ -425,7 +426,7 @@ public class BeltScenes {
 		scene.idle(7);
 		scene.world().modifyBlock(beltPos2, s -> s.setValue(BeltBlock.CASING, true), true);
 		scene.world().modifyBlockEntityNBT(util.select().position(beltPos2), BeltBlockEntity.class, nbt -> {
-			NBTHelper.writeEnum(nbt, "Casing", BeltBlockEntity.CasingType.ANDESITE);
+			NBTHelper.writeEnum(nbt, "Casing", LegacyCasingType.ANDESITE); //Schematic has legacy NBT
 		});
 		scene.idle(20);
 
@@ -460,7 +461,7 @@ public class BeltScenes {
 			scene.idle(4);
 			scene.world().modifyBlock(pos, s -> s.setValue(BeltBlock.CASING, true), true);
 			scene.world().modifyBlockEntityNBT(util.select().position(pos), BeltBlockEntity.class, nbt -> {
-				NBTHelper.writeEnum(nbt, "Casing", BeltBlockEntity.CasingType.ANDESITE);
+				NBTHelper.writeEnum(nbt, "Casing", LegacyCasingType.ANDESITE); //Schematic has legacy NBT
 			});
 		}
 		for (BlockPos pos : brassBelts) {

--- a/src/main/java/com/simibubi/create/infrastructure/ponder/scenes/TunnelScenes.java
+++ b/src/main/java/com/simibubi/create/infrastructure/ponder/scenes/TunnelScenes.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.simibubi.create.AllItems;
+import com.simibubi.create.content.kinetics.belt.AllBeltCasingTypes.LegacyCasingType;
 import com.simibubi.create.content.kinetics.belt.BeltBlock;
 import com.simibubi.create.content.kinetics.belt.BeltBlockEntity;
 import com.simibubi.create.content.logistics.tunnel.BrassTunnelBlockEntity;
@@ -57,7 +58,7 @@ public class TunnelScenes {
 		for (int i = 0; i < 3; i++) {
 			scene.world().cycleBlockProperty(util.grid().at(1 + i, 1, 2), BeltBlock.CASING);
 			scene.world().modifyBlockEntityNBT(util.select().position(1 + i, 1, 2), BeltBlockEntity.class,
-				nbt -> NBTHelper.writeEnum(nbt, "Casing", BeltBlockEntity.CasingType.ANDESITE), true);
+				nbt -> NBTHelper.writeEnum(nbt, "Casing", LegacyCasingType.ANDESITE), true); // Schematic uses legacy nbt
 			scene.idle(4);
 		}
 
@@ -130,7 +131,7 @@ public class TunnelScenes {
 		for (int i = 0; i < 3; i++) {
 			scene.world().cycleBlockProperty(util.grid().at(2 + i, 1, 2), BeltBlock.CASING);
 			scene.world().modifyBlockEntityNBT(util.select().position(2 + i, 1, 2), BeltBlockEntity.class,
-				nbt -> NBTHelper.writeEnum(nbt, "Casing", BeltBlockEntity.CasingType.BRASS), true);
+				nbt -> NBTHelper.writeEnum(nbt, "Casing", LegacyCasingType.BRASS), true); // Schematic uses legacy nbt
 			scene.idle(4);
 		}
 


### PR DESCRIPTION
Changes the belt casing Enum to be an extendable registry, for addons (me) to add their own.

This also includes a fix to belts placed by schematics always being brass, since it wasn't being written as safeNBT.

(There is a bug with the ponder resulting in it appearing as brass, it took me way to long to realise this is pre-existing. I think this is because ponder doesen't seem to like model data, but all the relevant code is the exact same in function so it will go back to normal when this is fixed)

I've tried to model this closely to typical registry setups in create, but I'm still new to the conventions, so if there is a preferred way please say.