### PR TITLE
Prioritize filling depots during postbox package loading

### DIFF
--- a/src/main/java/com/simibubi/create/content/trains/station/GlobalStation.java
+++ b/src/main/java/com/simibubi/create/content/trains/station/GlobalStation.java
@@ -1,6 +1,7 @@
 package com.simibubi.create.content.trains.station;
 
 import java.lang.ref.WeakReference;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -8,8 +9,10 @@ import java.util.Map.Entry;
 import org.jetbrains.annotations.Nullable;
 
 import com.simibubi.create.Create;
+import com.simibubi.create.api.contraption.storage.item.MountedItemStorage;
 import com.simibubi.create.content.logistics.box.PackageItem;
 import com.simibubi.create.content.logistics.packagePort.postbox.PostboxBlockEntity;
+import com.simibubi.create.content.logistics.depot.storage.DepotMountedStorage;
 import com.simibubi.create.compat.computercraft.events.PackageEvent;
 import com.simibubi.create.content.trains.entity.Carriage;
 import com.simibubi.create.content.trains.entity.Train;
@@ -163,6 +166,16 @@ public class GlobalStation extends SingleBlockEntityEdgePoint {
 		return this.nearestTrain.get();
 	}
 
+	private ItemStack putPackageOntoTrain(IItemHandlerModifiable carriageInv, ArrayList<DepotMountedStorage> depots, ItemStack stack){
+		for (DepotMountedStorage depot : depots){
+			ItemStack result = depot.insertItem(0, stack, false);
+			if (result.isEmpty())
+				return result;
+		}
+
+		return ItemHandlerHelper.insertItemStacked(carriageInv, stack, false);
+	}
+
 	public void runMailTransfer() {
 		Train train = getPresentTrain();
 		if (train == null || connectedPorts.isEmpty())
@@ -170,6 +183,15 @@ public class GlobalStation extends SingleBlockEntityEdgePoint {
 
 		MinecraftServer server = ServerLifecycleHooks.getCurrentServer();
 		Level level = server.getLevel(getBlockEntityDimension());
+
+		ArrayList<DepotMountedStorage> depots = new ArrayList<>();
+		for (Carriage carriage : train.carriages) {
+			for (MountedItemStorage storage : carriage.storage.getAllItemStorages().values()) {
+				if (storage instanceof DepotMountedStorage depot) {
+					depots.add(depot);
+				}
+			}
+		}
 
 		for (Carriage carriage : train.carriages) {
 			IItemHandlerModifiable carriageInventory = carriage.storage.getAllItems();
@@ -196,7 +218,7 @@ public class GlobalStation extends SingleBlockEntityEdgePoint {
 					if (PackageItem.matchAddress(stack, port.address))
 						continue;
 
-					ItemStack result = ItemHandlerHelper.insertItemStacked(carriageInventory, stack, false);
+					ItemStack result = putPackageOntoTrain(carriageInventory, depots, stack);
 					if (box != null)
 						box.computerBehaviour.prepareComputerEvent(new PackageEvent(stack, "package_sent"));
 					if (!result.isEmpty())
@@ -256,6 +278,7 @@ public class GlobalStation extends SingleBlockEntityEdgePoint {
 			}
 
 		}
+		depots.clear();
 	}
 
 }


### PR DESCRIPTION
Originally part of https://github.com/Creators-of-Create/Create/pull/9826

Postboxes will now prioritize filling depots across all carriages before any other inventories. I did this just for visual purposes as they can physically be seen which is quite nice, and before this if we have a fuel barrel etc the packages would fill that first, which made all our trains look empty. Unloading logic is unmodified.

Let me know if there's anything I need to change or if you have any ideas to how it could be improved.

Thanks,
Jensen