### PR TITLE
Fix #9334: belt funnel not blocking items when inserting to a full vault

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/belt/transport/BeltFunnelInteractionHandler.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/transport/BeltFunnelInteractionHandler.java
@@ -71,7 +71,10 @@ public class BeltFunnelInteractionHandler {
 					continue;
 
 			if (beltInventory.belt.invVersionTracker.stillWaiting(inserting))
-				continue;
+				if (blocking)
+					return true;
+				else
+					continue;
 
 			int amountToExtract = funnelBE.getAmountToExtract();
 			ExtractionCountMode modeToExtract = funnelBE.getModeToExtract();


### PR DESCRIPTION
fix #7400
fix #9334 (duplicate issue)

### Bug Description
Belt funnels facing against belt movement fail to block items when the target vault is already full.

- **Affected versions:** 0.5.1f and later
- **Trigger condition:** When a belt funnel attempts to insert to a full vault

### Fix
When the vault is full, `stillWaiting()` returns true, indicating that items cannot be inserted. In this case, `blocking` should be checked, and `checkForFunnels()` should return true when blocked, indicating that the item is obstructed.

```java
if (beltInventory.belt.invVersionTracker.stillWaiting(inserting))
	if (blocking)
		return true;
	else
		continue;
```