### PR TITLE
Improve /create trains and /create train command: Added schedule information and copy UUID on hover

### DIFF
--- a/src/main/java/com/simibubi/create/infrastructure/command/DumpRailwaysCommand.java
+++ b/src/main/java/com/simibubi/create/infrastructure/command/DumpRailwaysCommand.java
@@ -81,11 +81,10 @@ public class DumpRailwaysCommand {
 			chat.accept("Nearest Graphs: ", orange);
 			chat.accept("", white);
 			for (TrackGraph graph : nearest) {
-				chat.accept(graph.id.toString()
-					.substring(0, 5) + " with "
-					+ graph.getNodes()
-					.size()
-					+ " Nodes", white);
+				String fullGraphId = graph.id.toString();
+				Component graphLine = createClickableUuid(fullGraphId, white)
+					.append(Component.literal(" with " + graph.getNodes().size() + " Nodes").withColor(white));
+				chatRaw.accept(graphLine);
 				Collection<SignalBoundary> signals = graph.getPoints(EdgePointType.SIGNAL);
 				if (!signals.isEmpty())
 					chat.accept(" -> " + signals.size() + " Signals", blue);
@@ -113,16 +112,8 @@ public class DumpRailwaysCommand {
 			for (Train train : nearestTrains) {
 				// Create the train header with clickable UUID
 				String fullUuid = train.id.toString();
-				String shortUuid = fullUuid.substring(0, 5);
 				Component trainHeader = Component.literal("┬").withColor(bright)
-					.append(ComponentUtils.wrapInSquareBrackets(
-						Component.literal(shortUuid)
-							.withStyle(style -> style
-								.withColor(bright)
-								.withClickEvent(new ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, fullUuid))
-								.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, 
-									Component.literal("Click to copy full UUID:\n" + fullUuid))))
-					).withColor(bright))
+					.append(createClickableUuid(fullUuid, bright))
 					.append(Component.literal(String.format(": %s, %d Wagons",
 						train.name.getString(),
 						train.carriages.size()
@@ -130,9 +121,12 @@ public class DumpRailwaysCommand {
 				chatRaw.accept(trainHeader);
 				if (train.derailed)
 					chat.accept("├─Derailed", orange);
-				else if (train.graph != null)
-					chat.accept("├─On Track: " + train.graph.id.toString()
-						.substring(0, 5), blue);
+				else if (train.graph != null) {
+					String graphId = train.graph.id.toString();
+					Component trackLine = Component.literal("├─On Track: ").withColor(blue)
+						.append(createClickableUuid(graphId, blue));
+					chatRaw.accept(trackLine);
+				}
 				LivingEntity owner = train.getOwner(level);
 				if (owner != null)
 					chat.accept("├─Owned by " + owner.getName()
@@ -171,6 +165,18 @@ public class DumpRailwaysCommand {
 		}
 
 		chat.accept("-+--------------------------------+-", white);
+	}
+
+	private static Component createClickableUuid(String fullUuid, int color) {
+		String shortUuid = fullUuid.substring(0, 5);
+		return ComponentUtils.wrapInSquareBrackets(
+			Component.literal(shortUuid)
+				.withStyle(style -> style
+					.withColor(color)
+					.withClickEvent(new ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, fullUuid))
+					.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT,
+						Component.literal("Click to copy full UUID:\n" + fullUuid))))
+		);
 	}
 
 	private static Component createDeleteButton(Train train) {

--- a/src/main/java/com/simibubi/create/infrastructure/command/DumpRailwaysCommand.java
+++ b/src/main/java/com/simibubi/create/infrastructure/command/DumpRailwaysCommand.java
@@ -112,14 +112,16 @@ public class DumpRailwaysCommand {
 			chat.accept("", white);
 			for (Train train : nearestTrains) {
 				// Create the train header with clickable UUID
+				String fullUuid = train.id.toString();
+				String shortUuid = fullUuid.substring(0, 5);
 				Component trainHeader = Component.literal("┬").withColor(bright)
 					.append(ComponentUtils.wrapInSquareBrackets(
-						Component.literal(train.id.toString().substring(0, 5))
+						Component.literal(shortUuid)
 							.withStyle(style -> style
 								.withColor(bright)
-								.withClickEvent(new ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, train.id.toString()))
+								.withClickEvent(new ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, fullUuid))
 								.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, 
-									Component.literal("Click to copy full UUID:\n" + train.id.toString()))))
+									Component.literal("Click to copy full UUID:\n" + fullUuid))))
 					).withColor(bright))
 					.append(Component.literal(String.format(": %s, %d Wagons",
 						train.name.getString(),

--- a/src/main/java/com/simibubi/create/infrastructure/command/DumpRailwaysCommand.java
+++ b/src/main/java/com/simibubi/create/infrastructure/command/DumpRailwaysCommand.java
@@ -168,7 +168,7 @@ public class DumpRailwaysCommand {
 	}
 
 	private static Component createClickableUuid(String fullUuid, int color) {
-		String shortUuid = fullUuid.substring(0, 5);
+		String shortUuid = fullUuid.length() >= 5 ? fullUuid.substring(0, 5) : fullUuid;
 		return ComponentUtils.wrapInSquareBrackets(
 			Component.literal(shortUuid)
 				.withStyle(style -> style

--- a/src/main/java/com/simibubi/create/infrastructure/command/DumpRailwaysCommand.java
+++ b/src/main/java/com/simibubi/create/infrastructure/command/DumpRailwaysCommand.java
@@ -148,7 +148,7 @@ public class DumpRailwaysCommand {
 					chat.accept("├─In %1$s near [%2$s]".formatted(key.location(), train.getPositionInDimension(key).get().toShortString()), darkerBlue)
 				);
 				chatRaw.accept(createTeleportButton(train));
-
+				chatRaw.accept(createScheduleButton(train));
 				chatRaw.accept(createDeleteButton(train));
 				chat.accept("", white);
 			}
@@ -184,6 +184,20 @@ public class DumpRailwaysCommand {
 						.withColor(darkBlue)
 						.withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/c train tp " + train.id.toString()))
 						.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.literal("Click to teleport to ").append(train.name)));
+				}
+			)
+		);
+	}
+
+	private static Component createScheduleButton(Train train) {
+		return Component.literal("├─").withStyle(style -> style.withColor(darkBlue)).append(
+			ComponentUtils.wrapInSquareBrackets(
+				Component.literal("Schedule").withStyle(style -> style.withColor(orange))
+			).withStyle(style -> {
+					return style
+						.withColor(darkBlue)
+						.withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/c train " + train.id.toString() + " schedule"))
+						.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.literal("Click to view schedule of ").append(train.name)));
 				}
 			)
 		);

--- a/src/main/java/com/simibubi/create/infrastructure/command/DumpRailwaysCommand.java
+++ b/src/main/java/com/simibubi/create/infrastructure/command/DumpRailwaysCommand.java
@@ -196,7 +196,7 @@ public class DumpRailwaysCommand {
 			).withStyle(style -> {
 					return style
 						.withColor(darkBlue)
-						.withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/c train " + train.id.toString() + " schedule"))
+						.withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/c train schedule " + train.id.toString()))
 						.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.literal("Click to view schedule of ").append(train.name)));
 				}
 			)

--- a/src/main/java/com/simibubi/create/infrastructure/command/DumpRailwaysCommand.java
+++ b/src/main/java/com/simibubi/create/infrastructure/command/DumpRailwaysCommand.java
@@ -82,7 +82,8 @@ public class DumpRailwaysCommand {
 			chat.accept("", white);
 			for (TrackGraph graph : nearest) {
 				String fullGraphId = graph.id.toString();
-				Component graphLine = createClickableUuid(fullGraphId, white)
+				Component graphLine = Component.literal("") // literal is necessary or append doesn't work
+					.append(createClickableUuid(fullGraphId, white))
 					.append(Component.literal(" with " + graph.getNodes().size() + " Nodes").withColor(white));
 				chatRaw.accept(graphLine);
 				Collection<SignalBoundary> signals = graph.getPoints(EdgePointType.SIGNAL);

--- a/src/main/java/com/simibubi/create/infrastructure/command/DumpRailwaysCommand.java
+++ b/src/main/java/com/simibubi/create/infrastructure/command/DumpRailwaysCommand.java
@@ -111,11 +111,21 @@ public class DumpRailwaysCommand {
 			chat.accept("Nearest Trains: ", orange);
 			chat.accept("", white);
 			for (Train train : nearestTrains) {
-				chat.accept(String.format("┬%1$s: %2$s, %3$d Wagons",
-					train.id.toString().substring(0, 5),
-					train.name.getString(),
-					train.carriages.size()
-				), bright);
+				// Create the train header with clickable UUID
+				Component trainHeader = Component.literal("┬").withColor(bright)
+					.append(ComponentUtils.wrapInSquareBrackets(
+						Component.literal(train.id.toString().substring(0, 5))
+							.withStyle(style -> style
+								.withColor(bright)
+								.withClickEvent(new ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, train.id.toString()))
+								.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, 
+									Component.literal("Click to copy full UUID:\n" + train.id.toString()))))
+					).withColor(bright))
+					.append(Component.literal(String.format(": %s, %d Wagons",
+						train.name.getString(),
+						train.carriages.size()
+					)).withColor(bright));
+				chatRaw.accept(trainHeader);
 				if (train.derailed)
 					chat.accept("├─Derailed", orange);
 				else if (train.graph != null)

--- a/src/main/java/com/simibubi/create/infrastructure/command/TrainCommand.java
+++ b/src/main/java/com/simibubi/create/infrastructure/command/TrainCommand.java
@@ -23,6 +23,7 @@ import net.minecraft.commands.Commands;
 import net.minecraft.commands.arguments.UuidArgument;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
@@ -267,9 +268,9 @@ public class TrainCommand {
 					for (ScheduleWaitCondition condition : column) {
 						// Use getTitleAs to get full condition details
 						List<Component> conditionTitle = condition.getTitleAs("condition");
-						Component conditionLine = Component.literal("    - ").withColor(darkBlue);
+						MutableComponent conditionLine = Component.literal("    - ").withColor(darkBlue);
 						for (Component titlePart : conditionTitle) {
-							conditionLine = conditionLine.copy().append(titlePart);
+							conditionLine.append(titlePart);
 						}
 						message.add(conditionLine);
 					}

--- a/src/main/java/com/simibubi/create/infrastructure/command/TrainCommand.java
+++ b/src/main/java/com/simibubi/create/infrastructure/command/TrainCommand.java
@@ -24,6 +24,7 @@ import net.minecraft.commands.arguments.UuidArgument;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.chat.Style;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
@@ -52,6 +53,10 @@ public class TrainCommand {
 			.requires(cs -> cs.hasPermission(2))
 			.then(Commands.literal("remove")
 				.then(Commands.argument("train", UuidArgument.uuid())
+					.suggests((ctx, builder) -> {
+						builder.suggest("<UUID>");
+						return builder.buildFuture();
+					})
 					.executes(ctx -> runDelete(ctx.getSource(), UuidArgument.getUuid(ctx, "train")))
 				)
 				.then(Commands.literal("nearest")
@@ -59,6 +64,10 @@ public class TrainCommand {
 				)
 			).then(Commands.literal("tp")
 				.then(Commands.argument("train", UuidArgument.uuid())
+					.suggests((ctx, builder) -> {
+						builder.suggest("<UUID>");
+						return builder.buildFuture();
+					})
 					.requires(CommandSourceStack::isPlayer)
 					.executes(ctx -> runTeleport(ctx.getSource(), UuidArgument.getUuid(ctx, "train")))
 				)
@@ -68,6 +77,10 @@ public class TrainCommand {
 				)
 			).then(Commands.literal("schedule")
 				.then(Commands.argument("train", UuidArgument.uuid())
+					.suggests((ctx, builder) -> {
+						builder.suggest("<UUID>");
+						return builder.buildFuture();
+					})
 					.executes(ctx -> runSchedule(ctx.getSource(), UuidArgument.getUuid(ctx, "train")))
 				)
 				.then(Commands.literal("nearest")
@@ -270,7 +283,9 @@ public class TrainCommand {
 						List<Component> conditionTitle = condition.getTitleAs("condition");
 						MutableComponent conditionLine = Component.literal("    - ").withColor(darkBlue);
 						for (Component titlePart : conditionTitle) {
-							conditionLine.append(titlePart);
+							conditionLine.append(titlePart)
+								.append(" ") //This also adds a trailing space, meh
+							;
 						}
 						message.add(conditionLine);
 					}

--- a/src/main/java/com/simibubi/create/infrastructure/command/TrainCommand.java
+++ b/src/main/java/com/simibubi/create/infrastructure/command/TrainCommand.java
@@ -9,7 +9,12 @@ import com.mojang.brigadier.builder.ArgumentBuilder;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.simibubi.create.Create;
 import com.simibubi.create.content.trains.entity.Train;
+import com.simibubi.create.content.trains.schedule.Schedule;
+import com.simibubi.create.content.trains.schedule.ScheduleEntry;
+import com.simibubi.create.content.trains.schedule.condition.ScheduleWaitCondition;
+import com.simibubi.create.content.trains.schedule.destination.ScheduleInstruction;
 
+import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.commands.arguments.UuidArgument;
@@ -34,6 +39,10 @@ public class TrainCommand {
 				.then(Commands.argument("train", UuidArgument.uuid())
 					.requires(CommandSourceStack::isPlayer)
 					.executes(ctx -> runTeleport(ctx.getSource(), UuidArgument.getUuid(ctx, "train")))
+				)
+			).then(Commands.argument("train", UuidArgument.uuid())
+				.then(Commands.literal("schedule")
+					.executes(ctx -> runSchedule(ctx.getSource(), UuidArgument.getUuid(ctx, "train")))
 				)
 			);
 	}
@@ -100,6 +109,101 @@ public class TrainCommand {
             return Component.literal("Teleported to Train '").append(train.name)
                 .append("' successfully");
         }, true);
+		return Command.SINGLE_SUCCESS;
+	}
+
+	private static int runSchedule(CommandSourceStack source, UUID argument) {
+		Train train = Create.RAILWAYS.trains.get(argument);
+		if (train == null) {
+			source.sendFailure(Component.literal("No Train with id " + argument.toString()
+				.substring(0, 5) + "[...] was found"));
+			return 0;
+		}
+
+		Schedule schedule = train.runtime.getSchedule();
+		if (schedule == null) {
+			source.sendFailure(Component.literal("Train '").append(train.name)
+				.append("' has no schedule"));
+			return 0;
+		}
+
+		// Print schedule header
+		source.sendSuccess(() -> {
+			return Component.literal("").append(Component.literal("─────< Schedule for Train '")
+				.withStyle(ChatFormatting.WHITE))
+				.append(train.name)
+				.append(Component.literal("' >─────").withStyle(ChatFormatting.WHITE));
+		}, false);
+
+		// Print cyclic status
+		source.sendSuccess(() -> {
+			return Component.literal("Cyclic: " + (schedule.cyclic ? "Yes" : "No"))
+				.withStyle(ChatFormatting.GRAY);
+		}, false);
+
+		// Print current entry
+		source.sendSuccess(() -> {
+			return Component.literal("Current Entry: " + train.runtime.currentEntry + " / " + (schedule.entries.size() - 1))
+				.withStyle(ChatFormatting.GRAY);
+		}, false);
+
+		// Print state
+		source.sendSuccess(() -> {
+			return Component.literal("State: " + train.runtime.state.name())
+				.withStyle(ChatFormatting.GRAY);
+		}, false);
+
+		source.sendSuccess(() -> Component.literal(""), false);
+
+		// Print each schedule entry
+		for (int i = 0; i < schedule.entries.size(); i++) {
+			final int index = i;
+			boolean isCurrent = i == train.runtime.currentEntry;
+			ScheduleEntry entry = schedule.entries.get(i);
+			ScheduleInstruction instruction = entry.instruction;
+
+			// Entry header
+			source.sendSuccess(() -> {
+				Component prefix = Component.literal((isCurrent ? "→ " : "  ") + "Entry " + index + ": ")
+					.withStyle(isCurrent ? ChatFormatting.YELLOW : ChatFormatting.WHITE);
+				Component summary = instruction.getSummary().getSecond();
+				return prefix.copy().append(summary);
+			}, false);
+
+			// Print conditions
+			if (instruction.supportsConditions() && !entry.conditions.isEmpty()) {
+				for (int columnIndex = 0; columnIndex < entry.conditions.size(); columnIndex++) {
+					List<ScheduleWaitCondition> column = entry.conditions.get(columnIndex);
+					final int col = columnIndex;
+					
+					source.sendSuccess(() -> {
+						return Component.literal("  Condition Group " + col + ":")
+							.withStyle(ChatFormatting.DARK_GRAY);
+					}, false);
+					
+					for (int condIndex = 0; condIndex < column.size(); condIndex++) {
+						ScheduleWaitCondition condition = column.get(condIndex);
+						source.sendSuccess(() -> {
+							Component summary = condition.getSummary().getSecond();
+							return Component.literal("    - ").withStyle(ChatFormatting.DARK_GRAY)
+								.append(summary);
+						}, false);
+					}
+				}
+			}
+
+			// Add spacing between entries
+			if (i < schedule.entries.size() - 1) {
+				source.sendSuccess(() -> Component.literal(""), false);
+			}
+		}
+
+		// Print footer
+		source.sendSuccess(() -> {
+			return Component.literal("─────────────────────────────────")
+				.withStyle(ChatFormatting.WHITE);
+		}, false);
+
 		return Command.SINGLE_SUCCESS;
 	}
 

--- a/src/main/java/com/simibubi/create/infrastructure/command/TrainCommand.java
+++ b/src/main/java/com/simibubi/create/infrastructure/command/TrainCommand.java
@@ -13,6 +13,8 @@ import com.simibubi.create.content.trains.entity.Train;
 import com.simibubi.create.content.trains.schedule.Schedule;
 import com.simibubi.create.content.trains.schedule.ScheduleEntry;
 import com.simibubi.create.content.trains.schedule.condition.ScheduleWaitCondition;
+import com.simibubi.create.content.trains.schedule.destination.DeliverPackagesInstruction;
+import com.simibubi.create.content.trains.schedule.destination.FetchPackagesInstruction;
 import com.simibubi.create.content.trains.schedule.destination.ScheduleInstruction;
 
 import net.minecraft.ChatFormatting;
@@ -183,29 +185,44 @@ public class TrainCommand {
 			boolean isCurrent = i == train.runtime.currentEntry;
 			ScheduleEntry entry = schedule.entries.get(i);
 			ScheduleInstruction instruction = entry.instruction;
+			// Build entry summary with proper name (translated title + content)
+			Component title = Component.translatable("create.schedule.instruction." + instruction.getId().getPath());
 
-			// Entry header
-			Component prefix = Component.literal("┬Entry " + i + ": " + (isCurrent ? "[ACTIVE]" : ""))
+			Component summary;
+			// Special handling for Retrieve Package so information is not lost.
+			if (instruction instanceof FetchPackagesInstruction retrieve) {
+				Component target = Component.nullToEmpty(retrieve.getFilter());
+				summary = title.copy().append(Component.literal(": ")).append(target);
+			}
+			else if (instruction instanceof DeliverPackagesInstruction){
+				summary = title; //Deliver instructions have no content
+			}
+			else{
+				Component content = instruction.getSummary().getSecond();
+				summary = title.copy().append(Component.literal(": ")).append(content);
+			}
+
+			// Entry header with [ACTIVE] at the end
+			Component prefix = Component.literal((isCurrent ? "-> " : "") + "Entry " + i + ": ")
 				.withColor(isCurrent ? orange : white);
-			Component summary = instruction.getSummary().getSecond();
-			message.add(prefix.copy().append(summary));
+			Component active = isCurrent ? Component.literal(" [ACTIVE]").withColor(orange) : Component.literal("");
+			message.add(prefix.copy().append(summary).append(active));
 
-			// Add conditions
-			if (instruction.supportsConditions() && !entry.conditions.isEmpty()) {
+			// Add conditions with simple indented structure
+			boolean hasConditions = instruction.supportsConditions() && !entry.conditions.isEmpty();
+			if (hasConditions) {
 				for (int columnIndex = 0; columnIndex < entry.conditions.size(); columnIndex++) {
-					List<ScheduleWaitCondition> column = entry.conditions.get(columnIndex);
-					message.add(Component.literal("├─Condition Group " + columnIndex + ":")
+					message.add(Component.literal("  Condition Group " + columnIndex + ":")
 						.withColor(blue));
-
+					List<ScheduleWaitCondition> column = entry.conditions.get(columnIndex);
 					for (ScheduleWaitCondition condition : column) {
 						Component conditionSummary = condition.getSummary().getSecond();
-						message.add(Component.literal("├──")
+						message.add(Component.literal("    - ")
 							.withColor(darkBlue)
 							.append(conditionSummary));
 					}
 				}
 			}
-
 			if (i < schedule.entries.size() - 1) {
 				message.add(Component.literal("")); // Blank line between entries
 			}
@@ -215,6 +232,7 @@ public class TrainCommand {
 		String footer = "-".repeat(Math.max(headerLength-6, 5));
 		message.add(Component.literal(footer)
 			.withColor(white));
+
 
 		return message;
 	}

--- a/src/main/java/com/simibubi/create/infrastructure/command/TrainCommand.java
+++ b/src/main/java/com/simibubi/create/infrastructure/command/TrainCommand.java
@@ -1,5 +1,6 @@
 package com.simibubi.create.infrastructure.command;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -27,6 +28,20 @@ import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.Level;
 
 public class TrainCommand {
+
+	// duplicate of DumpRailwaysCommand.java, should really be unified
+	private static final int white = ChatFormatting.WHITE.getColor();
+	private static final int blue = 0xaac8e0;
+	//private static final int blue = 0xD3DEDC;
+	private static final int darkBlue = 0x88a5b7;
+	//private static final int darkBlue = 0x92A9BD;
+	private static final int darkerBlue = 0x6b8694;
+	private static final int darkestBlue = 0x536b75;
+	private static final int bright = 0xFFEFEF;
+	private static final int orange = 0xFFAD60;
+	//custom additions
+	private static final int green = 0xb5fb99;
+	private static final int red = 0xe08894;
 
 	static ArgumentBuilder<CommandSourceStack, ?> register() {
 		return Commands.literal("train")
@@ -127,84 +142,81 @@ public class TrainCommand {
 			return 0;
 		}
 
-		// Print schedule header
-		source.sendSuccess(() -> {
-			return Component.literal("").append(Component.literal("─────< Schedule for Train '")
-				.withStyle(ChatFormatting.WHITE))
-				.append(train.name)
-				.append(Component.literal("' >─────").withStyle(ChatFormatting.WHITE));
-		}, false);
+		// Build the message
+		List<Component> message = buildScheduleMessage(train, schedule);
 
-		// Print cyclic status
-		source.sendSuccess(() -> {
-			return Component.literal("Cyclic: " + (schedule.cyclic ? "Yes" : "No"))
-				.withStyle(ChatFormatting.GRAY);
-		}, false);
+		// Send each line to chat
+		for (Component line : message) {
+			source.sendSuccess(() -> line, true);
+		}
 
-		// Print current entry
-		source.sendSuccess(() -> {
-			return Component.literal("Current Entry: " + train.runtime.currentEntry + " / " + (schedule.entries.size() - 1))
-				.withStyle(ChatFormatting.GRAY);
-		}, false);
+		return Command.SINGLE_SUCCESS;
+	}
 
-		// Print state
-		source.sendSuccess(() -> {
-			return Component.literal("State: " + train.runtime.state.name())
-				.withStyle(ChatFormatting.GRAY);
-		}, false);
+	private static List<Component> buildScheduleMessage(Train train, Schedule schedule) {
+		List<Component> message = new ArrayList<>();
 
-		source.sendSuccess(() -> Component.literal(""), false);
+		// Add schedule header
+		message.add(Component.literal("").append(Component.literal("-+---<< Schedule for Train '"))
+			.append(train.name)
+			.append(Component.literal("' >>---+-").withColor(white)));
+		int headerLength = message.get(0).getString().length();
 
-		// Print each schedule entry
+		// Add cyclic status
+		message.add(Component.literal("Cyclic: ")
+			.append(Component.literal(schedule.cyclic ? "Yes" : "No")
+				.withColor(schedule.cyclic ? green : red))
+			.withColor(blue));
+
+		// Add current entry
+		message.add(Component.literal("Current Entry: " + train.runtime.currentEntry + " / " + (schedule.entries.size() - 1))
+			.withColor(blue));
+
+		// Add state
+		message.add(Component.literal("State: " + train.runtime.state.name())
+			.withColor(blue));
+
+		message.add(Component.literal("")); // Blank line
+
+		// Add each schedule entry
 		for (int i = 0; i < schedule.entries.size(); i++) {
-			final int index = i;
 			boolean isCurrent = i == train.runtime.currentEntry;
 			ScheduleEntry entry = schedule.entries.get(i);
 			ScheduleInstruction instruction = entry.instruction;
 
 			// Entry header
-			source.sendSuccess(() -> {
-				Component prefix = Component.literal((isCurrent ? "→ " : "  ") + "Entry " + index + ": ")
-					.withStyle(isCurrent ? ChatFormatting.YELLOW : ChatFormatting.WHITE);
-				Component summary = instruction.getSummary().getSecond();
-				return prefix.copy().append(summary);
-			}, false);
+			Component prefix = Component.literal("┬Entry " + i + ": " + (isCurrent ? "[ACTIVE]" : ""))
+				.withColor(isCurrent ? orange : white);
+			Component summary = instruction.getSummary().getSecond();
+			message.add(prefix.copy().append(summary));
 
-			// Print conditions
+			// Add conditions
 			if (instruction.supportsConditions() && !entry.conditions.isEmpty()) {
 				for (int columnIndex = 0; columnIndex < entry.conditions.size(); columnIndex++) {
 					List<ScheduleWaitCondition> column = entry.conditions.get(columnIndex);
-					final int col = columnIndex;
-					
-					source.sendSuccess(() -> {
-						return Component.literal("  Condition Group " + col + ":")
-							.withStyle(ChatFormatting.DARK_GRAY);
-					}, false);
-					
-					for (int condIndex = 0; condIndex < column.size(); condIndex++) {
-						ScheduleWaitCondition condition = column.get(condIndex);
-						source.sendSuccess(() -> {
-							Component summary = condition.getSummary().getSecond();
-							return Component.literal("    - ").withStyle(ChatFormatting.DARK_GRAY)
-								.append(summary);
-						}, false);
+					message.add(Component.literal("├─Condition Group " + columnIndex + ":")
+						.withColor(blue));
+
+					for (ScheduleWaitCondition condition : column) {
+						Component conditionSummary = condition.getSummary().getSecond();
+						message.add(Component.literal("├──")
+							.withColor(darkBlue)
+							.append(conditionSummary));
 					}
 				}
 			}
 
-			// Add spacing between entries
 			if (i < schedule.entries.size() - 1) {
-				source.sendSuccess(() -> Component.literal(""), false);
+				message.add(Component.literal("")); // Blank line between entries
 			}
 		}
 
-		// Print footer
-		source.sendSuccess(() -> {
-			return Component.literal("─────────────────────────────────")
-				.withStyle(ChatFormatting.WHITE);
-		}, false);
+		// Add footer (length cropped due to non-monospace font, best guess)
+		String footer = "-".repeat(Math.max(headerLength-6, 5));
+		message.add(Component.literal(footer)
+			.withColor(white));
 
-		return Command.SINGLE_SUCCESS;
+		return message;
 	}
 
 }

--- a/src/main/java/com/simibubi/create/infrastructure/command/TrainCommand.java
+++ b/src/main/java/com/simibubi/create/infrastructure/command/TrainCommand.java
@@ -265,10 +265,13 @@ public class TrainCommand {
 						.withColor(blue));
 					List<ScheduleWaitCondition> column = entry.conditions.get(columnIndex);
 					for (ScheduleWaitCondition condition : column) {
-						Component conditionSummary = condition.getSummary().getSecond();
-						message.add(Component.literal("    - ")
-							.withColor(darkBlue)
-							.append(conditionSummary));
+						// Use getTitleAs to get full condition details
+						List<Component> conditionTitle = condition.getTitleAs("condition");
+						Component conditionLine = Component.literal("    - ").withColor(darkBlue);
+						for (Component titlePart : conditionTitle) {
+							conditionLine = conditionLine.copy().append(titlePart);
+						}
+						message.add(conditionLine);
 					}
 				}
 			}

--- a/src/main/java/com/simibubi/create/infrastructure/command/TrainCommand.java
+++ b/src/main/java/com/simibubi/create/infrastructure/command/TrainCommand.java
@@ -28,6 +28,7 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
 
 public class TrainCommand {
 
@@ -194,12 +195,12 @@ public class TrainCommand {
 
 	private static Train findNearestTrain(CommandSourceStack source) {
 		ServerLevel level = source.getLevel();
+		Vec3 position = source.getPosition();
 		return Create.RAILWAYS.trains.values()
 			.stream()
-			.sorted((t1, t2) -> Float.compare(
-				t1.distanceToLocationSqr(level, source.getPosition()),
-				t2.distanceToLocationSqr(level, source.getPosition())))
-			.findFirst()
+			.min((t1, t2) -> Float.compare(
+				t1.distanceToLocationSqr(level, position),
+				t2.distanceToLocationSqr(level, position)))
 			.orElse(null);
 	}
 

--- a/src/main/java/com/simibubi/create/infrastructure/command/TrainCommand.java
+++ b/src/main/java/com/simibubi/create/infrastructure/command/TrainCommand.java
@@ -40,8 +40,8 @@ public class TrainCommand {
 					.requires(CommandSourceStack::isPlayer)
 					.executes(ctx -> runTeleport(ctx.getSource(), UuidArgument.getUuid(ctx, "train")))
 				)
-			).then(Commands.argument("train", UuidArgument.uuid())
-				.then(Commands.literal("schedule")
+			).then(Commands.literal("schedule")
+				.then(Commands.argument("train", UuidArgument.uuid())
 					.executes(ctx -> runSchedule(ctx.getSource(), UuidArgument.getUuid(ctx, "train")))
 				)
 			);

--- a/src/main/java/com/simibubi/create/infrastructure/command/TrainCommand.java
+++ b/src/main/java/com/simibubi/create/infrastructure/command/TrainCommand.java
@@ -52,14 +52,24 @@ public class TrainCommand {
 				.then(Commands.argument("train", UuidArgument.uuid())
 					.executes(ctx -> runDelete(ctx.getSource(), UuidArgument.getUuid(ctx, "train")))
 				)
+				.then(Commands.literal("nearest")
+					.executes(ctx -> runDeleteNearest(ctx.getSource()))
+				)
 			).then(Commands.literal("tp")
 				.then(Commands.argument("train", UuidArgument.uuid())
 					.requires(CommandSourceStack::isPlayer)
 					.executes(ctx -> runTeleport(ctx.getSource(), UuidArgument.getUuid(ctx, "train")))
 				)
+				.then(Commands.literal("nearest")
+					.requires(CommandSourceStack::isPlayer)
+					.executes(ctx -> runTeleportNearest(ctx.getSource()))
+				)
 			).then(Commands.literal("schedule")
 				.then(Commands.argument("train", UuidArgument.uuid())
 					.executes(ctx -> runSchedule(ctx.getSource(), UuidArgument.getUuid(ctx, "train")))
+				)
+				.then(Commands.literal("nearest")
+					.executes(ctx -> runScheduleNearest(ctx.getSource()))
 				)
 			);
 	}
@@ -78,6 +88,15 @@ public class TrainCommand {
                 .append("' removed successfully");
         }, true);
 		return Command.SINGLE_SUCCESS;
+	}
+
+	private static int runDeleteNearest(CommandSourceStack source) {
+		Train train = findNearestTrain(source);
+		if (train == null) {
+			source.sendFailure(Component.literal("No trains found nearby"));
+			return 0;
+		}
+		return runDelete(source, train.id);
 	}
 
 	private static int runTeleport(CommandSourceStack source, UUID argument) throws CommandSyntaxException {
@@ -129,6 +148,15 @@ public class TrainCommand {
 		return Command.SINGLE_SUCCESS;
 	}
 
+	private static int runTeleportNearest(CommandSourceStack source) throws CommandSyntaxException {
+		Train train = findNearestTrain(source);
+		if (train == null) {
+			source.sendFailure(Component.literal("No trains found nearby"));
+			return 0;
+		}
+		return runTeleport(source, train.id);
+	}
+
 	private static int runSchedule(CommandSourceStack source, UUID argument) {
 		Train train = Create.RAILWAYS.trains.get(argument);
 		if (train == null) {
@@ -153,6 +181,26 @@ public class TrainCommand {
 		}
 
 		return Command.SINGLE_SUCCESS;
+	}
+
+	private static int runScheduleNearest(CommandSourceStack source) {
+		Train train = findNearestTrain(source);
+		if (train == null) {
+			source.sendFailure(Component.literal("No trains found nearby"));
+			return 0;
+		}
+		return runSchedule(source, train.id);
+	}
+
+	private static Train findNearestTrain(CommandSourceStack source) {
+		ServerLevel level = source.getLevel();
+		return Create.RAILWAYS.trains.values()
+			.stream()
+			.sorted((t1, t2) -> Float.compare(
+				t1.distanceToLocationSqr(level, source.getPosition()),
+				t2.distanceToLocationSqr(level, source.getPosition())))
+			.findFirst()
+			.orElse(null);
 	}
 
 	private static List<Component> buildScheduleMessage(Train train, Schedule schedule) {


### PR DESCRIPTION
I made a few changes to the ``/create trains`` and ``/create train`` debug commands. 

The changes were largely motivated by my server building a relatively large and complex train network that likes to have some problems that are hard to debug. Further PRs to fix some of these bugs will likely follow.

While a large part of it was written with help of Claude Sonnet 4.5, I have verified all code manually to the best of my ability and tested all changes in game. This PR was also written by me.



## Change 1:
``/create train <...> nearest`` allows a player to use the create train command to target a single train without having to know the full UUID. As there are now two entries for input options, the code suggestion was edited such that `nearest` or `<UUID>` are displayed in game.

<img width="649" height="152" alt="grafik" src="https://github.com/user-attachments/assets/f7d521d5-cb59-4d02-8600-ac208a975de3" />


## Change 2:
``/create train schedule <...>`` allows a player to dump the full schedule a train currently has into the chat for debugging. This became necessary as an auto schedule assigned to a train by a station with a schedule on top can not be taken off the train and then read by the player. As such, this is the only way to understand what a train with an auto schedule is even trying to do. 

<img width="1377" height="756" alt="grafik" src="https://github.com/user-attachments/assets/ea878640-a69c-4c6e-b212-e3a4d7542b61" />
<sub>Note that the weird printout of players seated is caused by a bug reported in #9866</sub>


## Change 3:
``/create trains`` was amended to include a button to display the schedule for this train.

<img width="1021" height="316" alt="grafik" src="https://github.com/user-attachments/assets/ccbab682-320b-47a9-bcb5-6b9adb5df113" />


## Change 4:
``/create trains`` was extended to allow copying of the full UUID when hovering over it. This applies to all UUIDs including graph, track edge and train. When a UUID is clicked it is copied to the clipboard for further use, for example in the ``/create train`` command.

<img width="1194" height="447" alt="grafik" src="https://github.com/user-attachments/assets/1c5cfb30-bc6c-44f2-96b3-f2687bd2b351" />


# Things I came across while editing the codebase:

- [Permalink](https://github.com/Creators-of-Create/Create/blob/f2a0e5931ea5b62d7d6d5846752bc95c8adb4bd6/src/main/java/com/simibubi/create/infrastructure/command/DumpRailwaysCommand.java#L44) The dump schedule command uses a really complex way of sending specific chat to specific places, when a for loop using ``sendSuccess()`` appears to work pretty well. It does print twice in the dev console as chat log and server chat log, but that seems acceptable. 
- The custom colors are hard-coded into DumpRailwaysCommand.java [link](https://github.com/Creators-of-Create/Create/blob/f2a0e5931ea5b62d7d6d5846752bc95c8adb4bd6/src/main/java/com/simibubi/create/infrastructure/command/DumpRailwaysCommand.java#L34) instead of being available in a public style guide. A future addition may want to extract these. I have copied the colors to TrainCommand.java and added two extra colors I needed to make it work. 
- Create has a bug, the tooltip when hovering a players seated schedule condition does not show whether it is configured to be an exact match or a greater than match. This disagrees with the implementation used for liquids, items, etc. I have opened an issue regarding this as #9866 
- with now three buttons under each train in /create trains it may be worth considering moving the teleport button to the coordinate display that is present anyways, coloring the coordinates themselves orange and making them clickable.
- The truncated UUID printing may be present in other debug commands. I did not go looking too far here. The copy on click feature should likely be extended to all of them.