### PR TITLE
Fix Mechanical Mixer animation

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/mixer/MechanicalMixerBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/mixer/MechanicalMixerBlockEntity.java
@@ -138,6 +138,14 @@ public class MechanicalMixerBlockEntity extends BasinOperatingBlockEntity {
 			if (level.isClientSide && runningTicks == 20)
 				renderParticles();
 
+			if (getSpeed() == 0) {
+			    if (runningTicks < 20)
+			        runningTicks = 40 - runningTicks;
+			    else if (runningTicks == 20)
+			        runningTicks++;
+			}
+
+
 			if ((!level.isClientSide || isVirtual()) && runningTicks == 20) {
 				if (processingTicks < 0) {
 					float recipeSpeed = 1;


### PR DESCRIPTION
Checks to see if the mixer is still running but without power, and will stop processing and raise the mixer head if so.

Closes #6249 