### PR TITLE
Add config for rendering the hat layer

### DIFF
--- a/src/main/java/com/simibubi/create/content/equipment/hats/CreateHatArmorLayer.java
+++ b/src/main/java/com/simibubi/create/content/equipment/hats/CreateHatArmorLayer.java
@@ -9,6 +9,8 @@ import com.simibubi.create.content.trains.schedule.hat.TrainHatInfoReloadListene
 import com.simibubi.create.foundation.mixin.accessor.AgeableListModelAccessor;
 import com.simibubi.create.foundation.mixin.accessor.EntityRenderDispatcherAccessor;
 
+import com.simibubi.create.infrastructure.config.AllConfigs;
+
 import dev.engine_room.flywheel.lib.model.baked.PartialModel;
 import dev.engine_room.flywheel.lib.transform.TransformStack;
 import net.createmod.catnip.render.CachedBuffers;
@@ -38,6 +40,9 @@ public class CreateHatArmorLayer<T extends LivingEntity, M extends EntityModel<T
 
 	public void render(PoseStack ms, MultiBufferSource buffer, int light, LivingEntity entity, float limbSwing, float limbSwingAmount,
 					   float partialTicks, float ageInTicks, float netHeadYaw, float headPitch) {
+		if (!AllConfigs.client().renderHatLayer.get())
+			return;
+
 		PartialModel hat = EntityHats.getHatFor(entity);
 		if (hat == null)
 			return;

--- a/src/main/java/com/simibubi/create/infrastructure/config/CClient.java
+++ b/src/main/java/com/simibubi/create/infrastructure/config/CClient.java
@@ -32,6 +32,8 @@ public class CClient extends ConfigBase {
 		Comments.ignoreFabulousWarning);
 	public final ConfigBool rotateWhenSeated = b(true, "rotateWhenSeated",
 		Comments.rotatewhenSeated);
+	public final ConfigBool renderHatLayer = b(true, "renderHatLayer",
+		Comments.renderHatLayer);
 
 	// custom fluid fog
 	public final ConfigGroup fluidFogSettings = group(1, "fluidFogSettings", Comments.fluidFogSettings);
@@ -120,6 +122,7 @@ public class CClient extends ConfigBase {
 		};
 		static String ignoreFabulousWarning = "Setting this to true will prevent Create from sending you a warning when playing with Fabulous graphics enabled";
 		static String rotatewhenSeated = "Disable to prevent being rotated while seated on a Moving Contraption";
+		static String renderHatLayer = "Whether the Train and Stock Ticker hat layer should render on entities";
 		static String overlay = "Settings for the Goggle Overlay";
 		static String overlayOffset = "Offset the overlay from goggle- and hover- information by this many pixels on the respective axis; Use /create overlay";
 		static String overlayCustomColor = "Enable this to use your custom colors for the Goggle- and Hover- Overlay";


### PR DESCRIPTION
<img width="1708" height="1016" alt="A chicken in a seat next to a stock ticker. It is not wearing a hat." src="https://github.com/user-attachments/assets/3894c9f0-3216-4bac-b5af-b7ce1778b44b" />
<img width="1708" height="1016" alt="A chicken in a seat next to a stock ticker. It's wearing a hat." src="https://github.com/user-attachments/assets/1f04ffa4-c64a-4e66-b97a-78191d104562" />

This PR adds a config to toggle the rendering of the Train/Stock Ticker hat layer on entities, particularly for those with animation resource packs that cause the hat to clip.