### PR TITLE
Fix trains overrunning stations and being unable to pathfind to current station

### DIFF
--- a/src/main/java/com/simibubi/create/content/trains/entity/Navigation.java
+++ b/src/main/java/com/simibubi/create/content/trains/entity/Navigation.java
@@ -235,11 +235,10 @@ public class Navigation {
 		double targetDistance = waitingForSignal != null ? distanceToSignal : distanceToDestination;
 
 		// Always overshoot for signals to ensure the travelling point crosses them
-		// But DON'T overshoot for stations - the frontSignalListener handles precise stops
+		// don't overshoot for stations - frontSignalListener handles stopping
 		if (waitingForSignal != null) {
-			targetDistance += 0.25d;  // Only add overshoot for signals, not stations
+			targetDistance += 0.25d;
 		}
-		// For stations (destination != null && waitingForSignal == null), use exact distance
 
 		// dont leave until green light
 		if (targetDistance > 1 / 32f && train.getCurrentStation() != null) {

--- a/src/main/java/com/simibubi/create/content/trains/entity/Navigation.java
+++ b/src/main/java/com/simibubi/create/content/trains/entity/Navigation.java
@@ -234,8 +234,12 @@ public class Navigation {
 
 		double targetDistance = waitingForSignal != null ? distanceToSignal : distanceToDestination;
 
-		// always overshoot to ensure the travelling point crosses the target
-		targetDistance += 0.25d;
+		// Always overshoot for signals to ensure the travelling point crosses them
+		// But DON'T overshoot for stations - the frontSignalListener handles precise stops
+		if (waitingForSignal != null) {
+			targetDistance += 0.25d;  // Only add overshoot for signals, not stations
+		}
+		// For stations (destination != null && waitingForSignal == null), use exact distance
 
 		// dont leave until green light
 		if (targetDistance > 1 / 32f && train.getCurrentStation() != null) {


### PR DESCRIPTION
This PR fixes an issue where in very specific rail network shapes a train could overrun the station it intended to stop at by a minuscule amount. If the train was given a looping schedule sending it only to the station it is currently stopped at (and there was another station of the same name in the network), the train would discard its current station from the pathfinding calculation as it was technically behind it on the initial edge of the graph, and thus the train would leave towards the other station with the same name despite already being at a valid target. 

This fix is implemented by selectively patching out a seeming bodge that makes trains always overshoot their target by 0.25 blocks. Testing on my end has not shown any change in behavior (other than stations working correctly) from patching this overshoot code out when a train is approaching a station instead of a signal. It is possible that the bodge could be removed completely, but this was the minimum possible to fix the current issue.