### PR TITLE
Add logistics request events for Factory Panels and Stock Tickers

### DIFF
--- a/src/main/java/com/simibubi/create/api/event/CreateRequestKind.java
+++ b/src/main/java/com/simibubi/create/api/event/CreateRequestKind.java
@@ -1,0 +1,19 @@
+package com.simibubi.create.api.event;
+
+/**
+	* Normalized request kinds for Create logistics API events.
+	*
+	* <p>Used to classify requests across different sources (e.g. Factory Panels and Stock Tickers)
+	* while preserving their specific source data and raw request types. For Stock Ticker requests,
+	* {@link StockRequestEvent#getType()} retains the original {@link com.simibubi.create.content.logistics.packagerLink.LogisticallyLinkedBehaviour.RequestType}.
+	*/
+public enum CreateRequestKind {
+	/** Requests originating from a Factory Panel's crafting path (non-restocker). */
+	CRAFTING,
+	/** Requests originating from a Factory Panel or Stock Ticker restock mode. */
+	RESTOCK,
+	/** Requests originating from a Redstone Requester. */
+	REDSTONE,
+	/** Requests originating from a Player/Stock Ticker interaction. */
+	PLAYER
+}

--- a/src/main/java/com/simibubi/create/api/event/FactoryPanelRequestEvent.java
+++ b/src/main/java/com/simibubi/create/api/event/FactoryPanelRequestEvent.java
@@ -1,0 +1,61 @@
+package com.simibubi.create.api.event;
+
+import java.util.UUID;
+
+import com.simibubi.create.content.logistics.factoryBoard.FactoryPanelBehaviour;
+import com.simibubi.create.content.logistics.stockTicker.PackageOrderWithCrafts;
+
+import net.neoforged.bus.api.Event;
+import net.neoforged.bus.api.ICancellableEvent;
+
+/**
+	* Fired server-side when a Factory Panel is about to submit a logistics request for a
+	* network.
+	*
+	* <p>This event is cancelable. If canceled, Create will not submit the request to its
+	* logistics network. External mods can use this to route or fulfill the request elsewhere.</p>
+	*
+	* <p>Note: {@link #getOrder()} returns the mutable order object used by Create. Mutation is
+	* unsupported and may break internal Create logic. The address may be empty if the panel has no
+	* address configured.</p>
+	*/
+public class FactoryPanelRequestEvent extends Event implements ICancellableEvent {
+	private final FactoryPanelBehaviour panel;
+	private final UUID network;
+	private final PackageOrderWithCrafts order;
+	private final String address;
+	private final CreateRequestKind kind;
+
+	public FactoryPanelRequestEvent(
+		FactoryPanelBehaviour panel,
+		UUID network,
+		PackageOrderWithCrafts order,
+		String address,
+		CreateRequestKind kind) {
+		this.panel = panel;
+		this.network = network;
+		this.order = order;
+		this.address = address;
+		this.kind = kind;
+	}
+
+	public FactoryPanelBehaviour getPanel() {
+		return panel;
+	}
+
+	public UUID getNetwork() {
+		return network;
+	}
+
+	public PackageOrderWithCrafts getOrder() {
+		return order;
+	}
+
+	public String getAddress() {
+		return address;
+	}
+
+	public CreateRequestKind getKind() {
+		return kind;
+	}
+}

--- a/src/main/java/com/simibubi/create/api/event/StockRequestEvent.java
+++ b/src/main/java/com/simibubi/create/api/event/StockRequestEvent.java
@@ -1,0 +1,77 @@
+package com.simibubi.create.api.event;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import com.simibubi.create.content.logistics.packagerLink.LogisticallyLinkedBehaviour.RequestType;
+import com.simibubi.create.content.logistics.stockTicker.PackageOrderWithCrafts;
+import com.simibubi.create.content.logistics.stockTicker.StockCheckingBlockEntity;
+
+import net.neoforged.bus.api.Event;
+import net.neoforged.bus.api.ICancellableEvent;
+
+/**
+	* Fired server-side when a Stock Ticker or Redstone Requester is about to submit a
+	* logistics request.
+	*
+	* <p>This event is cancelable. If canceled, Create will not submit the request to its logistics
+	* network.</p>
+	*
+	* <p>Note: {@link #getOrder()} returns the mutable order object used by Create. Mutation is
+	* unsupported and may break internal Create logic. The address may be empty if the requester has
+	* no address configured. {@link #getType()} is never null.</p>
+	*/
+public class StockRequestEvent extends Event implements ICancellableEvent {
+	private final StockCheckingBlockEntity source;
+	private final UUID network;
+	private final RequestType type;
+	private final PackageOrderWithCrafts order;
+	private final String address;
+	private final CreateRequestKind kind;
+
+	public StockRequestEvent(
+		StockCheckingBlockEntity source,
+		UUID network,
+		RequestType type,
+		PackageOrderWithCrafts order,
+		String address) {
+		this.source = source;
+		this.network = network;
+		this.type = Objects.requireNonNull(type, "type");
+		this.order = order;
+		this.address = address;
+		this.kind = mapKind(type);
+	}
+
+	public StockCheckingBlockEntity getSource() {
+		return source;
+	}
+
+	public UUID getNetwork() {
+		return network;
+	}
+
+	public RequestType getType() {
+		return type;
+	}
+
+	public CreateRequestKind getKind() {
+		return kind;
+	}
+
+	public PackageOrderWithCrafts getOrder() {
+		return order;
+	}
+
+	public String getAddress() {
+		return address;
+	}
+
+	private static CreateRequestKind mapKind(RequestType type) {
+		return switch (type) {
+			case RESTOCK -> CreateRequestKind.RESTOCK;
+			case REDSTONE -> CreateRequestKind.REDSTONE;
+			case PLAYER -> CreateRequestKind.PLAYER;
+		};
+	}
+}

--- a/src/main/java/com/simibubi/create/content/logistics/factoryBoard/FactoryPanelBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/logistics/factoryBoard/FactoryPanelBehaviour.java
@@ -21,6 +21,8 @@ import com.mojang.serialization.Codec;
 import com.simibubi.create.AllBlocks;
 import com.simibubi.create.AllSoundEvents;
 import com.simibubi.create.Create;
+import com.simibubi.create.api.event.CreateRequestKind;
+import com.simibubi.create.api.event.FactoryPanelRequestEvent;
 import com.simibubi.create.content.logistics.BigItemStack;
 import com.simibubi.create.content.logistics.factoryBoard.FactoryPanelBlock.PanelSlot;
 import com.simibubi.create.content.logistics.filter.FilterItem;
@@ -85,6 +87,7 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.neoforge.common.Tags.Items;
+import net.neoforged.neoforge.common.NeoForge;
 
 public class FactoryPanelBehaviour extends FilteringBehaviour implements MenuProvider {
 
@@ -483,6 +486,15 @@ public class FactoryPanelBehaviour extends FilteringBehaviour implements MenuPro
 		for (Entry<UUID, Collection<BigItemStack>> entry : asMap.entrySet()) {
 			PackageOrderWithCrafts order =
 				new PackageOrderWithCrafts(new PackageOrder(new ArrayList<>(entry.getValue())), craftingContext.orderedCrafts());
+			FactoryPanelRequestEvent event = new FactoryPanelRequestEvent(
+				this,
+				entry.getKey(),
+				order,
+				recipeAddress,
+				CreateRequestKind.CRAFTING);
+			NeoForge.EVENT_BUS.post(event);
+			if (event.isCanceled())
+				continue;
 			Multimap<PackagerBlockEntity, PackagingRequest> request =
 				LogisticsManager.findPackagersForRequest(entry.getKey(), order, null, recipeAddress);
 			requests.add(request);
@@ -531,11 +543,21 @@ public class FactoryPanelBehaviour extends FilteringBehaviour implements MenuPro
 		BigItemStack orderedItem = new BigItemStack(item, Math.min(amountToOrder, availableOnNetwork));
 		PackageOrderWithCrafts order = PackageOrderWithCrafts.simple(List.of(orderedItem));
 
-		sendEffect(getPanelPosition(), true);
+		FactoryPanelRequestEvent event = new FactoryPanelRequestEvent(
+			this,
+			network,
+			order,
+			recipeAddress,
+			CreateRequestKind.RESTOCK);
+		NeoForge.EVENT_BUS.post(event);
+		if (event.isCanceled())
+			return;
 
 		if (!LogisticsManager.broadcastPackageRequest(network, RequestType.RESTOCK, order,
 			packager.targetInventory.getIdentifiedInventory(), recipeAddress))
 			return;
+
+		sendEffect(getPanelPosition(), true);
 
 		restockerPromises.add(new RequestPromise(orderedItem));
 	}

--- a/src/main/java/com/simibubi/create/content/logistics/stockTicker/StockCheckingBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/stockTicker/StockCheckingBlockEntity.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.jetbrains.annotations.Nullable;
 
+import com.simibubi.create.api.event.StockRequestEvent;
 import com.simibubi.create.content.logistics.packager.IdentifiedInventory;
 import com.simibubi.create.content.logistics.packager.InventorySummary;
 import com.simibubi.create.content.logistics.packagerLink.LogisticallyLinkedBehaviour;
@@ -15,6 +16,7 @@ import com.simibubi.create.foundation.blockEntity.behaviour.BlockEntityBehaviour
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.neoforge.common.NeoForge;
 
 public abstract class StockCheckingBlockEntity extends SmartBlockEntity {
 
@@ -43,6 +45,10 @@ public abstract class StockCheckingBlockEntity extends SmartBlockEntity {
 	}
 
 	public boolean broadcastPackageRequest(RequestType type, PackageOrderWithCrafts order, @Nullable IdentifiedInventory ignoredHandler, String address) {
+		StockRequestEvent event = new StockRequestEvent(this, behaviour.freqId, type, order, address);
+		NeoForge.EVENT_BUS.post(event);
+		if (event.isCanceled())
+			return false;
 		return LogisticsManager.broadcastPackageRequest(behaviour.freqId, type, order, ignoredHandler, address);
 	}
 


### PR DESCRIPTION
Summary
Introduces server-side, cancellable events for logistics requests issued by Factory Panels and Stock Tickers.
Adds a normalized request kind enum to provide a shared classification across request sources.
Ensures restock success feedback is emitted only after a successful broadcast.
Details
New API events
• FactoryPanelRequestEvent (CRAFTING, RESTOCK)
• StockRequestEvent (RESTOCK, REDSTONE, PLAYER)
• CreateRequestKind as a shared classification layer
CreateRequestKind provides a unified view across request sources while preserving original semantics.
StockRequestEvent continues to expose the underlying RequestType.
Behavior
• Events are fired server-side immediately before a logistics request is submitted.
• Cancelling the event prevents submission to the logistics network.
• Restock feedback is emitted only after a successful broadcast.
• Order objects are passed by reference; mutation is unsupported and may break internal logic.
Files
• com/simibubi/create/api/event/CreateRequestKind.java
• com/simibubi/create/api/event/FactoryPanelRequestEvent.java
• com/simibubi/create/api/event/StockRequestEvent.java
• com/simibubi/create/content/logistics/factoryBoard/FactoryPanelBehaviour.java
• com/simibubi/create/content/logistics/stockTicker/StockCheckingBlockEntity.java
Compatibility
Additive API only.
No existing public types, signatures, or behavior are modified unless an event is explicitly cancelled by a listener.