### PR TITLE
Only migrate clipboard components on a clipboard

### DIFF
--- a/src/main/java/com/simibubi/create/Create.java
+++ b/src/main/java/com/simibubi/create/Create.java
@@ -102,6 +102,8 @@ public class Create {
 	public static final GlobalLogisticsManager LOGISTICS = new GlobalLogisticsManager();
 	public static final ServerLagger LAGGER = new ServerLagger();
 
+	public static boolean hasBeenRegistered = false;
+
 	public Create(IEventBus eventBus, ModContainer modContainer) {
 		onCtor(eventBus, modContainer);
 	}
@@ -163,6 +165,8 @@ public class Create {
 		// FIXME: this is not thread-safe
 		Mods.CURIOS.executeIfInstalled(() -> () -> Curios.init(modEventBus));
 		Mods.INVENTORYSORTER.executeIfInstalled(() -> () -> InventorySorterCompat.init(modEventBus));
+
+		hasBeenRegistered = true;
 	}
 
 	public static void init(final FMLCommonSetupEvent event) {

--- a/src/main/java/com/simibubi/create/foundation/mixin/ItemStackMixin.java
+++ b/src/main/java/com/simibubi/create/foundation/mixin/ItemStackMixin.java
@@ -11,6 +11,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import com.simibubi.create.AllBlocks;
 import com.simibubi.create.AllDataComponents;
+import com.simibubi.create.Create;
 import com.simibubi.create.content.equipment.clipboard.ClipboardContent;
 
 import net.minecraft.core.component.DataComponentType;
@@ -24,7 +25,7 @@ import net.minecraft.world.level.ItemLike;
 public class ItemStackMixin {
 	@Inject(method = "<init>(Lnet/minecraft/world/level/ItemLike;ILnet/minecraft/core/component/PatchedDataComponentMap;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/Item;verifyComponentsAfterLoad(Lnet/minecraft/world/item/ItemStack;)V"))
 	private void create$migrateOldClipboardComponents(ItemLike item, int count, PatchedDataComponentMap components, CallbackInfo ci) {
-		if (item.asItem() != AllBlocks.CLIPBOARD.get().asItem())
+		if (!Create.hasBeenRegistered || item.asItem() != AllBlocks.CLIPBOARD.get().asItem())
 			return;
 		ClipboardContent content = ClipboardContent.EMPTY;
 

--- a/src/main/java/com/simibubi/create/foundation/mixin/ItemStackMixin.java
+++ b/src/main/java/com/simibubi/create/foundation/mixin/ItemStackMixin.java
@@ -9,6 +9,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import com.simibubi.create.AllBlocks;
 import com.simibubi.create.AllDataComponents;
 import com.simibubi.create.content.equipment.clipboard.ClipboardContent;
 
@@ -23,6 +24,8 @@ import net.minecraft.world.level.ItemLike;
 public class ItemStackMixin {
 	@Inject(method = "<init>(Lnet/minecraft/world/level/ItemLike;ILnet/minecraft/core/component/PatchedDataComponentMap;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/Item;verifyComponentsAfterLoad(Lnet/minecraft/world/item/ItemStack;)V"))
 	private void create$migrateOldClipboardComponents(ItemLike item, int count, PatchedDataComponentMap components, CallbackInfo ci) {
+		if (item.asItem() != AllBlocks.CLIPBOARD.get().asItem())
+			return;
 		ClipboardContent content = ClipboardContent.EMPTY;
 
 		content = create$migrateComponent(content, components, AllDataComponents.CLIPBOARD_PAGES, ClipboardContent::setPages);


### PR DESCRIPTION
Currently the `migrateOldClipboardComponents` Mixin checks for clipboard components on every single itemstack, which causes some minor performance issues. This makes the mixin check if the stack is actually a clipboard before checking its components.