### PR TITLE
Basin Partial Fluid Auto-Outputs

### DIFF
--- a/src/main/java/com/simibubi/create/AllTags.java
+++ b/src/main/java/com/simibubi/create/AllTags.java
@@ -87,6 +87,7 @@ public class AllTags {
 
 	public enum AllBlockTags {
 
+        BASIN_COMPATIBLE,
 		BRITTLE,
 		FAN_HEATERS,
 		FAN_TRANSPARENT,

--- a/src/main/java/com/simibubi/create/content/contraptions/processing/BasinBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/processing/BasinBlock.java
@@ -231,7 +231,7 @@ public class BasinBlock extends Block implements ITE<BasinTileEntity>, IWrenchab
 			TileEntityBehaviour.get(world, output, DirectBeltInputBehaviour.TYPE);
 		if (directBeltInputBehaviour != null)
 			return directBeltInputBehaviour.canInsertFromSide(direction);
-		return false;
+		return world.getBlockState(output).is(AllBlockTags.BASIN_COMPATIBLE.tag);
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/contraptions/processing/BasinTileEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/processing/BasinTileEntity.java
@@ -373,13 +373,17 @@ public class BasinTileEntity extends SmartTileEntity implements IHaveGoggleInfor
 				int fill = targetTank instanceof SmartFluidTankBehaviour.InternalFluidHandler
 					? ((SmartFluidTankBehaviour.InternalFluidHandler) targetTank).forceFill(fluidStack.copy(), action)
 					: targetTank.fill(fluidStack.copy(), action);
-				if (fill != fluidStack.getAmount())
+				if (fill == 0)
 					break;
 				if (simulate)
 					continue;
 
 				update = true;
-				iterator.remove();
+                if (fill == fluidStack.getAmount())
+					iterator.remove();
+				else{
+					fluidStack.shrink(fill);
+				}
 				visualizedOutputFluids.add(IntAttached.withZero(fluidStack));
 			}
 		}

--- a/src/main/resources/data/create/tags/blocks/basin_compatible.json
+++ b/src/main/resources/data/create/tags/blocks/basin_compatible.json
@@ -1,0 +1,11 @@
+{
+  "replace": false,
+  "values": [
+    "tconstruct:seared_channel",
+    "tconstruct:scorched_channel",
+    "tconstruct:seared_basin",
+    "tconstruct:scorched_basin",
+    "tconstruct:seared_table",
+    "tconstruct:scorched_table"    
+  ]
+}


### PR DESCRIPTION
Adds support for partial Basin fluid auto-outputs (like with items), and add a block tag for custom Basin auto-output destinations (currently Tinker's Construct channels, basins, and tables)

### Possible `create:basin_compatible` candidates:
- Hopper
- Basket (Farmer's Delight)

## Why 1.16?
This is the earliest version where Basins could auto-output their fluids.