### PR TITLE
Fix #9414. Respect interfaceScale for train map in Xaero

### DIFF
--- a/src/main/java/com/simibubi/create/compat/trainmap/XaeroTrainMap.java
+++ b/src/main/java/com/simibubi/create/compat/trainmap/XaeroTrainMap.java
@@ -78,7 +78,8 @@ public class XaeroTrainMap {
 		Window window = mc.getWindow();
 
 		double guiScale = (double) window.getScreenWidth() / window.getGuiScaledWidth();
-		double scale = mapScale / guiScale;
+		double interfaceScale = (double) window.getWidth() / window.getScreenWidth();
+		double scale = mapScale / guiScale / interfaceScale;
 
 		PoseStack pose = graphics.pose();
 		pose.pushPose();


### PR DESCRIPTION
Related #9414. 

Tested on MacOs 15.7