### PR TITLE
Fix hose pulley deleting fluid blocks when extracting FluidStack.EMPTY

### DIFF
--- a/src/main/java/com/simibubi/create/content/fluids/FluidNetwork.java
+++ b/src/main/java/com/simibubi/create/content/fluids/FluidNetwork.java
@@ -185,6 +185,8 @@ public class FluidNetwork {
 		Map<IFluidHandler, Integer> accumulatedFill = new IdentityHashMap<>();
 
 		for (boolean simulate : Iterate.trueAndFalse) {
+			if (flowSpeed <= 0)
+				break;
 			FluidAction action = simulate ? FluidAction.SIMULATE : FluidAction.EXECUTE;
 
 			if (source == null)

--- a/src/main/java/com/simibubi/create/content/fluids/hosePulley/HosePulleyFluidHandler.java
+++ b/src/main/java/com/simibubi/create/content/fluids/hosePulley/HosePulleyFluidHandler.java
@@ -57,6 +57,8 @@ public class HosePulleyFluidHandler implements IFluidHandler {
 
 	@Override
 	public FluidStack drain(FluidStack resource, FluidAction action) {
+		if (resource.isEmpty())
+			return FluidStack.EMPTY;
 		return drainInternal(resource.getAmount(), resource, action);
 	}
 


### PR DESCRIPTION
### Description

When a pump connected to a hose pulley tries to extract fluid while its target is already full, hose pulley will delete the fluid block.
<img width="854" height="480" alt="2026-03-14_00 40 34" src="https://github.com/user-attachments/assets/d64787e6-ffee-4ba5-aa36-5165c8ae5637" />


### Cause

The issue is caused by an inconsistent handling of FluidStack.EMPTY.

1. Hose pulley extraction logic

In [HosePulleyFluidHandler::drainInternal](https://github.com/Creators-of-Create/Create/blob/0a17a7243c3e5e6e3ceb34450d9c6df240af1b83/src/main/java/com/simibubi/create/content/fluids/hosePulley/HosePulleyFluidHandler.java#L68):

The hose pulley removes the fluid block (line 75) and attempts to place the remainder into its internal tank (line 94).
However, the check at line 87 compares the requested fluid (EMPTY) with the actual fluid (Water) and aborts early.

As a result, the fluid block has already been removed but no fluid is stored.

<img width="1672" height="825" alt="QQ20260314-004131" src="https://github.com/user-attachments/assets/899bd8ca-e983-4e8b-9d01-4863632e8eb0" />

2. Pump requesting `FluidStack.EMPTY`

Looking at [FluidNetwork::tick](https://github.com/Creators-of-Create/Create/blob/0a17a7243c3e5e6e3ceb34450d9c6df240af1b83/src/main/java/com/simibubi/create/content/fluids/FluidNetwork.java#L203):

During the previous simulation step, the pump already determined it needs to extract 0 mB of fluid.

Later, line 201 confirms the hose pulley can provide water. The pump then requests 0 mB of water, which effectively becomes FluidStack.EMPTY.
<img width="1653" height="503" alt="4c0f0500-4471-414e-ab12-02d4f190eb9c" src="https://github.com/user-attachments/assets/b3bbad07-ed90-43c2-92da-fb16ff4b2cab" />


### Fix

Either side fixing the issue would work, but this PR applies both fixes:

- Prevent pumps from requesting 0 mB fluid, since extracting zero fluid has no meaningful effect.
- Make the hose pulley ignore FluidStack.EMPTY extraction requests, as other mods' pumps might still request empty stacks.
