### PR TITLE
Fix #8777: Permanently connected Portable Storage (PSI) Interface facing upwards or sideways unnecessarily pauses the contraption

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/ControlledContraptionEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/ControlledContraptionEntity.java
@@ -183,8 +183,8 @@ public class ControlledContraptionEntity extends AbstractContraptionEntity {
 			return false;
 		Direction facing = bc.getFacing();
 		Vec3 activeAreaOffset = actor.getActiveAreaOffset(context);
-		if (!activeAreaOffset.multiply(VecHelper.axisAlingedPlaneOf(Vec3.atLowerCornerOf(facing.getNormal())))
-			.equals(Vec3.ZERO))
+		if (activeAreaOffset.multiply(VecHelper.axisAlingedPlaneOf(Vec3.atLowerCornerOf(facing.getNormal())))
+			.lengthSqr() != 0)
 			return false;
 		if (!VecHelper.onSameAxis(blockInfo.pos(), BlockPos.ZERO, facing.getAxis()))
 			return false;

--- a/src/main/java/com/simibubi/create/content/contraptions/ControlledContraptionEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/ControlledContraptionEntity.java
@@ -191,6 +191,7 @@ public class ControlledContraptionEntity extends AbstractContraptionEntity {
 		context.motion = Vec3.atLowerCornerOf(facing.getNormal())
 			.scale(angleDelta / 360.0);
 		context.relativeMotion = context.motion;
+		context.realMotionIsZero = true;
 		int timer = context.data.getInt("StationaryTimer");
 		if (timer > 0) {
 			context.data.putInt("StationaryTimer", timer - 1);

--- a/src/main/java/com/simibubi/create/content/contraptions/actors/psi/PortableStorageInterfaceMovement.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/actors/psi/PortableStorageInterfaceMovement.java
@@ -95,7 +95,7 @@ public class PortableStorageInterfaceMovement implements MovementBehaviour {
 		BlockPos pos = NBTHelper.readBlockPos(context.data, _workingPos_);
 		Vec3 target = VecHelper.getCenterOf(pos);
 
-		if (!context.stall && !onCarriage
+		if (!context.stall && !onCarriage && !context.realMotionIsZero
 			&& context.position.closerThan(target, target.distanceTo(context.position.add(context.motion))))
 			context.stall = true;
 

--- a/src/main/java/com/simibubi/create/content/contraptions/behaviour/MovementContext.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/behaviour/MovementContext.java
@@ -25,6 +25,7 @@ public class MovementContext {
 	public Vec3 position;
 	public Vec3 motion;
 	public Vec3 relativeMotion;
+	public boolean realMotionIsZero;
 	public UnaryOperator<Vec3> rotation;
 
 	public Level world;


### PR DESCRIPTION
Fixes this by carrying additional information in the MovementContext about the real movement when synthetic movement for activation in the center of rotating contraptions is set.

Also fixes the synthetic movement not being set when the affected block is facing in a negative direction.

Fixes #8777 