### PR TITLE
Refactor tick method to address missing ambient sounds

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/sound/SoundScape.java
+++ b/src/main/java/com/simibubi/create/foundation/sound/SoundScape.java
@@ -56,8 +56,13 @@ class SoundScape {
 	}
 
 	public void tick() {
-		if (AnimationTickHolder.getTicks() % SoundScapes.UPDATE_INTERVAL == 0)
+		if (AnimationTickHolder.getTicks() % SoundScapes.UPDATE_INTERVAL == 0) {
 			meanPos = null;
+			for (ContinuousSound continuousSound : continuous) {
+				if (!Minecraft.getInstance().getSoundManager().isActive(continuousSound))
+					Minecraft.getInstance().getSoundManager().play(continuousSound);
+			}
+		}
 		repeating.forEach(RepeatingSound::tick);
 	}
 


### PR DESCRIPTION
In Create 6.0.9 on NeoForge 21.1.217, there is a bug where ContinuousSound sounds such as cog and shaft ambience are not played. This usally happens when you log in to a server or singleplayer world where there are already spinning cogs, and can be fixed in game be either reloading resources (F3-T) and thus triggering a SoundScapes.invalidateAll, or by teleporting away such that the machines get unloaded and then teleporting back (or by retoggling the ambient sound config. From my testing, this bug is a result of a desync between Create (ContinuousSound instances) and the Minecraft SoundManager. This pull request introduces a potential fix by ensuring sounds in the continuous sound list in the SoundScape class are actually playing in the Minecraft SoundManager every few ticks. I have tested in game and this patch fixes the audio bug without side effects, but it may not be the best or most idiomatic solution. Even if this is not the route taken, I would apreciate feedback on the PR and hope this is at least a good starting point.