### PR TITLE
fix: restore stock link priority

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/packagerLink/LogisticsManager.java
+++ b/src/main/java/com/simibubi/create/content/logistics/packagerLink/LogisticsManager.java
@@ -111,23 +111,43 @@ public class LogisticsManager {
 
 		// Group links by InventoryIdentifier and randomly select one from each group
 		Map<InventoryIdentifier, List<LogisticallyLinkedBehaviour>> linksByInventory = new HashMap<>();
-		List<LogisticallyLinkedBehaviour> availableLinks = new ArrayList<>();
+		List<List<LogisticallyLinkedBehaviour>> availableLinkGroups = new ArrayList<>();
 
 		// Group links by their inventory identifier
 		for (LogisticallyLinkedBehaviour link : allAvailableLinks) {
 			InventoryIdentifier inventoryId = getInventoryIdentifierFromLink(link);
 			if (inventoryId != null) {
-				linksByInventory.computeIfAbsent(inventoryId, k -> new ArrayList<>()).add(link);
+				List<LogisticallyLinkedBehaviour> listGroup = linksByInventory.get(inventoryId);
+				if (listGroup == null) {
+					listGroup = new ArrayList<>();
+					listGroup.add(link);
+					linksByInventory.put(inventoryId, listGroup);
+				}
+				listGroup.add(link);
+				availableLinkGroups.add(listGroup);
 			} else {
 				// Links without inventory identifier are added directly
-				availableLinks.add(link);
+				List<LogisticallyLinkedBehaviour> listGroup = new ArrayList<>();
+				listGroup.add(link);
+				availableLinkGroups.add(listGroup);
 			}
 		}
 
+		List<LogisticallyLinkedBehaviour> availableLinks = new ArrayList<>();
+
 		// Randomly select one link from each inventory group
-		for (List<LogisticallyLinkedBehaviour> linkGroup : linksByInventory.values()) {
-			if (!linkGroup.isEmpty()) {
-				LogisticallyLinkedBehaviour selectedLink = linkGroup.get(r.nextInt(linkGroup.size()));
+		for (List<LogisticallyLinkedBehaviour> linkGroup : availableLinkGroups) {
+			if (linkGroup.size() == 1) {
+				availableLinks.add(linkGroup.getFirst());
+			} else {
+				int priority = linkGroup.getFirst().redstonePower;
+				List<LogisticallyLinkedBehaviour> priorityLinkGroup = new ArrayList<>();
+				for (LogisticallyLinkedBehaviour link : linkGroup) {
+					if (link.redstonePower == priority) {
+						priorityLinkGroup.add(link);
+					}
+				}
+				LogisticallyLinkedBehaviour selectedLink = priorityLinkGroup.get(r.nextInt(priorityLinkGroup.size()));
 				availableLinks.add(selectedLink);
 			}
 		}


### PR DESCRIPTION
## Problem

Stock links weren't respecting priority. Simple case: create a logistics network with two inventories and a linked packager on each. Put a stack of the same material in each inventory. Place an order and observe which is used. Deprioritize that one with redstone/an analog lever. Place another order. Observe same packager being used despite being deprioritized.

## Solution

Have groups of stock links under the same inventoryId tracked for priority along with other links via a list of lists. Flatten by choosing randomly between all links with the same + highest priority. I saw one user suggest picking the packager with the shortest queue, but I don't know enough about the code to figure out how to do that, so I kept what the previous contributor did.

Fixes #9689 

I'm not the most experienced with Java, so any eyes and advice would be much appreciated. Thanks!