### PR TITLE
Postbox package transfer rate

### DIFF
--- a/src/main/java/com/simibubi/create/content/trains/station/GlobalStation.java
+++ b/src/main/java/com/simibubi/create/content/trains/station/GlobalStation.java
@@ -16,6 +16,7 @@ import com.simibubi.create.content.trains.entity.Train;
 import com.simibubi.create.content.trains.graph.DimensionPalette;
 import com.simibubi.create.content.trains.graph.TrackNode;
 import com.simibubi.create.content.trains.signal.SingleBlockEntityEdgePoint;
+import com.simibubi.create.infrastructure.config.AllConfigs;
 
 import net.createmod.catnip.nbt.NBTHelper;
 import net.minecraft.core.BlockPos;
@@ -171,6 +172,9 @@ public class GlobalStation extends SingleBlockEntityEdgePoint {
 		MinecraftServer server = ServerLifecycleHooks.getCurrentServer();
 		Level level = server.getLevel(getBlockEntityDimension());
 
+		int maxPackagesPerTransfer = AllConfigs.server().logistics.postboxTransferRate.get();
+		int packagesTransferred = 0;
+
 		for (Carriage carriage : train.carriages) {
 			IItemHandlerModifiable carriageInventory = carriage.storage.getAllItems();
 			if (carriageInventory == null)
@@ -190,6 +194,8 @@ public class GlobalStation extends SingleBlockEntityEdgePoint {
 				}
 
 				for (int slot = 0; slot < postboxInventory.getSlots(); slot++) {
+					if (packagesTransferred >= maxPackagesPerTransfer)
+						return;
 					ItemStack stack = postboxInventory.getStackInSlot(slot);
 					if (!PackageItem.isPackage(stack))
 						continue;
@@ -203,6 +209,7 @@ public class GlobalStation extends SingleBlockEntityEdgePoint {
 						continue;
 
 					postboxInventory.setStackInSlot(slot, ItemStack.EMPTY);
+					packagesTransferred++;
 
 					if (box == null) {
 						port.primed = true;
@@ -221,6 +228,8 @@ public class GlobalStation extends SingleBlockEntityEdgePoint {
 					continue;
 
 				for (Entry<BlockPos, GlobalPackagePort> entry : connectedPorts.entrySet()) {
+					if (packagesTransferred >= maxPackagesPerTransfer)
+						return;
 					GlobalPackagePort port = entry.getValue();
 					BlockPos pos = entry.getKey();
 					PostboxBlockEntity box = null;
@@ -242,6 +251,7 @@ public class GlobalStation extends SingleBlockEntityEdgePoint {
 						continue;
 
 					carriageInventory.setStackInSlot(slot, ItemStack.EMPTY);
+					packagesTransferred++;
 
 					if (box == null) {
 						port.primed = true;

--- a/src/main/java/com/simibubi/create/infrastructure/config/CLogistics.java
+++ b/src/main/java/com/simibubi/create/infrastructure/config/CLogistics.java
@@ -16,6 +16,7 @@ public class CLogistics extends ConfigBase {
 	public final ConfigInt brassTunnelTimer = i(10, 1, 10, "brassTunnelTimer", Comments.brassTunnelTimer);
 	public final ConfigInt factoryGaugeTimer = i(100, 5, "factoryGaugeTimer", Comments.factoryGaugeTimer);
 	public final ConfigBool seatHostileMobs = b(true, "seatHostileMobs", Comments.seatHostileMobs);
+	public final ConfigInt postboxTransferRate = i(4, 1, "postboxTransferRate", Comments.postboxTransferRate);
 
 	@Override
 	public String getName() {
@@ -37,6 +38,7 @@ public class CLogistics extends ConfigBase {
 		static String brassTunnelTimer = "The amount of ticks a brass tunnel waits between distributions.";
 		static String factoryGaugeTimer = "The amount of ticks a factory gauge waits between requests.";
 		static String seatHostileMobs = "Whether hostile mobs walking near a seat will start riding it.";
+		static String postboxTransferRate = "The amount of packages that can be transferred to / from a postbox per second.";
 	}
 
 }


### PR DESCRIPTION
Originally part of https://github.com/Creators-of-Create/Create/pull/9826

The transfer rate of packages to and from a postbox can now be set in the config. 4 packages per second is the default I've set, feel free to change this, some people may argue this should be an opt-in config, where the default is a high number, meaning default behaviour is unchanged, but this is a design decision so I will let the Create team decide this. We made this change as we found that trains could just do drive-by's to pick up/deliver packages and thought it might be nice from an immersion point of view as it was nice to see the depots on a train filling up over time and it felt weird that most transfers could happen instantly.

Let me know if there's anything I need to change or if you have any ideas to how it could be improved.

Thanks,
Jensen