### PR TITLE
Change to FluidPropagator for better support of addon pumps

### DIFF
--- a/src/main/java/com/simibubi/create/content/fluids/FluidPropagator.java
+++ b/src/main/java/com/simibubi/create/content/fluids/FluidPropagator.java
@@ -7,10 +7,10 @@ import java.util.Set;
 
 import org.jetbrains.annotations.Nullable;
 
-import com.simibubi.create.AllBlocks;
 import com.simibubi.create.AllTags.AllBlockTags;
 import com.simibubi.create.content.fluids.PipeConnection.Flow;
 import com.simibubi.create.content.fluids.pipes.AxisPipeBlock;
+import com.simibubi.create.content.fluids.pipes.EncasedPipeBlock;
 import com.simibubi.create.content.fluids.pipes.FluidPipeBlock;
 import com.simibubi.create.content.fluids.pipes.VanillaFluidTargets;
 import com.simibubi.create.content.fluids.pump.PumpBlock;
@@ -74,7 +74,7 @@ public class FluidPropagator {
 				BlockEntity blockEntity = world.getBlockEntity(target);
 				BlockState targetState = world.getBlockState(target);
 				if (blockEntity instanceof PumpBlockEntity) {
-					if (!AllBlocks.MECHANICAL_PUMP.has(targetState) || targetState.getValue(PumpBlock.FACING)
+					if (!(targetState.getBlock() instanceof PumpBlock) || targetState.getValue(PumpBlock.FACING)
 						.getAxis() != direction.getAxis())
 						continue;
 					discoveredPumps.add(Pair.of((PumpBlockEntity) blockEntity, direction.getOpposite()));
@@ -150,7 +150,7 @@ public class FluidPropagator {
 			return null;
 		if (otherBlock instanceof LiquidBlock)
 			return null;
-		if (getStraightPipeAxis(state) == null && !AllBlocks.ENCASED_FLUID_PIPE.has(state))
+		if (getStraightPipeAxis(state) == null && !(state.getBlock() instanceof EncasedPipeBlock))
 			return null;
 		for (Direction d : Iterate.directions) {
 			if (!pos.relative(d)


### PR DESCRIPTION
This simply replaces `AllBlocks.MECHANICAL_PUMP.has()` for `.getBlock() instanceof PumpBlock` in `propagateChangedPipe()` so that addon created pumps extending the base class will work as intended. 

The same has been done to the encased pipe check in `validadeNeighbourChange()`

This has no gameplay effect, only eases addon compatibility.
This commit can be applied in 1.20.1 with no modification.