### PR TITLE
Fix schedules not stacking after copy recipe

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/recipe/ItemCopyingRecipe.java
+++ b/src/main/java/com/simibubi/create/foundation/recipe/ItemCopyingRecipe.java
@@ -13,13 +13,14 @@ import net.minecraft.world.item.crafting.CraftingBookCategory;
 import net.minecraft.world.item.crafting.CraftingInput;
 import net.minecraft.world.item.crafting.CustomRecipe;
 import net.minecraft.world.item.crafting.RecipeSerializer;
+import net.minecraft.world.item.enchantment.ItemEnchantments;
 import net.minecraft.world.level.Level;
 
 public class ItemCopyingRecipe extends CustomRecipe {
 	public interface SupportsItemCopying {
 		default ItemStack createCopy(ItemStack original, int count) {
 			ItemStack copyWithCount = original.copyWithCount(count);
-			copyWithCount.remove(DataComponents.ENCHANTMENTS);
+			copyWithCount.set(DataComponents.ENCHANTMENTS, ItemEnchantments.EMPTY);
 			copyWithCount.remove(DataComponents.STORED_ENCHANTMENTS);
 			return copyWithCount;
 		}


### PR DESCRIPTION
Related https://github.com/Creators-of-Create/Create/issues/9485

This bug was introduced in https://github.com/Creators-of-Create/Create/commit/6d1e38192f664d65074b9d2894641b579f84ae32 which released with 6.0.7. This PR reverts a change made in that commit, I'm not entirely sure why this change was made, so any insight would be nice if this is not a valid fix.

Thanks,
Jensen