### PR TITLE
Fix exception in displaylink computercraft-api, when setting the cursor position to negative value

### DIFF
--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/DisplayLinkPeripheral.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/DisplayLinkPeripheral.java
@@ -30,7 +30,10 @@ public class DisplayLinkPeripheral extends SyncedPeripheral<DisplayLinkBlockEnti
 	}
 
 	@LuaFunction
-	public final void setCursorPos(int x, int y) {
+	public final void setCursorPos(int x, int y) throws LuaException {
+		if (x < 1 || y < 1)
+			throw new LuaException("cursor position must be larger then 0");
+
 		cursorX.set(x - 1);
 		cursorY.set(y - 1);
 	}


### PR DESCRIPTION
## Issue

When calling the `setCursor` function on a display link periphal with the `x` or `y` argument smaller then 1,
and then writing text using the `write`, causes a StringIndexOutOfBoundsException or IndexOutOfBoundsException respectively.

## Cause

This happens because the [`setCursor`](https://github.com/Creators-of-Create/Create/blob/c54810b31ab5335b59788199dc17010c690c7f20/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/DisplayLinkPeripheral.java#L33) method sets the cursor position to a negative value.

If the `x` value is set to negative value writing text causes a `StringIndexOutOfBoundsException` at [DisplayLinkPeripheral.java#L96](https://github.com/Creators-of-Create/Create/blob/c54810b31ab5335b59788199dc17010c690c7f20/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/DisplayLinkPeripheral.java#L96).

If the `y` value is set to a negative value writing text causes a `IndexOutOfBoundsException` at [DisplayLinkPeripheral.java#L98](https://github.com/Creators-of-Create/Create/blob/c54810b31ab5335b59788199dc17010c690c7f20/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/DisplayLinkPeripheral.java#L98).

## Fix

In [`setCursor`](https://github.com/Creators-of-Create/Create/blob/c54810b31ab5335b59788199dc17010c690c7f20/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/DisplayLinkPeripheral.java#L33) check if `x` or `y` is smaller then 1 and throw a lua exception.

```java
if (x < 1 || y < 1)
    throw new LuaException("cursor position must be larger then 0");

cursorX.set(x - 1);
cursorY.set(y - 1);
```