### PR TITLE
Fix/avoid sync modify danger

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/sync/ContraptionSeatMappingPacket.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/sync/ContraptionSeatMappingPacket.java
@@ -29,7 +29,7 @@ public record ContraptionSeatMappingPacket(int entityId, Map<UUID, Integer> mapp
 	);
 
         public ContraptionSeatMappingPacket {
-                mapping = (mapping == null) ? null : mapping.clone();
+                mapping = (mapping == null) ? null : new HashMap<>(mapping);
         }
 
 	public ContraptionSeatMappingPacket(int entityID, Map<UUID, Integer> mapping) {

--- a/src/main/java/com/simibubi/create/content/contraptions/sync/ContraptionSeatMappingPacket.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/sync/ContraptionSeatMappingPacket.java
@@ -28,6 +28,10 @@ public record ContraptionSeatMappingPacket(int entityId, Map<UUID, Integer> mapp
 	        ContraptionSeatMappingPacket::new
 	);
 
+        public ContraptionSeatMappingPacket {
+                mapping = (mapping == null) ? null : mapping.clone();
+        }
+
 	public ContraptionSeatMappingPacket(int entityID, Map<UUID, Integer> mapping) {
 		this(entityID, mapping, -1);
 	}

--- a/src/main/java/com/simibubi/create/foundation/blockEntity/behaviour/filtering/FilteringBehaviour.java
+++ b/src/main/java/com/simibubi/create/foundation/blockEntity/behaviour/filtering/FilteringBehaviour.java
@@ -157,7 +157,7 @@ public class FilteringBehaviour extends BlockEntityBehaviour implements ValueSet
 		if (!filter.isEmpty() && !predicate.test(filter))
 			return false;
 		this.filter = FilterItemStack.of(filter);
-		if (!upTo)
+		if (!upTo && !stack.isEmpty())
 			count = Math.min(count, stack.getMaxStackSize());
 		callback.accept(filter);
 		blockEntity.setChanged();


### PR DESCRIPTION
Avoid the danger of modifying seat mappings in main thread while reading the same seat mapping in network thread by a clone