### PR TITLE
Fix #8462 - Use absolute position to prevent '.offset' rounding issue on decode

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/ControlledContraptionEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/ControlledContraptionEntity.java
@@ -80,7 +80,9 @@ public class ControlledContraptionEntity extends AbstractContraptionEntity {
 	@Override
 	protected void readAdditional(CompoundTag compound, boolean spawnPacket) {
 		super.readAdditional(compound, spawnPacket);
-		if (compound.contains("ControllerRelative"))
+		if (compound.contains("ControllerPos"))
+			controllerPos = NBTHelper.readBlockPos(compound, "ControllerPos");
+		else if (compound.contains("ControllerRelative"))
 			controllerPos = NBTHelper.readBlockPos(compound, "ControllerRelative").offset(blockPosition());
 		if (compound.contains("Axis"))
 			rotationAxis = NBTHelper.readEnum(compound, "Axis", Axis.class);
@@ -90,7 +92,7 @@ public class ControlledContraptionEntity extends AbstractContraptionEntity {
 	@Override
 	protected void writeAdditional(CompoundTag compound, HolderLookup.Provider registries, boolean spawnPacket) {
 		super.writeAdditional(compound, registries, spawnPacket);
-		compound.put("ControllerRelative", NbtUtils.writeBlockPos(controllerPos.subtract(blockPosition())));
+		compound.put("ControllerPos", NbtUtils.writeBlockPos(controllerPos));
 		if (rotationAxis != null)
 			NBTHelper.writeEnum(compound, "Axis", rotationAxis);
 		compound.putFloat("Angle", angle);


### PR DESCRIPTION
Resolves #8462 by changing controllerPos nbt from relative to absolute position. There is a client desync bug that appears to occur in the '.offset(blockPosition())' calculation where the computed controllerPos can be slightly different from the true controllerPos on the client. This can result in piston contraptions for instance appearing invisible at login. I tested this fix and conifrmed it solved the issue. I don't know if this is the best place to address this in the code, but this seemed the safest option to me. An else clause was left to prevent breaking blocks with the relative tag. I would greatly apreciate feedback on this PR.