### PR TITLE
Fix the issue where an empty basin allows the same fluid in both input tanks

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/fluid/CombinedTankWrapper.java
+++ b/src/main/java/com/simibubi/create/foundation/fluid/CombinedTankWrapper.java
@@ -86,7 +86,7 @@ public class CombinedTankWrapper implements IFluidHandler {
 
 				if (resource.isEmpty())
 					break Outer;
-				if (fittingHandlerFound && (enforceVariety || filledIntoCurrent != 0))
+				if (enforceVariety && (fittingHandlerFound || filledIntoCurrent != 0))
 					break Outer;
 			}
 		}

--- a/src/main/java/com/simibubi/create/foundation/fluid/CombinedTankWrapper.java
+++ b/src/main/java/com/simibubi/create/foundation/fluid/CombinedTankWrapper.java
@@ -86,7 +86,7 @@ public class CombinedTankWrapper implements IFluidHandler {
 
 				if (resource.isEmpty())
 					break Outer;
-				if (enforceVariety && (fittingHandlerFound || filledIntoCurrent != 0))
+				if (filledIntoCurrent != 0 || (enforceVariety && fittingHandlerFound))
 					break Outer;
 			}
 		}


### PR DESCRIPTION
### Issue

Under normal circumstances, the Basin’s internal fluid tank only allows one type of fluid to occupy a single slot. However, an empty Basin is an exception: if fluid is pumped in fast enough, the issue shown in the image can occur.

<img width="1920" height="986" alt="2026-02-13_15 01 31" src="https://github.com/user-attachments/assets/c7e8d87e-b70c-4629-9d80-ccc64bfc1374" />

### Cause

The root cause lies in the condition at [CombinedTankWrapper.java#L89](https://github.com/Creators-of-Create/Create/blob/c54810b31ab5335b59788199dc17010c690c7f20/src/main/java/com/simibubi/create/foundation/fluid/CombinedTankWrapper.java#L89)
```java
if (fittingHandlerFound && (enforceVariety || filledIntoCurrent != 0))
    break Outer;
```
This logic is somewhat counterintuitive. For an empty Basin, `fittingHandlerFound` is guaranteed to be false, which causes the value of `enforceVariety` to be ignored entirely, leading to the issue described above.

~~On the other hand, if `filledIntoCurrent != 0`, the program will treat the current handler as unable to continue filling and break the outer loop — even when `enforceVariety` is false. As a result, the remaining fluid can only be inserted during the next input. For certain indivisible FluidStack cases, this also introduces a subtle logical inconsistency.~~
I think I understand this logic now: operate on only one tank at a time to prevent overfilling and make right-click interaction more convenient for players.

### Fix

CombinedTankWrapper organizes the fluid system into a well-structured tree hierarchy, and considering the intended semantics of the code, enforceVariety is meant to control whether sibling nodes under the same parent are allowed to contain the same fluid type.

```java
if (filledIntoCurrent != 0 || (enforceVariety && fittingHandlerFound))
    break Outer;
```