### PR TITLE
Fix #8160, making Turntables correctly rotate players

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/turntable/TurntableHandler.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/turntable/TurntableHandler.java
@@ -2,8 +2,8 @@ package com.simibubi.create.content.kinetics.turntable;
 
 import com.simibubi.create.AllBlocks;
 
-import net.createmod.catnip.animation.AnimationTickHolder;
 import net.createmod.catnip.math.VecHelper;
+import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.Mth;
@@ -12,8 +12,12 @@ import net.minecraft.world.phys.Vec3;
 
 public class TurntableHandler {
 
-	public static void gameRenderFrame() {
+	public static void gameRenderFrame(DeltaTracker deltaTracker) {
 		Minecraft mc = Minecraft.getInstance();
+
+		assert mc.player != null;
+		assert mc.level != null;
+
 		BlockPos pos = mc.player.blockPosition();
 
 		if (mc.gameMode == null)
@@ -29,7 +33,7 @@ public class TurntableHandler {
 		if (!(blockEntity instanceof TurntableBlockEntity turnTable))
 			return;
 
-		float speed = turnTable.getSpeed() * 3 / 10;
+		float speed = turnTable.getSpeed() * (2/3f) * deltaTracker.getRealtimeDeltaTicks();
 
 		if (speed == 0)
 			return;
@@ -38,10 +42,11 @@ public class TurntableHandler {
 		Vec3 offset = mc.player.position().subtract(origin);
 
 		if (offset.length() > 1 / 4f)
-			speed *= Mth.clamp((1 / 2f - offset.length()) * 2, 0, 1);
+			speed *= (float)Mth.clamp((1 / 2f - offset.length()) * 2, 0, 1);
 
-		mc.player.setYRot(mc.player.yRotO - speed * AnimationTickHolder.getPartialTicks());
-		mc.player.yBodyRot = mc.player.getYRot();
+		float yRotOffset = speed * deltaTracker.getGameTimeDeltaPartialTick(false);
+		mc.player.setYRot(mc.player.getYRot() - yRotOffset);
+		mc.player.yBodyRot -= yRotOffset;
 	}
 
 }

--- a/src/main/java/com/simibubi/create/content/kinetics/turntable/TurntableHandler.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/turntable/TurntableHandler.java
@@ -33,7 +33,8 @@ public class TurntableHandler {
 		if (!(blockEntity instanceof TurntableBlockEntity turnTable))
 			return;
 
-		float speed = turnTable.getSpeed() * (2/3f) * deltaTracker.getRealtimeDeltaTicks();
+		float tickSpeed = mc.level.tickRateManager().tickrate() / 20;
+		float speed = turnTable.getSpeed() * (2/3f) * tickSpeed * deltaTracker.getRealtimeDeltaTicks();
 
 		if (speed == 0)
 			return;

--- a/src/main/java/com/simibubi/create/foundation/events/ClientEvents.java
+++ b/src/main/java/com/simibubi/create/foundation/events/ClientEvents.java
@@ -105,6 +105,7 @@ import net.neoforged.neoforge.client.event.EntityRenderersEvent;
 import net.neoforged.neoforge.client.event.RegisterClientReloadListenersEvent;
 import net.neoforged.neoforge.client.event.RegisterGuiLayersEvent;
 import net.neoforged.neoforge.client.event.RegisterItemDecorationsEvent;
+import net.neoforged.neoforge.client.event.RenderFrameEvent;
 import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
 import net.neoforged.neoforge.client.event.RenderLevelStageEvent.Stage;
 import net.neoforged.neoforge.client.event.ViewportEvent;
@@ -282,19 +283,10 @@ public class ClientEvents {
 	}
 
 	@SubscribeEvent
-	public static void onRenderFramePre(ClientTickEvent.Pre event) {
-		onRenderFrame(true);
-	}
-
-	@SubscribeEvent
-	public static void onRenderFramePost(ClientTickEvent.Post event) {
-		onRenderFrame(false);
-	}
-
-	public static void onRenderFrame(boolean isPreEvent) {
+	public static void onRenderFrame(RenderFrameEvent.Pre event) {
 		if (!isGameActive())
 			return;
-		TurntableHandler.gameRenderFrame();
+		TurntableHandler.gameRenderFrame(event.getPartialTick());
 	}
 
 	@SubscribeEvent


### PR DESCRIPTION
This PR fixes Issue #8160, changing the events in `ClientEvents` to make `TurntableHandler` trigger on `RenderFrameEvent.Pre` instead of both `ClientTickEvent.Pre` and `ClientTickEvent.Post`.

It also slightly changes behavior in `TurntableHandler`, adding the y-rotation offset to the player's body instead of rotating the body to match the head. It also uses the DeltaTracker provided by `RenderFrameEvent` to make this behavior consistent across frame rates. Finally, it respects the `TickRateManager`'s tick rate, making the turntable turn slower when the tick rate is slowed down.