### PR TITLE
Fix #9882: items disappearing during belt transfers when chunks unload

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/belt/transport/BeltInventory.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/transport/BeltInventory.java
@@ -407,8 +407,14 @@ public class BeltInventory {
 
 	public void read(CompoundTag nbt, HolderLookup.Provider registries) {
 		items.clear();
+		toInsert.clear();
+		toRemove.clear();
 		nbt.getList("Items", Tag.TAG_COMPOUND)
 			.forEach(inbt -> items.add(TransportedItemStack.read((CompoundTag) inbt, registries)));
+		nbt.getList("ToInsert", Tag.TAG_COMPOUND)
+			.forEach(inbt -> toInsert.add(TransportedItemStack.read((CompoundTag) inbt, registries)));
+		nbt.getList("ToRemove", Tag.TAG_COMPOUND)
+			.forEach(inbt -> toRemove.add(TransportedItemStack.read((CompoundTag) inbt, registries)));
 		if (nbt.contains("LazyItem"))
 			lazyClientItem = TransportedItemStack.read(nbt.getCompound("LazyItem"), registries);
 		beltMovementPositive = nbt.getBoolean("PositiveOrder");
@@ -417,8 +423,14 @@ public class BeltInventory {
 	public CompoundTag write(HolderLookup.Provider registries) {
 		CompoundTag nbt = new CompoundTag();
 		ListTag itemsNBT = new ListTag();
+		ListTag toInsertNBT = new ListTag();
+		ListTag toRemoveNBT = new ListTag();
 		items.forEach(stack -> itemsNBT.add(stack.serializeNBT(registries)));
+		toInsert.forEach(stack -> toInsertNBT.add(stack.serializeNBT(registries)));
+		toRemove.forEach(stack -> toRemoveNBT.add(stack.serializeNBT(registries)));
 		nbt.put("Items", itemsNBT);
+		nbt.put("ToInsert", toInsertNBT);
+		nbt.put("ToRemove", toRemoveNBT);
 		if (lazyClientItem != null)
 			nbt.put("LazyItem", lazyClientItem.serializeNBT(registries));
 		nbt.putBoolean("PositiveOrder", beltMovementPositive);


### PR DESCRIPTION
Fix #9882: When a belt receives items, they are first placed into the `toInsert` list and only actually inserted into the inventory on the next tick. However, during chunk unloading, the `toInsert` list is not persisted, causing all pending items to be lost.

Similarly, in some cases when items leave a belt, they are added to the `toRemove` list. This list is also not saved during chunk unload, which can lead to item duplication.

Testing confirms that the structure described in [the issue](https://github.com/Creators-of-Create/Create/issues/9882) can reproduce the item loss problem in both Create 0.5.1.j and 6.0.6.