### PR TITLE
Fix valve pipes and smart pipes not updating correctly

### DIFF
--- a/src/main/java/com/simibubi/create/content/fluids/FluidPropagator.java
+++ b/src/main/java/com/simibubi/create/content/fluids/FluidPropagator.java
@@ -5,6 +5,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import com.simibubi.create.content.fluids.pipes.IAxisPipe;
+
 import org.jetbrains.annotations.Nullable;
 
 import com.simibubi.create.AllTags.AllBlockTags;
@@ -213,8 +215,8 @@ public class FluidPropagator {
 		if (state.getBlock() instanceof PumpBlock)
 			return state.getValue(PumpBlock.FACING)
 				.getAxis();
-		if (state.getBlock() instanceof AxisPipeBlock)
-			return state.getValue(AxisPipeBlock.AXIS);
+		if (state.getBlock() instanceof IAxisPipe axisPipe)
+			return axisPipe.getAxis(state);
 		if (!FluidPipeBlock.isPipe(state))
 			return null;
 		Axis axisFound = null;


### PR DESCRIPTION
### Issue

~~Recently, the community discovered a very simple method to duplicate fluids in Create:~~

~~1. Connect a **Fluid Valve** directly to a tank, and use a Mechanical Pump to transfer the fluid into another tank.~~
~~2. Assemble the source tank onto a minecart and store it in player's inventory.~~

I recently realized that another PR (#10016) has already eliminated this way to duplicate fluids. Though the issue described in this PR still exists, its impact is no longer as severe.

### Cause
The root cause appears to be that during fluid network ticks, Create only checks whether the original source fluid capability still exists, but does not further validate its correctness or validity:

[PipeConnection#L86](https://github.com/Creators-of-Create/Create/blob/c54810b31ab5335b59788199dc17010c690c7f20/src/main/java/com/simibubi/create/content/fluids/PipeConnection.java#L86)
```java
if (!source.isPresent() && !determineSource(world, pos))
	return;
```

Additionally, assembling the tank onto a minecart does not remove the corresponding fluid capability. This may or may not be intentional — I am not entirely sure.

The key issue, however, lies in whether adjacent pipes properly handle block updates.

All pipe blocks respond to `neighborChanged` by validating the update and, if valid, propagating changes to the fluid network. However, when placing breakpoints inside `neighborChanged` for **Fluid Valve** and **Smart Fluid Pipe**, I found that their updates always fail validation:

[FluidValveBlock.java#L118](https://github.com/Creators-of-Create/Create/blob/c54810b31ab5335b59788199dc17010c690c7f20/src/main/java/com/simibubi/create/content/fluids/pipes/valve/FluidValveBlock.java#L118)
```java
Direction d = FluidPropagator.validateNeighbourChange(state, world, pos, otherBlock, neighborPos, isMoving);
if (d == null)
	return;
```

Looking deeper into the validation logic, the code checks whether the updated block is a Pump, Glass Fluid Pipe, or a normal Pipe — but notably excludes Fluid Valve and Smart Fluid Pipe.

This happens because the implementation only checks for instances of `AxisPipeBlock`. Unfortunately, both Fluid Valve and Smart Fluid Pipe merely implement the `IAxisPipe` interface. As a result, the fluid network is not properly updated.

[FluidPropagator.java#L216](https://github.com/Creators-of-Create/Create/blob/c54810b31ab5335b59788199dc17010c690c7f20/src/main/java/com/simibubi/create/content/fluids/FluidPropagator.java#L216)
```java
if (state.getBlock() instanceof AxisPipeBlock)
	return state.getValue(AxisPipeBlock.AXIS);
```