### PR TITLE
Fix #9931: They Rotate Smoothly Now

### DIFF
--- a/src/main/java/com/simibubi/create/content/fluids/drain/ItemDrainRenderer.java
+++ b/src/main/java/com/simibubi/create/content/fluids/drain/ItemDrainRenderer.java
@@ -21,7 +21,6 @@ import net.minecraft.client.renderer.entity.ItemRenderer;
 import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.core.Direction;
 import net.minecraft.util.Mth;
-import net.minecraft.world.entity.Entity;
 import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.AABB;
@@ -94,20 +93,17 @@ public class ItemDrainRenderer extends SmartBlockEntityRenderer<ItemDrainBlockEn
 			msr.rotateZDegrees(-verticalAngle);
 
 		if (renderUpright) {
-			Entity renderViewEntity = Minecraft.getInstance().cameraEntity;
-			if (renderViewEntity != null) {
-				Vec3 positionVec = renderViewEntity.position();
-				Vec3 vectorForOffset = itemPosition.add(offsetVec);
-				Vec3 diff = vectorForOffset.subtract(positionVec);
+			Vec3 cameraPosition = Minecraft.getInstance().gameRenderer.getMainCamera().getPosition();
+			Vec3 vectorForOffset = itemPosition.add(offsetVec);
+			Vec3 diff = vectorForOffset.subtract(cameraPosition);
 
-				if (insertedFrom.getAxis() != Direction.Axis.X)
-					diff = VecHelper.rotate(diff, verticalAngle, Direction.Axis.X);
-				if (insertedFrom.getAxis() != Direction.Axis.Z)
-					diff = VecHelper.rotate(diff, -verticalAngle, Direction.Axis.Z);
+			if (insertedFrom.getAxis() != Direction.Axis.X)
+				diff = VecHelper.rotate(diff, verticalAngle, Direction.Axis.X);
+			if (insertedFrom.getAxis() != Direction.Axis.Z)
+				diff = VecHelper.rotate(diff, -verticalAngle, Direction.Axis.Z);
 
-				float yRot = (float) Mth.atan2(diff.z, -diff.x);
-				ms.mulPose(Axis.YP.rotation((float) (yRot - Math.PI / 2)));
-			}
+			float yRot = (float) Mth.atan2(diff.z, -diff.x);
+			ms.mulPose(Axis.YP.rotation((float) (yRot - Math.PI / 2)));
 			ms.translate(0, 0, -1 / 16f);
 		}
 

--- a/src/main/java/com/simibubi/create/content/kinetics/belt/BeltRenderer.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/BeltRenderer.java
@@ -39,7 +39,6 @@ import net.minecraft.core.Direction;
 import net.minecraft.core.Direction.AxisDirection;
 import net.minecraft.core.Vec3i;
 import net.minecraft.util.Mth;
-import net.minecraft.world.entity.Entity;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.level.block.state.BlockState;
@@ -311,14 +310,11 @@ public class BeltRenderer extends SafeBlockEntityRenderer<BeltBlockEntity> {
 		}
 
 		if (renderUpright) {
-			Entity renderViewEntity = mc.cameraEntity;
-			if (renderViewEntity != null) {
-				Vec3 positionVec = renderViewEntity.position();
-				Vec3 vectorForOffset = BeltHelper.getVectorForOffset(be, offset);
-				Vec3 diff = vectorForOffset.subtract(positionVec);
-				float yRot = (float) (Mth.atan2(diff.x, diff.z) + Math.PI);
-				ms.mulPose(Axis.YP.rotation(yRot));
-			}
+			Vec3 cameraPosition = Minecraft.getInstance().gameRenderer.getMainCamera().getPosition();
+			Vec3 vectorForOffset = BeltHelper.getVectorForOffset(be, offset);
+			Vec3 diff = vectorForOffset.subtract(cameraPosition);
+			float yRot = (float) (Mth.atan2(diff.x, diff.z) + Math.PI);
+			ms.mulPose(Axis.YP.rotation(yRot));
 			ms.translate(0, 3 / 32d, 1 / 16f);
 		}
 

--- a/src/main/java/com/simibubi/create/content/logistics/depot/DepotRenderer.java
+++ b/src/main/java/com/simibubi/create/content/logistics/depot/DepotRenderer.java
@@ -19,10 +19,8 @@ import net.minecraft.client.renderer.entity.ItemRenderer;
 import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.core.Direction;
 import net.minecraft.util.Mth;
-import net.minecraft.world.entity.Entity;
 import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
 
 public class DepotRenderer extends SafeBlockEntityRenderer<DepotBlockEntity> {
@@ -71,7 +69,7 @@ public class DepotRenderer extends SafeBlockEntityRenderer<DepotBlockEntity> {
 			ItemStack itemStack = tis.stack;
 			int angle = tis.angle;
 			Random r = new Random(0);
-			renderItem(be.getLevel(), ms, buffer, light, overlay, itemStack, angle, r, itemPosition, false);
+			renderItem(ms, buffer, light, overlay, itemStack, angle, r, itemPosition, false);
 			ms.popPose();
 		}
 
@@ -93,7 +91,7 @@ public class DepotRenderer extends SafeBlockEntityRenderer<DepotBlockEntity> {
 				msr.rotateYDegrees(-(360 / 8f * i));
 			Random r = new Random(i + 1);
 			int angle = (int) (360 * r.nextFloat());
-			renderItem(be.getLevel(), ms, buffer, light, overlay, stack, renderUpright ? angle + 90 : angle, r,
+			renderItem(ms, buffer, light, overlay, stack, renderUpright ? angle + 90 : angle, r,
 				itemPosition, false);
 			ms.popPose();
 		}
@@ -101,12 +99,12 @@ public class DepotRenderer extends SafeBlockEntityRenderer<DepotBlockEntity> {
 		ms.popPose();
 	}
 
-	public static void renderItem(Level level, PoseStack ms, MultiBufferSource buffer, int light, int overlay,
-		ItemStack itemStack, int angle, Random r, Vec3 itemPosition, boolean alwaysUpright) {
+	public static void renderItem(PoseStack ms, MultiBufferSource buffer, int light, int overlay,
+								  ItemStack itemStack, int angle, Random r, Vec3 itemPosition, boolean alwaysUpright) {
 		ItemRenderer itemRenderer = Minecraft.getInstance()
 			.getItemRenderer();
 		var msr = TransformStack.of(ms);
-		int count = (int) (Mth.log2((int) (itemStack.getCount()))) / 2;
+		int count = Mth.log2((itemStack.getCount())) / 2;
 		BakedModel bakedModel = itemRenderer.getModel(itemStack, null, null, 0);
 		boolean blockItem = bakedModel.isGui3d();
 		boolean renderUpright = BeltHelper.isItemUpright(itemStack) || alwaysUpright && !blockItem;
@@ -115,14 +113,10 @@ public class DepotRenderer extends SafeBlockEntityRenderer<DepotBlockEntity> {
 		msr.rotateYDegrees(angle);
 
 		if (renderUpright) {
-			Entity renderViewEntity = Minecraft.getInstance().cameraEntity;
-			if (renderViewEntity != null) {
-				Vec3 positionVec = renderViewEntity.position();
-				Vec3 vectorForOffset = itemPosition;
-				Vec3 diff = vectorForOffset.subtract(positionVec);
-				float yRot = (float) (Mth.atan2(diff.x, diff.z) + Math.PI);
-				ms.mulPose(Axis.YP.rotation(yRot));
-			}
+			Vec3 cameraPosition = Minecraft.getInstance().gameRenderer.getMainCamera().getPosition();
+			Vec3 diff = itemPosition.subtract(cameraPosition);
+			float yRot = (float) (Mth.atan2(diff.x, diff.z) + Math.PI);
+			ms.mulPose(Axis.YP.rotation(yRot));
 			ms.translate(0, 3 / 32d, -1 / 16f);
 		}
 

--- a/src/main/java/com/simibubi/create/content/logistics/tableCloth/TableClothRenderer.java
+++ b/src/main/java/com/simibubi/create/content/logistics/tableCloth/TableClothRenderer.java
@@ -66,7 +66,7 @@ public class TableClothRenderer extends SmartBlockEntityRenderer<TableClothBlock
 				TransformStack.of(ms)
 					.rotate(-rotationInRadians + Mth.PI, Direction.UP);
 
-			DepotRenderer.renderItem(blockEntity.getLevel(), ms, buffer, light, OverlayTexture.NO_OVERLAY, entry, 0,
+			DepotRenderer.renderItem(ms, buffer, light, OverlayTexture.NO_OVERLAY, entry, 0,
 				null, Vec3.atCenterOf(blockEntity.getBlockPos()), true);
 			ms.popPose();
 		}


### PR DESCRIPTION
This PR fixes #9931, changing `DepotRenderer`, `BeltRenderer`, and `ItemDrainRender` to use the actual camera position instead of the (per-tick) player position, making it appear smoother e.g. when walking on top of the depot.

It also cleans up some code around that logic, removing a unused `Level` argument and removing unnecessary casts.