### PR TITLE
Update Xaero's compat to work with Xaero's World Map 1.40.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,7 @@ repositories {
             includeGroup "mysticdrew"
         }
     }
+    maven {url "https://chocolateminecraft.com/maven" } // Xaero
 }
 
 dependencies {
@@ -158,7 +159,8 @@ dependencies {
         exclude(group: "curse.maven") // Pulls in a old version of journey map which is for forge
     }
 
-    compileOnly("curse.maven:xaeros-world-map-317780:6778114")
+    implementation("xaero.lib:xaerolib-neoforge-1.21:1.0.42")
+    implementation("curse.maven:xaeros-world-map-317780:7401095")
 }
 
 sourceSets.main {

--- a/src/main/java/com/simibubi/create/compat/trainmap/XaeroTrainMap.java
+++ b/src/main/java/com/simibubi/create/compat/trainmap/XaeroTrainMap.java
@@ -18,8 +18,8 @@ import net.minecraft.network.chat.FormattedText;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.util.Mth;
 import net.minecraft.world.level.Level;
+import xaero.lib.client.gui.ScreenBase;
 import xaero.map.gui.GuiMap;
-import xaero.map.gui.ScreenBase;
 
 import net.neoforged.neoforge.client.event.InputEvent;
 

--- a/src/main/templates/META-INF/neoforge.mods.toml
+++ b/src/main/templates/META-INF/neoforge.mods.toml
@@ -71,6 +71,14 @@ versionRange = "[1.21.1-6.0.0-beta.46,)"
 ordering = "NONE"
 side = "CLIENT"
 
+[[dependencies."${mod_id}"]]
+modId = "xaeroworldmap"
+type = "optional"
+reason = "Versions before 1.40.2 do not contain the classes Create requires to work with Xaero's World Map."
+versionRange = "[1.40.2,)"
+ordering = "NONE"
+side = "CLIENT"
+
 # Incompatible Mods
 
 # Users should use lithium instead, it's up to date and does not crash with level wrappers (anymore)


### PR DESCRIPTION
Fixes https://github.com/Creators-of-Create/Create/issues/9770

I've updated the compat to use the new lib which Xaero's requires. This lib is included into the world map jar so should never be missing from a client. I've also added a new minimum version requirement for xaero's world map in neoforge.mods.toml.

To try and prevent this happening again in future, would it be worth trying to use reflection in a try-catch (rather than just loading the classes in a try catch - I thought this would be sufficient when I originally made the compat, but my understanding of class loading was incorrect) to access the methods as Xaero's does not have an API. If so, I can have a go at implementing that as part of this PR if you would like, or if you guys want to handle it, that's all good.

Thanks