### PR TITLE
fix: Fixed the bug of errorly set the filtering count to 1 when removing the filtering item

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/blockEntity/behaviour/filtering/FilteringBehaviour.java
+++ b/src/main/java/com/simibubi/create/foundation/blockEntity/behaviour/filtering/FilteringBehaviour.java
@@ -157,7 +157,7 @@ public class FilteringBehaviour extends BlockEntityBehaviour implements ValueSet
 		if (!filter.isEmpty() && !predicate.test(filter))
 			return false;
 		this.filter = FilterItemStack.of(filter);
-		if (!upTo)
+		if (!upTo && !stack.isEmpty())
 			count = Math.min(count, stack.getMaxStackSize());
 		callback.accept(filter);
 		blockEntity.setChanged();

--- a/src/main/java/com/simibubi/create/foundation/blockEntity/behaviour/filtering/FilteringBehaviour.java
+++ b/src/main/java/com/simibubi/create/foundation/blockEntity/behaviour/filtering/FilteringBehaviour.java
@@ -157,7 +157,7 @@ public class FilteringBehaviour extends BlockEntityBehaviour implements ValueSet
 		if (!filter.isEmpty() && !predicate.test(filter))
 			return false;
 		this.filter = FilterItemStack.of(filter);
-		if (!upTo &&  !stack.isEmpty())
+		if (!upTo && !stack.isEmpty())
 			count = Math.min(count, stack.getMaxStackSize());
 		callback.accept(filter);
 		blockEntity.setChanged();

--- a/src/main/java/com/simibubi/create/foundation/blockEntity/behaviour/filtering/FilteringBehaviour.java
+++ b/src/main/java/com/simibubi/create/foundation/blockEntity/behaviour/filtering/FilteringBehaviour.java
@@ -157,7 +157,7 @@ public class FilteringBehaviour extends BlockEntityBehaviour implements ValueSet
 		if (!filter.isEmpty() && !predicate.test(filter))
 			return false;
 		this.filter = FilterItemStack.of(filter);
-		if (!upTo && !stack.isEmpty())
+		if (!upTo &&  !stack.isEmpty())
 			count = Math.min(count, stack.getMaxStackSize());
 		callback.accept(filter);
 		blockEntity.setChanged();


### PR DESCRIPTION
In the method boolean setFilter(ItemStack stack) of class com.simibubi.create.foundation.blockEntity.behaviour.filtering.FilteringBehavior, the filter's count is limited to less than the max stack size of the item.
But, after 1.20.5, mojang use the data component to process items.But in data component, the default value of ItemStack.EMPTY.getMaxStackSize is 1(To some extent,minecraft:air is unstackable now……).
So in the newer Create mod,when we want to clear the filter item and the filter block isn't upTo mode,the stack setting is cleared and set to 1.
I fixed the problem by a special conditional statement of empty stack