### PR TITLE
Fix send only button in postboxes not working

### DIFF
--- a/src/generated/resources/assets/create/lang/en_ud.json
+++ b/src/generated/resources/assets/create/lang/en_ud.json
@@ -3087,7 +3087,7 @@
   "create.train.status.missing_driver": "buıssıɯ ǝuob sɐɥ ɹǝʌıɹᗡ",
   "create.train.status.navigation_success": "pǝpǝǝɔɔns uoıʇɐbıʌɐN",
   "create.train.status.no_match": ",%1$s, sǝɥɔʇɐɯ ɥdɐɹb uo uoıʇɐʇs oN",
-  "create.train.status.no_package_target": "ssǝɹppɐ sʇı sǝɥɔʇɐɯ ʇɐɥʇ xoqʇsod ou sɐɥ obɹɐɔ uı ǝbɐʞɔɐd Ɐ",
+  "create.train.status.no_package_target": "ʇı ʇdǝɔɔɐ uɐɔ ʇɐɥʇ xoqʇsod ou sɐɥ obɹɐɔ uı ǝbɐʞɔɐd Ɐ",
   "create.train.status.no_path": "punoɟ ǝq pןnoɔ uoıʇɐuıʇsǝp pǝןnpǝɥɔS ʇxǝu ǝɥʇ oʇ ɥʇɐd ǝןqɐʇıns oN",
   "create.train.status.opposite_driver": "uoıʇɔǝɹıp ǝʇısoddo ǝɥʇ buıɔɐɟ ɹǝʌıɹp ɐ sǝɹınbǝɹ ɥʇɐԀ",
   "create.train.status.paused_for_manual": "sןoɹʇuoɔ ןɐnuɐɯ ɹoɟ pǝsnɐd ǝןnpǝɥɔS",

--- a/src/generated/resources/assets/create/lang/en_us.json
+++ b/src/generated/resources/assets/create/lang/en_us.json
@@ -3087,7 +3087,7 @@
   "create.train.status.missing_driver": "Driver has gone missing",
   "create.train.status.navigation_success": "Navigation succeeded",
   "create.train.status.no_match": "No station on graph matches '%1$s'",
-  "create.train.status.no_package_target": "A package in cargo has no postbox that matches its address",
+  "create.train.status.no_package_target": "A package in cargo has no postbox that can accept it",
   "create.train.status.no_path": "No suitable path to the next Scheduled destination could be found",
   "create.train.status.opposite_driver": "Path requires a driver facing the opposite direction",
   "create.train.status.paused_for_manual": "Schedule paused for manual controls",

--- a/src/main/java/com/simibubi/create/content/logistics/packagePort/postbox/PostboxBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/packagePort/postbox/PostboxBlockEntity.java
@@ -137,6 +137,7 @@ public class PostboxBlockEntity extends PackagePortBlockEntity {
 			return;
 
 		globalPackagePort.saveOfflineBuffer(inventory);
+		globalPackagePort.acceptsPackages = acceptsPackages;
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/trains/schedule/destination/DeliverPackagesInstruction.java
+++ b/src/main/java/com/simibubi/create/content/trains/schedule/destination/DeliverPackagesInstruction.java
@@ -93,7 +93,10 @@ public class DeliverPackagesInstruction extends ScheduleInstruction {
 					firstPackage = PackageItem.getAddress(stack);
 				for (GlobalStation globalStation : train.graph.getPoints(EdgePointType.STATION)) {
 					for (Entry<BlockPos, GlobalPackagePort> port : globalStation.connectedPorts.entrySet()) {
-						if (!PackageItem.matchAddress(stack, port.getValue().address))
+						GlobalPackagePort packagePort = port.getValue();
+						if (!packagePort.acceptsPackages)
+							continue;
+						if (!PackageItem.matchAddress(stack, packagePort.address))
 							continue;
 						anyMatch = true;
 						validStations.add(globalStation);

--- a/src/main/java/com/simibubi/create/content/trains/station/GlobalPackagePort.java
+++ b/src/main/java/com/simibubi/create/content/trains/station/GlobalPackagePort.java
@@ -10,6 +10,7 @@ public class GlobalPackagePort {
 	public ItemStackHandler offlineBuffer = new ItemStackHandler(18);
 	public boolean primed = false;
 	private boolean restoring = false;
+	public boolean acceptsPackages = true;
 
 	public void restoreOfflineBuffer(IItemHandlerModifiable inventory) {
 		if (!primed) return;

--- a/src/main/java/com/simibubi/create/content/trains/station/GlobalStation.java
+++ b/src/main/java/com/simibubi/create/content/trains/station/GlobalStation.java
@@ -72,6 +72,7 @@ public class GlobalStation extends SingleBlockEntityEdgePoint {
 			port.address = c.getString("Address");
 			port.offlineBuffer.deserializeNBT(registries, c.getCompound("OfflineBuffer"));
 			port.primed = c.getBoolean("Primed");
+			port.acceptsPackages = c.getBoolean("AcceptsPackages");
 			connectedPorts.put(NBTHelper.readBlockPos(c, "Pos"), port);
 		});
 	}
@@ -96,6 +97,7 @@ public class GlobalStation extends SingleBlockEntityEdgePoint {
 			c.putString("Address", e.getValue().address);
 			c.put("OfflineBuffer", e.getValue().offlineBuffer.serializeNBT(registries));
 			c.putBoolean("Primed", e.getValue().primed);
+			c.putBoolean("AcceptsPackages", e.getValue().acceptsPackages);
 			c.put("Pos", NbtUtils.writeBlockPos(e.getKey()));
 			return c;
 		}));
@@ -224,6 +226,9 @@ public class GlobalStation extends SingleBlockEntityEdgePoint {
 					GlobalPackagePort port = entry.getValue();
 					BlockPos pos = entry.getKey();
 					PostboxBlockEntity box = null;
+
+					if (!port.acceptsPackages)
+						continue;
 
 					if (!PackageItem.matchAddress(stack, port.address))
 						continue;

--- a/src/main/java/com/simibubi/create/content/trains/station/StationBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/trains/station/StationBlockEntity.java
@@ -1015,6 +1015,7 @@ public class StationBlockEntity extends SmartBlockEntity implements Transformabl
 		if (globalPackagePort == null) {
 			globalPackagePort = new GlobalPackagePort();
 			globalPackagePort.address = ppbe.addressFilter;
+			globalPackagePort.acceptsPackages = ppbe.acceptsPackages;
 			station.connectedPorts.put(ppbe.getBlockPos(), globalPackagePort);
 		} else {
 			globalPackagePort.restoreOfflineBuffer(ppbe.inventory);

--- a/src/main/resources/assets/create/lang/default/interface.json
+++ b/src/main/resources/assets/create/lang/default/interface.json
@@ -994,7 +994,7 @@
 	"create.train.status.navigation_success": "Navigation succeeded",
 	"create.train.status.no_match": "No station on graph matches '%1$s'",
 	"create.train.status.no_path": "No suitable path to the next Scheduled destination could be found",
-	"create.train.status.no_package_target": "A package in cargo has no postbox that matches its address",
+  "create.train.status.no_package_target": "A package in cargo has no postbox that can accept it",
 
 	"create.track_signal.cannot_change_mode": "Unable to switch mode of this Signal",
 	"create.track_signal.mode_change.entry_signal": "-> Allow passage if section unoccupied",


### PR DESCRIPTION
Originally part of https://github.com/Creators-of-Create/Create/pull/9826
Fixes https://github.com/Creators-of-Create/Create/issues/7939

Fixes a bug where the send only option in the postbox UI was not respected. Localization of the train status message has been updated to reflect this change and datagen has been ran for this.

Let me know if there's anything I need to change or if you have any ideas to how it could be improved.

Thanks,
Jensen