### PR TITLE
Basin Compatibility Tag & Partial Fluid Auto-Output

### DIFF
--- a/src/generated/resources/data/create/tags/block/basin_compatible.json
+++ b/src/generated/resources/data/create/tags/block/basin_compatible.json
@@ -1,0 +1,9 @@
+{
+  "values": [
+    "minecraft:hopper",
+    {
+      "id": "farmersdelight:basket",
+      "required": false
+    }
+  ]
+}

--- a/src/main/java/com/simibubi/create/AllTags.java
+++ b/src/main/java/com/simibubi/create/AllTags.java
@@ -92,6 +92,7 @@ public class AllTags {
 	}
 
 	public enum AllBlockTags {
+		BASIN_COMPATIBLE,
 		BRITTLE,
 		CASING,
 		COPYCAT_ALLOW,

--- a/src/main/java/com/simibubi/create/content/processing/basin/BasinBlock.java
+++ b/src/main/java/com/simibubi/create/content/processing/basin/BasinBlock.java
@@ -2,6 +2,7 @@ package com.simibubi.create.content.processing.basin;
 
 import com.simibubi.create.AllBlockEntityTypes;
 import com.simibubi.create.AllShapes;
+import com.simibubi.create.AllTags.AllBlockTags;
 import com.simibubi.create.Create;
 import com.simibubi.create.content.equipment.wrench.IWrenchable;
 import com.simibubi.create.content.fluids.transfer.GenericItemEmptying;
@@ -216,7 +217,7 @@ public class BasinBlock extends Block implements IBE<BasinBlockEntity>, IWrencha
 			BlockEntityBehaviour.get(world, output, DirectBeltInputBehaviour.TYPE);
 		if (directBeltInputBehaviour != null)
 			return directBeltInputBehaviour.canInsertFromSide(direction);
-		return false;
+		return world.getBlockState(output).is(AllBlockTags.BASIN_COMPATIBLE.tag);
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/processing/basin/BasinBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/processing/basin/BasinBlockEntity.java
@@ -447,13 +447,17 @@ public class BasinBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 				int fill = targetTank instanceof SmartFluidTankBehaviour.InternalFluidHandler
 					? ((SmartFluidTankBehaviour.InternalFluidHandler) targetTank).forceFill(fluidStack.copy(), action)
 					: targetTank.fill(fluidStack.copy(), action);
-				if (fill != fluidStack.getAmount())
+				if (fill == 0)
 					break;
 				if (simulate)
 					continue;
 
 				update = true;
-				iterator.remove();
+				if (fill == fluidStack.getAmount())
+					iterator.remove();
+				else{
+					fluidStack.shrink(fill);
+				}
 				if (visualizedOutputFluids.size() < 3)
 					visualizedOutputFluids.add(IntAttached.withZero(fluidStack));
 			}

--- a/src/main/java/com/simibubi/create/content/processing/basin/BasinBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/processing/basin/BasinBlockEntity.java
@@ -455,9 +455,8 @@ public class BasinBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 				update = true;
 				if (fill == fluidStack.getAmount())
 					iterator.remove();
-				else{
+				else
 					fluidStack.shrink(fill);
-				}
 				if (visualizedOutputFluids.size() < 3)
 					visualizedOutputFluids.add(IntAttached.withZero(fluidStack));
 			}

--- a/src/main/java/com/simibubi/create/infrastructure/data/CreateRegistrateTags.java
+++ b/src/main/java/com/simibubi/create/infrastructure/data/CreateRegistrateTags.java
@@ -49,6 +49,8 @@ public class CreateRegistrateTags {
 	private static void genBlockTags(RegistrateTagsProvider<Block> provIn) {
 		CreateTagsProvider<Block> prov = new CreateTagsProvider<>(provIn, Block::builtInRegistryHolder);
 
+		prov.tag(AllBlockTags.BASIN_COMPATIBLE.tag).add(Blocks.HOPPER);
+
 		prov.tag(AllBlockTags.BRITTLE.tag)
 			.add(Blocks.BELL, Blocks.COCOA, Blocks.FLOWER_POT, Blocks.MOSS_CARPET, Blocks.BAMBOO_SAPLING,
 				Blocks.BIG_DRIPLEAF, Blocks.VINE, Blocks.TWISTING_VINES_PLANT, Blocks.TWISTING_VINES,
@@ -156,6 +158,8 @@ public class CreateRegistrateTags {
 			);
 
 		// COMPAT
+
+		TagGen.addOptional(prov.tag(AllBlockTags.BASIN_COMPATIBLE.tag), Mods.FD, List.of("basket"));
 
 		TagGen.addOptional(prov.tag(AllBlockTags.NON_MOVABLE.tag), Mods.IE, List.of(
 			"connector_lv", "connector_lv_relay", "connector_mv", "connector_mv_relay",


### PR DESCRIPTION
Adds a block tag (`create:basin_compatible`) to allow developers to have Basins auto-output to their blocks. 
Current tag entries:
- Hopper
- Basket (Farmer's Delight)

Also adds support for Basins auto-outputting partial fluid output amounts. (e.g. given an Item Drain has 525mb of Honey and a basin outputting Honey, the Basin will auto-output 975mb of Honey and keep 25mb in the overflow instead of waiting for the Item Drain to have at least 1b of free space.) This also allows outputting to containers that are smaller than the recipe amount (e.g Tinker's Construct Lanterns, which store 50mb).