### PR TITLE
Drop blocks destroyed by tree fertilizer

### DIFF
--- a/src/main/java/com/simibubi/create/content/equipment/TreeFertilizerItem.java
+++ b/src/main/java/com/simibubi/create/content/equipment/TreeFertilizerItem.java
@@ -68,6 +68,7 @@ public class TreeFertilizerItem extends Item {
 						.isEmpty())
 					continue;
 
+				context.getLevel().destroyBlock(actualPos, true);
 				context.getLevel()
 					.setBlockAndUpdate(actualPos, newState);
 			}


### PR DESCRIPTION
This prevents block drops being deleted if a tree is grown on top of them