### PR TITLE
Fix Nostalgic Tweaks drill crash

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/utility/BlockHelper.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/BlockHelper.java
@@ -1,5 +1,6 @@
 package com.simibubi.create.foundation.utility;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -233,7 +234,7 @@ public class BlockHelper {
 			&& (player == null || !player.isCreative())) {
 			List<ItemStack> drops = Block.getDrops(state, serverLevel, pos, blockEntity, player, usedTool);
 
-			BlockDropsEvent event = new BlockDropsEvent(serverLevel, pos, state, blockEntity, List.of(), player, usedTool);
+			BlockDropsEvent event = new BlockDropsEvent(serverLevel, pos, state, blockEntity, new ArrayList<>(), player, usedTool);
 			NeoForge.EVENT_BUS.post(event);
 			if (!event.isCanceled()) {
 				if (event.getDroppedExperience() > 0) {


### PR DESCRIPTION
The `List.of()` that gets passed to `BlockDropsEvent` isn't mutable, which causes problems with Nostalgic Tweaks. `BlockDropsEvent `doesn't confirm, but expects, to be provided a mutable list. Should maybe bother NeoForge about that.

Closes #9923