### PR TITLE
Fix belt processing items escape during chunk unload

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/belt/transport/BeltInventory.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/transport/BeltInventory.java
@@ -407,30 +407,24 @@ public class BeltInventory {
 
 	public void read(CompoundTag nbt, HolderLookup.Provider registries) {
 		items.clear();
-		toInsert.clear();
-		toRemove.clear();
 		nbt.getList("Items", Tag.TAG_COMPOUND)
 			.forEach(inbt -> items.add(TransportedItemStack.read((CompoundTag) inbt, registries)));
-		nbt.getList("ToInsert", Tag.TAG_COMPOUND)
-			.forEach(inbt -> toInsert.add(TransportedItemStack.read((CompoundTag) inbt, registries)));
-		nbt.getList("ToRemove", Tag.TAG_COMPOUND)
-			.forEach(inbt -> toRemove.add(TransportedItemStack.read((CompoundTag) inbt, registries)));
 		if (nbt.contains("LazyItem"))
 			lazyClientItem = TransportedItemStack.read(nbt.getCompound("LazyItem"), registries);
 		beltMovementPositive = nbt.getBoolean("PositiveOrder");
 	}
 
 	public CompoundTag write(HolderLookup.Provider registries) {
+		if (!toInsert.isEmpty() || !toRemove.isEmpty()) {
+			toInsert.forEach(this::insert);
+			toInsert.clear();
+			items.removeAll(toRemove);
+			toRemove.clear();
+		}
 		CompoundTag nbt = new CompoundTag();
 		ListTag itemsNBT = new ListTag();
-		ListTag toInsertNBT = new ListTag();
-		ListTag toRemoveNBT = new ListTag();
 		items.forEach(stack -> itemsNBT.add(stack.serializeNBT(registries)));
-		toInsert.forEach(stack -> toInsertNBT.add(stack.serializeNBT(registries)));
-		toRemove.forEach(stack -> toRemoveNBT.add(stack.serializeNBT(registries)));
 		nbt.put("Items", itemsNBT);
-		nbt.put("ToInsert", toInsertNBT);
-		nbt.put("ToRemove", toRemoveNBT);
 		if (lazyClientItem != null)
 			nbt.put("LazyItem", lazyClientItem.serializeNBT(registries));
 		nbt.putBoolean("PositiveOrder", beltMovementPositive);


### PR DESCRIPTION
### Issue
My previous fix (#9954) addressed item loss and duplication during chunk unload by persisting the `toInsert` and `toRemove` lists. However, this fix is not entirely correct and is related to another issue in belt processing machines (e.g. deployer, press, spout, etc.).

When a machine processes items, it:

- Places input items into `toRemove`
- Places output items into `toInsert`

When the chunk is unloaded, these lists are lost. The observed behavior is that items that should have been processed appear to skip the machine and directly reach the downstream belt.

However, after the fix in #9954, the issue became more severe: output items are now generated correctly, but the input items are not properly removed, resulting in item duplication.

### Cause
The root cause is that the `toRemove` list was intended to store references to elements in the `items` list. Persisting it has no meaningful effect. After a chunk reload, this code no longer functions correctly:

[BeltInventory.java#L70](https://github.com/Creators-of-Create/Create/blob/9c7316cbbac79b35105412a3b87792ee7a1a113d/src/main/java/com/simibubi/create/content/kinetics/belt/transport/BeltInventory.java#L70)
```java
items.removeAll(toRemove);
toRemove.clear();
```

### Solution
I now believe that `toInsert` and `toRemove` are transient data and should not be persisted. They should be fully processed before the NBT is written.

Ps: sorry for the follow-up after the previous merge. This issue was discovered while investigating the "items escaping processing machines during chunk unload" behavior -- just earlier today.