### PR TITLE
Farmer's Delight: Do not harvest vanilla mushrooms on rich soil

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -155,6 +155,7 @@ dependencies {
         runtimeOnly("cc.tweaked:cc-tweaked-$minecraft_version-forge:$cc_tweaked_version")
     }
 
+    compileOnly("maven.modrinth:farmers-delight:${farmers_delight_version}")
     if (farmers_delight_enable.toBoolean()) {
         implementation("maven.modrinth:farmers-delight:${farmers_delight_version}")
     }

--- a/build.gradle
+++ b/build.gradle
@@ -155,6 +155,10 @@ dependencies {
         runtimeOnly("cc.tweaked:cc-tweaked-$minecraft_version-forge:$cc_tweaked_version")
     }
 
+    if (farmers_delight_enable.toBoolean()) {
+        implementation("maven.modrinth:farmers-delight:${farmers_delight_version}")
+    }
+
     runtimeOnly("dev.architectury:architectury-neoforge:13d.0.8")
     implementation("dev.ftb.mods:ftb-chunks-neoforge:2101.1.1")
     implementation("dev.ftb.mods:ftb-teams-neoforge:2101.1.0")

--- a/gradle.properties
+++ b/gradle.properties
@@ -55,3 +55,8 @@ sodium_version = 0.6.9
 # https://modrinth.com/mod/cc-tweaked/versions
 cc_tweaked_enable = true
 cc_tweaked_version = 1.116.1
+
+# Farmer's Delight
+# https://modrinth.com/mod/farmers-delight
+farmers_delight_enable = true
+farmers_delight_version = 1.21.1-1.2.9

--- a/src/main/java/com/simibubi/create/Create.java
+++ b/src/main/java/com/simibubi/create/Create.java
@@ -2,8 +2,6 @@ package com.simibubi.create;
 
 import java.util.Random;
 
-import com.simibubi.create.compat.farmersdelight.FarmersDelightCompat;
-
 import org.slf4j.Logger;
 
 import com.google.gson.Gson;

--- a/src/main/java/com/simibubi/create/Create.java
+++ b/src/main/java/com/simibubi/create/Create.java
@@ -2,6 +2,8 @@ package com.simibubi.create;
 
 import java.util.Random;
 
+import com.simibubi.create.compat.farmersdelight.FarmersDelightCompat;
+
 import org.slf4j.Logger;
 
 import com.google.gson.Gson;
@@ -163,6 +165,7 @@ public class Create {
 		// FIXME: this is not thread-safe
 		Mods.CURIOS.executeIfInstalled(() -> () -> Curios.init(modEventBus));
 		Mods.INVENTORYSORTER.executeIfInstalled(() -> () -> InventorySorterCompat.init(modEventBus));
+		Mods.FARMERSDELIGHT.executeIfInstalled(() -> () -> FarmersDelightCompat.init(modEventBus));
 	}
 
 	public static void init(final FMLCommonSetupEvent event) {

--- a/src/main/java/com/simibubi/create/Create.java
+++ b/src/main/java/com/simibubi/create/Create.java
@@ -165,7 +165,6 @@ public class Create {
 		// FIXME: this is not thread-safe
 		Mods.CURIOS.executeIfInstalled(() -> () -> Curios.init(modEventBus));
 		Mods.INVENTORYSORTER.executeIfInstalled(() -> () -> InventorySorterCompat.init(modEventBus));
-		Mods.FARMERSDELIGHT.executeIfInstalled(() -> () -> FarmersDelightCompat.init(modEventBus));
 	}
 
 	public static void init(final FMLCommonSetupEvent event) {

--- a/src/main/java/com/simibubi/create/compat/Mods.java
+++ b/src/main/java/com/simibubi/create/compat/Mods.java
@@ -39,7 +39,8 @@ public enum Mods {
 	XAEROWORLDMAP,
 	FTBLIBRARY,
 	SODIUM,
-	INVENTORYSORTER;
+	INVENTORYSORTER,
+	FARMERSDELIGHT;
 
 	private final String id;
 	private final boolean isLoaded;

--- a/src/main/java/com/simibubi/create/compat/farmersdelight/FarmersDelightCompat.java
+++ b/src/main/java/com/simibubi/create/compat/farmersdelight/FarmersDelightCompat.java
@@ -1,0 +1,14 @@
+package com.simibubi.create.compat.farmersdelight;
+
+import com.simibubi.create.Create;
+
+import net.neoforged.bus.api.IEventBus;
+
+import vectorwing.farmersdelight.FarmersDelight;
+
+public class FarmersDelightCompat {
+	public static void init(IEventBus modEventBus) {
+		// Yet empty.
+		Create.LOGGER.info("Create Farmer's compat loaded! " + FarmersDelight.MODID);
+	}
+}

--- a/src/main/java/com/simibubi/create/compat/farmersdelight/FarmersDelightCompat.java
+++ b/src/main/java/com/simibubi/create/compat/farmersdelight/FarmersDelightCompat.java
@@ -1,14 +1,14 @@
 package com.simibubi.create.compat.farmersdelight;
 
-import com.simibubi.create.Create;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
 
-import net.neoforged.bus.api.IEventBus;
+import net.minecraft.world.level.block.state.BlockState;
 
-import vectorwing.farmersdelight.FarmersDelight;
+import vectorwing.farmersdelight.common.registry.ModBlocks;
 
 public class FarmersDelightCompat {
-	public static void init(IEventBus modEventBus) {
-		// Yet empty.
-		Create.LOGGER.info("Create Farmer's compat loaded! " + FarmersDelight.MODID);
+	public static boolean shouldHarvestMushroom(Level world, BlockPos pos, BlockState state) {
+		return !world.getBlockState(pos.below()).is(ModBlocks.RICH_SOIL.get());
 	}
 }

--- a/src/main/java/com/simibubi/create/content/contraptions/actors/harvester/HarvesterMovementBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/actors/harvester/HarvesterMovementBehaviour.java
@@ -1,5 +1,11 @@
 package com.simibubi.create.content.contraptions.actors.harvester;
 
+import com.simibubi.create.compat.Mods;
+
+import com.simibubi.create.compat.farmersdelight.FarmersDelightCompat;
+
+import net.minecraft.world.level.block.MushroomBlock;
+
 import org.jetbrains.annotations.Nullable;
 
 import org.apache.commons.lang3.mutable.MutableBoolean;
@@ -151,6 +157,10 @@ public class HarvesterMovementBehaviour implements MovementBehaviour {
 					.equals(BlockStateProperties.AGE_1.getName()))
 					continue;
 				return false;
+			}
+
+			if (state.getBlock() instanceof MushroomBlock && Mods.FARMERSDELIGHT.isLoaded()) {
+				return FarmersDelightCompat.shouldHarvestMushroom(world, pos, state);
 			}
 
 			// TODO: 1.21.5-rc1+ change to VegetationBlock (https://github.com/neoforged/NeoForge/commit/9f6edae1894ad249a8719c4e1f14beda0fdedc72)


### PR DESCRIPTION
In Farmer's Delight, mushrooms on rich soil will eventually grow into mushroom colonies. The colonies themselves harvest correctly, leaving an age 0 colony when replanting is enabled. However, in order to grow _into_ colonies, the mushrooms must _not_ be harvested until they have turned into colonies.

This PR adds a compatibility check to ensure mushrooms on rich soil are not harvested, but leaves the harvesting behaviour unchanged on other materials (e.g. mycelium).

https://github.com/user-attachments/assets/bb7833f0-feef-44da-acee-3c2659837e8b

https://github.com/user-attachments/assets/c5908649-ca52-4ec3-811c-da1602a4014d



