### PR TITLE
Bumbling Boilers

### DIFF
--- a/src/main/java/com/simibubi/create/api/connectivity/ConnectivityHandler.java
+++ b/src/main/java/com/simibubi/create/api/connectivity/ConnectivityHandler.java
@@ -274,7 +274,6 @@ public class ConnectivityHandler {
 			}
 		}
 		be.setExtraData(extraData);
-		be.notifyMultiUpdated();
 		return amount;
 	}
 


### PR DESCRIPTION
fixes - #9342 by removing an excess notifyMultiUpdated() call that would update boiler state before the new height was updated