### PR TITLE
CC:Tweaked Peripheral for Factory Gauge

### DIFF
--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/ComputerBehaviour.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/ComputerBehaviour.java
@@ -32,6 +32,8 @@ import com.simibubi.create.content.logistics.redstoneRequester.RedstoneRequester
 import com.simibubi.create.content.logistics.packager.PackagerBlockEntity;
 import com.simibubi.create.content.logistics.stockTicker.PackageOrderWithCrafts;
 import com.simibubi.create.content.logistics.stockTicker.StockTickerBlockEntity;
+import com.simibubi.create.content.logistics.factoryBoard.FactoryPanelBlockEntity;
+import com.simibubi.create.compat.computercraft.implementation.peripherals.FactoryGaugePeripheral;
 import com.simibubi.create.compat.computercraft.implementation.peripherals.SyncedPeripheral;
 import com.simibubi.create.compat.computercraft.implementation.peripherals.TrackObserverPeripheral;
 import com.simibubi.create.content.contraptions.chassis.StickerBlockEntity;
@@ -93,6 +95,8 @@ public class ComputerBehaviour extends AbstractComputerBehaviour {
 			return () -> new StressGaugePeripheral(sgbe);
 		if (be instanceof StockTickerBlockEntity sgbe)
 			return () -> new StockTickerPeripheral(sgbe);
+		if (be instanceof FactoryPanelBlockEntity fpbe)
+			return () -> new FactoryGaugePeripheral(fpbe);
 		// Has to be before PackagerBlockEntity as it's a subclass
 		if (be instanceof RepackagerBlockEntity rpbe)
 			return () -> new RepackagerPeripheral(rpbe);

--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/FactoryGaugePeripheral.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/FactoryGaugePeripheral.java
@@ -40,28 +40,27 @@ public class FactoryGaugePeripheral extends SyncedPeripheral<FactoryPanelBlockEn
 
 	@Nullable
 	private FactoryPanelBehaviour getPanelBehaviour(Optional<String> slotName) throws LuaException {
-		PanelSlot slot = PanelSlot.TOP_LEFT; // default
 		if (slotName.isPresent()) {
+			PanelSlot slot;
 			try {
 				slot = PanelSlot.valueOf(slotName.get().toUpperCase());
 			} catch (IllegalArgumentException e) {
 				throw new LuaException("Invalid slot name. Use: TOP_LEFT, TOP_RIGHT, BOTTOM_LEFT, BOTTOM_RIGHT");
 			}
-		} else {
-			// Find first active panel
-			for (FactoryPanelBehaviour panel : blockEntity.panels.values()) {
-				if (panel.isActive()) {
-					return panel;
-				}
+			FactoryPanelBehaviour panel = blockEntity.panels.get(slot);
+			if (panel == null || !panel.isActive()) {
+				return null;
 			}
-			return null;
+			return panel;
 		}
 
-		FactoryPanelBehaviour panel = blockEntity.panels.get(slot);
-		if (panel == null || !panel.isActive()) {
-			return null;
+		// Find first active panel
+		for (FactoryPanelBehaviour panel : blockEntity.panels.values()) {
+			if (panel.isActive()) {
+				return panel;
+			}
 		}
-		return panel;
+		return null;
 	}
 
 	// === READ METHODS ===

--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/FactoryGaugePeripheral.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/FactoryGaugePeripheral.java
@@ -1,0 +1,278 @@
+package com.simibubi.create.compat.computercraft.implementation.peripherals;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import com.simibubi.create.content.logistics.factoryBoard.FactoryPanelBehaviour;
+import com.simibubi.create.content.logistics.factoryBoard.FactoryPanelBlock.PanelSlot;
+import com.simibubi.create.content.logistics.factoryBoard.FactoryPanelBlockEntity;
+import com.simibubi.create.foundation.blockEntity.behaviour.ValueSettingsBehaviour.ValueSettings;
+
+import dan200.computercraft.api.detail.VanillaDetailRegistries;
+import dan200.computercraft.api.lua.IArguments;
+import dan200.computercraft.api.lua.LuaException;
+import dan200.computercraft.api.lua.LuaFunction;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.ItemStack;
+
+public class FactoryGaugePeripheral extends SyncedPeripheral<FactoryPanelBlockEntity> {
+
+	public FactoryGaugePeripheral(FactoryPanelBlockEntity blockEntity) {
+		super(blockEntity);
+	}
+
+	@NotNull
+	@Override
+	public String getType() {
+		return "Create_FactoryGauge";
+	}
+
+	// === PANEL SELECTION ===
+
+	@Nullable
+	private FactoryPanelBehaviour getPanelBehaviour(Optional<String> slotName) throws LuaException {
+		PanelSlot slot = PanelSlot.TOP_LEFT; // default
+		if (slotName.isPresent()) {
+			try {
+				slot = PanelSlot.valueOf(slotName.get().toUpperCase());
+			} catch (IllegalArgumentException e) {
+				throw new LuaException("Invalid slot name. Use: TOP_LEFT, TOP_RIGHT, BOTTOM_LEFT, BOTTOM_RIGHT");
+			}
+		} else {
+			// Find first active panel
+			for (FactoryPanelBehaviour panel : blockEntity.panels.values()) {
+				if (panel.isActive()) {
+					return panel;
+				}
+			}
+			return null;
+		}
+
+		FactoryPanelBehaviour panel = blockEntity.panels.get(slot);
+		if (panel == null || !panel.isActive()) {
+			return null;
+		}
+		return panel;
+	}
+
+	// === READ METHODS ===
+
+	@LuaFunction(mainThread = true)
+	public final List<String> getActivePanels() {
+		List<String> result = new ArrayList<>();
+		for (Map.Entry<PanelSlot, FactoryPanelBehaviour> entry : blockEntity.panels.entrySet()) {
+			if (entry.getValue().isActive()) {
+				result.add(entry.getKey().name());
+			}
+		}
+		return result;
+	}
+
+	@LuaFunction(mainThread = true)
+	public final int getActivePanelCount() {
+		return blockEntity.activePanels();
+	}
+
+	@LuaFunction(mainThread = true)
+	public final @Nullable Map<String, Object> getFilter(Optional<String> slot) throws LuaException {
+		FactoryPanelBehaviour panel = getPanelBehaviour(slot);
+		if (panel == null) return null;
+
+		ItemStack filter = panel.getFilter();
+		if (filter.isEmpty()) return null;
+
+		Map<String, Object> result = new HashMap<>(VanillaDetailRegistries.ITEM_STACK.getBasicDetails(filter));
+		return result;
+	}
+
+	@LuaFunction(mainThread = true)
+	public final @Nullable Map<String, Object> getThreshold(Optional<String> slot) throws LuaException {
+		FactoryPanelBehaviour panel = getPanelBehaviour(slot);
+		if (panel == null) return null;
+
+		Map<String, Object> result = new HashMap<>();
+		result.put("count", panel.getAmount());
+		result.put("mode", panel.upTo ? "items" : "stacks");
+		return result;
+	}
+
+	@LuaFunction(mainThread = true)
+	public final boolean isThresholdMet(Optional<String> slot) throws LuaException {
+		FactoryPanelBehaviour panel = getPanelBehaviour(slot);
+		if (panel == null) return false;
+		return panel.satisfied;
+	}
+
+	@LuaFunction(mainThread = true)
+	public final boolean isPromisedMet(Optional<String> slot) throws LuaException {
+		FactoryPanelBehaviour panel = getPanelBehaviour(slot);
+		if (panel == null) return false;
+		return panel.promisedSatisfied;
+	}
+
+	@LuaFunction(mainThread = true)
+	public final @Nullable Map<String, Object> getStatus(Optional<String> slot) throws LuaException {
+		FactoryPanelBehaviour panel = getPanelBehaviour(slot);
+		if (panel == null) return null;
+
+		Map<String, Object> result = new HashMap<>();
+		result.put("active", panel.isActive());
+		result.put("satisfied", panel.satisfied);
+		result.put("promisedSatisfied", panel.promisedSatisfied);
+		result.put("waitingForNetwork", panel.waitingForNetwork);
+		result.put("redstonePowered", panel.redstonePowered);
+		result.put("levelInStorage", panel.getLevelInStorage());
+		result.put("promised", panel.getPromised());
+		result.put("address", panel.recipeAddress);
+		result.put("recipeOutput", panel.recipeOutput);
+		result.put("isRestocker", blockEntity.restocker);
+		return result;
+	}
+
+	@LuaFunction(mainThread = true)
+	public final int getLevelInStorage(Optional<String> slot) throws LuaException {
+		FactoryPanelBehaviour panel = getPanelBehaviour(slot);
+		if (panel == null) return 0;
+		return panel.getLevelInStorage();
+	}
+
+	@LuaFunction(mainThread = true)
+	public final int getPromised(Optional<String> slot) throws LuaException {
+		FactoryPanelBehaviour panel = getPanelBehaviour(slot);
+		if (panel == null) return 0;
+		return panel.getPromised();
+	}
+
+	@LuaFunction(mainThread = true)
+	public final @Nullable String getAddress(Optional<String> slot) throws LuaException {
+		FactoryPanelBehaviour panel = getPanelBehaviour(slot);
+		if (panel == null) return null;
+		return panel.recipeAddress;
+	}
+
+	@LuaFunction(mainThread = true)
+	public final @Nullable String getNetwork(Optional<String> slot) throws LuaException {
+		FactoryPanelBehaviour panel = getPanelBehaviour(slot);
+		if (panel == null) return null;
+		return panel.network != null ? panel.network.toString() : null;
+	}
+
+	// === WRITE METHODS ===
+
+	@LuaFunction(mainThread = true)
+	public final boolean setFilter(IArguments args) throws LuaException {
+		String slotName = args.optString(1, null);
+		Optional<String> slot = Optional.ofNullable(slotName);
+		FactoryPanelBehaviour panel = getPanelBehaviour(slot);
+		if (panel == null) {
+			throw new LuaException("No active panel found");
+		}
+
+		Object arg = args.get(0);
+		ItemStack stack;
+
+		if (arg == null) {
+			stack = ItemStack.EMPTY;
+		} else if (arg instanceof String itemId) {
+			stack = parseItemString(itemId);
+		} else if (arg instanceof Map<?, ?> itemTable) {
+			stack = parseItemTable(itemTable);
+		} else {
+			throw new LuaException("Expected item string, table, or nil");
+		}
+
+		return panel.setFilter(stack);
+	}
+
+	@LuaFunction(mainThread = true)
+	public final void setThreshold(IArguments args) throws LuaException {
+		int count = args.getInt(0);
+		String mode = args.optString(1, "items");
+		String slotName = args.optString(2, null);
+
+		Optional<String> slot = Optional.ofNullable(slotName);
+		FactoryPanelBehaviour panel = getPanelBehaviour(slot);
+		if (panel == null) {
+			throw new LuaException("No active panel found");
+		}
+
+		if (count < 0 || count > 100) {
+			throw new LuaException("Threshold count must be between 0 and 100");
+		}
+
+		if (!mode.equalsIgnoreCase("items") && !mode.equalsIgnoreCase("stacks")) {
+			throw new LuaException("Mode must be 'items' or 'stacks'");
+		}
+
+		boolean upTo = mode.equalsIgnoreCase("items");
+		ValueSettings settings = new ValueSettings(upTo ? 0 : 1, count);
+		panel.setValueSettings(null, settings, false);
+	}
+
+	@LuaFunction(mainThread = true)
+	public final void setAddress(IArguments args) throws LuaException {
+		String address = args.getString(0);
+		String slotName = args.optString(1, null);
+
+		Optional<String> slot = Optional.ofNullable(slotName);
+		FactoryPanelBehaviour panel = getPanelBehaviour(slot);
+		if (panel == null) {
+			throw new LuaException("No active panel found");
+		}
+
+		panel.recipeAddress = address;
+		panel.blockEntity.notifyUpdate();
+	}
+
+	@LuaFunction(mainThread = true)
+	public final void clearPromises(Optional<String> slot) throws LuaException {
+		FactoryPanelBehaviour panel = getPanelBehaviour(slot);
+		if (panel == null) {
+			throw new LuaException("No active panel found");
+		}
+
+		panel.forceClearPromises = true;
+	}
+
+	// === HELPER METHODS ===
+
+	private ItemStack parseItemString(String itemId) throws LuaException {
+		String fullId = itemId.contains(":") ? itemId : "minecraft:" + itemId;
+		ResourceLocation id = ResourceLocation.tryParse(fullId);
+		if (id == null) {
+			throw new LuaException("Invalid item ID format: " + itemId);
+		}
+
+		Item item = BuiltInRegistries.ITEM.get(id);
+		if (item == Items.AIR) {
+			throw new LuaException("Unknown item: " + itemId);
+		}
+
+		return new ItemStack(item);
+	}
+
+	private ItemStack parseItemTable(Map<?, ?> table) throws LuaException {
+		Object nameObj = table.get("name");
+		if (!(nameObj instanceof String name)) {
+			throw new LuaException("Item table must have a 'name' field");
+		}
+
+		ItemStack stack = parseItemString(name);
+
+		Object countObj = table.get("count");
+		if (countObj instanceof Number count) {
+			stack.setCount(count.intValue());
+		}
+
+		return stack;
+	}
+}

--- a/src/main/java/com/simibubi/create/content/logistics/factoryBoard/FactoryPanelBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/factoryBoard/FactoryPanelBlockEntity.java
@@ -33,6 +33,11 @@ import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.util.LazyOptional;
+import org.jetbrains.annotations.NotNull;
+import com.simibubi.create.compat.computercraft.AbstractComputerBehaviour;
+import com.simibubi.create.compat.computercraft.ComputerCraftProxy;
 
 public class FactoryPanelBlockEntity extends SmartBlockEntity {
 
@@ -43,6 +48,7 @@ public class FactoryPanelBlockEntity extends SmartBlockEntity {
 	public VoxelShape lastShape;
 
 	public AdvancementBehaviour advancements;
+	public AbstractComputerBehaviour computerBehaviour;
 
 	public FactoryPanelBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
 		super(type, pos, state);
@@ -65,6 +71,14 @@ public class FactoryPanelBlockEntity extends SmartBlockEntity {
 		}
 
 		behaviours.add(advancements = new AdvancementBehaviour(this, AllAdvancements.FACTORY_GAUGE));
+		behaviours.add(computerBehaviour = ComputerCraftProxy.behaviour(this));
+	}
+
+	@Override
+	public <T> @NotNull LazyOptional<T> getCapability(@NotNull Capability<T> cap, @Nullable Direction side) {
+		if (computerBehaviour.isPeripheralCap(cap))
+			return computerBehaviour.getPeripheralCapability();
+		return super.getCapability(cap, side);
 	}
 
 	@Override


### PR DESCRIPTION
Adds ComputerCraft peripheral support to Factory Gauge (`Create_FactoryGauge`).

Factory Gauge was the only major logistics component without CC support. This enables programmatic factory configuration - reading/writing filters, thresholds, and status without player interaction.

### Changes

- New `FactoryGaugePeripheral.java` extending `SyncedPeripheral`
- Added `computerBehaviour` field and `getCapability()` override to `FactoryPanelBlockEntity`
- Registered peripheral in `ComputerBehaviour.getPeripheralFor()`

### API

```lua
local gauge = peripheral.find("Create_FactoryGauge")

-- Read
gauge.getActivePanels()      -- {"TOP_LEFT", ...}
gauge.getFilter()            -- {name="...", count=1}
gauge.getThreshold()         -- {count=64, mode="items"|"stacks"}
gauge.getNetwork()           -- UUID string
gauge.getStatus()            -- full status object
gauge.isThresholdMet()
gauge.isPromisedMet()
gauge.getLevelInStorage()
gauge.getPromised()
gauge.getAddress()

-- Write
gauge.setFilter("minecraft:iron_ingot")
gauge.setThreshold(64, "items")
gauge.setAddress("A1")
gauge.clearPromises()
```

All methods accept optional slot parameter (`TOP_LEFT`, `TOP_RIGHT`, `BOTTOM_LEFT`, `BOTTOM_RIGHT`). Defaults to first active panel.

### Testing

Place computer next to Factory Gauge, run:

```lua
local gauge = peripheral.find("Create_FactoryGauge")
print(textutils.serialize(gauge.getActivePanels()))
print(textutils.serialize(gauge.getFilter()))
gauge.setFilter("minecraft:gold_ingot")
gauge.setThreshold(32, "stacks")
print(textutils.serialize(gauge.getFilter()))  -- should show gold_ingot
```

Tested on 1.20.1 with CC:Tweaked. All read/write methods verified working.