### PR TITLE
Fix fluid crashes by ensuring cache is only called when valid

### DIFF
--- a/src/main/java/com/simibubi/create/content/fluids/FlowSource.java
+++ b/src/main/java/com/simibubi/create/content/fluids/FlowSource.java
@@ -83,13 +83,16 @@ public abstract class FlowSource {
 				BlockEntity blockEntity = level.getBlockEntity(location.getConnectedPos());
 				if (blockEntity != null) {
 					if (level instanceof ServerLevel serverLevel) {
-						fluidHandlerCache = ICapabilityProvider.of(BlockCapabilityCache.create(
+						fluidHandlerCache = ICapabilityProvider.of((invalidate) -> BlockCapabilityCache.create(
 							Capabilities.FluidHandler.BLOCK,
 							serverLevel,
 							blockEntity.getBlockPos(),
 							location.getOppositeFace(),
 							() -> !networkBE.isRemoved(),
-							() -> fluidHandlerCache = EMPTY
+							() -> {
+								fluidHandlerCache = EMPTY;
+								invalidate.run();
+							}
 						));
 					} else if (level instanceof PonderLevel) {
 						fluidHandlerCache = ICapabilityProvider.of(() -> level.getCapability(

--- a/src/main/java/com/simibubi/create/foundation/ICapabilityProvider.java
+++ b/src/main/java/com/simibubi/create/foundation/ICapabilityProvider.java
@@ -29,14 +29,10 @@ public interface ICapabilityProvider<T> {
 		private final BlockCapabilityCache<T, C> inner;
 		private volatile boolean invalid;
 
-		private BlockCapabilityCacheProvider(BlockCapabilityCache<T, C> inner) {
-			this.inner = inner;
-			this.invalid = false;
-		}
-
 		private BlockCapabilityCacheProvider(Function<Runnable, BlockCapabilityCache<T, C>> cacheFactory) {
 			this.invalid = false;
-			this.inner = cacheFactory == null ? null : cacheFactory.apply(() -> this.invalid = true);
+			this.inner = cacheFactory == null ? null :
+				cacheFactory.apply(() -> this.invalid = true);
 		}
 
 		@Override

--- a/src/main/java/com/simibubi/create/foundation/ICapabilityProvider.java
+++ b/src/main/java/com/simibubi/create/foundation/ICapabilityProvider.java
@@ -1,6 +1,7 @@
 package com.simibubi.create.foundation;
 
 import java.util.function.Supplier;
+import java.util.function.Function;
 
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
@@ -11,8 +12,8 @@ public interface ICapabilityProvider<T> {
 	@Nullable
 	T getCapability();
 
-	static <T, C> ICapabilityProvider<T> of(BlockCapabilityCache<T, C> cache) {
-		return new BlockCapabilityCacheProvider<>(cache);
+	static <T, C> ICapabilityProvider<T> of(Function<Runnable, BlockCapabilityCache<T, C>> cacheFactory) {
+		return new BlockCapabilityCacheProvider<>(cacheFactory);
 	}
 
 	static <T> ICapabilityProvider<T> of(Supplier<T> supplier) {
@@ -26,14 +27,21 @@ public interface ICapabilityProvider<T> {
 	@ApiStatus.Internal
 	class BlockCapabilityCacheProvider<T, C> implements ICapabilityProvider<T> {
 		private final BlockCapabilityCache<T, C> inner;
+		private volatile boolean invalid;
 
 		private BlockCapabilityCacheProvider(BlockCapabilityCache<T, C> inner) {
 			this.inner = inner;
+			this.invalid = false;
+		}
+
+		private BlockCapabilityCacheProvider(Function<Runnable, BlockCapabilityCache<T, C>> cacheFactory) {
+			this.invalid = false;
+			this.inner = cacheFactory == null ? null : cacheFactory.apply(() -> this.invalid = true);
 		}
 
 		@Override
 		public @Nullable T getCapability() {
-			return inner == null ? null : inner.getCapability();
+			return inner == null || invalid ? null : inner.getCapability();
 		}
 	}
 


### PR DESCRIPTION
Ensure block cache invalidation stops ICapabilityProvider calling getCapability(). Fixes #9965.

Done in reference to [Neoforge's block capability caching](https://docs.neoforged.net/docs/1.21.1/inventories/capabilities/#block-capability-caching).

Attempting to reproduce the error with this setup no longer causes a crash:
<img width="1130" height="886" alt="image" src="https://github.com/user-attachments/assets/4ef0153e-abcd-4ea4-8082-c666419952aa" />
And debugger shows the capability provider being correctly invalidated.