### PR TITLE
Increase epsilon for rotation propagator speed comparison

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/RotationPropagator.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/RotationPropagator.java
@@ -286,7 +286,7 @@ public class RotationPropagator {
 				}
 			}
 
-			if (Math.abs(neighbourTE.getTheoreticalSpeed() - newSpeed) <= 1e-5f)
+			if (Math.abs(neighbourTE.getTheoreticalSpeed() - newSpeed) <= 1e-4f)
 				continue;
 
 			float prevSpeed = neighbourTE.getSpeed();


### PR DESCRIPTION
1e-5f is too small of an epsilon to use for this comparison, replaced it with 1e-4f