### PR TITLE
Tricky Twins

### DIFF
--- a/src/main/java/com/simibubi/create/api/packager/InventoryIdentifier.java
+++ b/src/main/java/com/simibubi/create/api/packager/InventoryIdentifier.java
@@ -62,6 +62,12 @@ public interface InventoryIdentifier {
 	}
 
 	record Pair(BlockPos first, BlockPos second) implements InventoryIdentifier {
+		public Pair(BlockPos first, BlockPos second) {
+			boolean isFirstLower = first.compareTo(second) < 0;
+			this.first = isFirstLower ? first : second;
+			this.second = isFirstLower ? second : first;
+		}
+
 		@Override
 		public boolean contains(BlockFace face) {
 			BlockPos pos = face.getPos();


### PR DESCRIPTION
fixes, #9627 by enforcing a sorted canonical form for Pair-type InventoryIdentifiers