### PR TITLE
Update Sophisticated Storage compat

### DIFF
--- a/src/main/java/com/simibubi/create/compat/thresholdSwitch/SophisticatedStorage.java
+++ b/src/main/java/com/simibubi/create/compat/thresholdSwitch/SophisticatedStorage.java
@@ -3,6 +3,7 @@ package com.simibubi.create.compat.thresholdSwitch;
 import com.simibubi.create.compat.Mods;
 
 import net.createmod.catnip.registry.RegisteredObjectsHelper;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.world.level.block.entity.BlockEntity;
 
 import net.neoforged.neoforge.items.IItemHandler;
@@ -24,7 +25,7 @@ public class SophisticatedStorage implements ThresholdSwitchCompat {
 
 	@Override
 	public long getSpaceInSlot(IItemHandler inv, int slot) {
-		return ((long) inv.getSlotLimit(slot) * inv.getStackInSlot(slot).getMaxStackSize()) / 64;
+		return Math.max(1, (long) inv.getSlotLimit(slot) * inv.getStackInSlot(slot).getOrDefault(DataComponents.MAX_STACK_SIZE, 64) / 64);
 	}
 
 }


### PR DESCRIPTION
Going back to getOrDefault as getMaxStackSize on air returns 1 as stack size.
Forcing slot space to be at least 1 because soph storage can set the slot limit to be 0 or low enough where the final result would be less then 1 (still allows 1 item in the slot).