### PR TITLE
Abide by `/tick freeze`

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/ContraptionCollider.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/ContraptionCollider.java
@@ -101,7 +101,7 @@ public class ContraptionCollider {
 		List<Entity> entitiesWithinAABB = world.getEntitiesOfClass(Entity.class, bounds.inflate(2)
 			.expandTowards(0, 32, 0), contraptionEntity::canCollideWith);
 		for (Entity entity : entitiesWithinAABB) {
-			if (!entity.isAlive())
+			if (!entity.isAlive() || world.tickRateManager().isEntityFrozen(entity))
 				continue;
 
 			PlayerType playerType = getPlayerType(entity);

--- a/src/main/java/com/simibubi/create/content/contraptions/minecart/CouplingPhysics.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/minecart/CouplingPhysics.java
@@ -8,6 +8,7 @@ import net.createmod.catnip.math.VecHelper;
 import net.minecraft.core.BlockPos;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.util.Mth;
+import net.minecraft.world.TickRateManager;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.MoverType;
 import net.minecraft.world.entity.vehicle.AbstractMinecart;
@@ -25,6 +26,12 @@ public class CouplingPhysics {
 
 	public static void tickCoupling(Level world, Couple<MinecartController> c) {
 		Couple<AbstractMinecart> carts = c.map(MinecartController::cart);
+
+		TickRateManager trm = world.tickRateManager();
+		if (trm.isEntityFrozen(carts.getFirst()) && trm.isEntityFrozen(carts.getSecond())) {
+			return;
+		}
+
 		float couplingLength = c.getFirst()
 			.getCouplingLength(true);
 		softCollisionStep(world, carts, couplingLength);


### PR DESCRIPTION
Makes contraption collision and coupling behaviour work properly when time is frozen via `/tick freeze`.