### PR TITLE
Fix contraption seat mapping packet encode CME

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/sync/ContraptionSeatMappingPacket.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/sync/ContraptionSeatMappingPacket.java
@@ -23,10 +23,14 @@ import net.neoforged.api.distmarker.OnlyIn;
 public record ContraptionSeatMappingPacket(int entityId, Map<UUID, Integer> mapping, int dismountedId) implements ClientboundPacketPayload {
 	public static final StreamCodec<ByteBuf, ContraptionSeatMappingPacket> STREAM_CODEC = StreamCodec.composite(
 			ByteBufCodecs.INT, ContraptionSeatMappingPacket::entityId,
-		ByteBufCodecs.map(HashMap::new, UUIDUtil.STREAM_CODEC, ByteBufCodecs.INT), p -> new HashMap<>(p.mapping),
+			ByteBufCodecs.map(HashMap::new, UUIDUtil.STREAM_CODEC, ByteBufCodecs.INT), ContraptionSeatMappingPacket::mapping,
 			ByteBufCodecs.INT, ContraptionSeatMappingPacket::dismountedId,
 	        ContraptionSeatMappingPacket::new
 	);
+
+	public ContraptionSeatMappingPacket {
+		mapping = Map.copyOf(mapping);
+	}
 
 	public ContraptionSeatMappingPacket(int entityID, Map<UUID, Integer> mapping) {
 		this(entityID, mapping, -1);

--- a/src/main/java/com/simibubi/create/content/contraptions/sync/ContraptionSeatMappingPacket.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/sync/ContraptionSeatMappingPacket.java
@@ -50,8 +50,7 @@ public record ContraptionSeatMappingPacket(int entityId, Map<UUID, Integer> mapp
 						.put("ContraptionDismountLocation", VecHelper.writeNBT(transformedVector));
 		}
 
-		contraptionEntity.getContraption()
-			.setSeatMapping(new HashMap<>(mapping));
+		contraptionEntity.getContraption().setSeatMapping(mapping);
 	}
 
 	@Override


### PR DESCRIPTION
Updated `ContraptionSeatMappingPacket` to snapshot the seat mapping on construction to prevent CME.

Have tested this for the last few days and no more player kicks. They used to occur every half hour. CPU/GC impact should be negligible.

Closes issue: #7919 