### PR TITLE
[POC] Reduce contraption flickering when disassembling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,7 +124,7 @@ repositories {
 dependencies {
     jarJar(implementation("com.tterrag.registrate:Registrate:$registrate_version"))
 
-    compileOnly("dev.engine-room.flywheel:flywheel-neoforge-api-$minecraft_version:$flywheel_version")
+    compileOnly("dev.engine-room.flywheel:flywheel-neoforge-$minecraft_version:$flywheel_version")
     runtimeOnly(jarJar("dev.engine-room.flywheel:flywheel-neoforge-$minecraft_version:$flywheel_version") {
         version {
             strictly "[${flywheel_version},2.0)"

--- a/src/main/java/com/simibubi/create/content/contraptions/AbstractContraptionEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/AbstractContraptionEntity.java
@@ -8,6 +8,8 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.UUID;
 
+import net.minecraft.world.level.entity.EntityInLevelCallback;
+
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.jetbrains.annotations.NotNull;
@@ -89,6 +91,7 @@ public abstract class AbstractContraptionEntity extends Entity implements IEntit
 	protected boolean initialized;
 	protected boolean prevPosInvalid;
 	private boolean skipActorStop;
+	private ClientContraptionStatus clientContraptionStatus = ClientContraptionStatus.ALIVE;
 
 	/*
 	 * staleTicks are a band-aid to prevent a frame or two of missing blocks between
@@ -933,5 +936,19 @@ public abstract class AbstractContraptionEntity extends Entity implements IEntit
 
 	public boolean isPrevPosInvalid() {
 		return prevPosInvalid;
+	}
+
+	@Override
+	public void setLevelCallback(EntityInLevelCallback levelCallback) {
+		EntityInLevelCallback contraptionLevel = new ContraptionInClientLevel(levelCallback, this);
+		super.setLevelCallback(contraptionLevel);
+	}
+
+	public void setClientContraptionStatus(ClientContraptionStatus status) {
+		this.clientContraptionStatus = status;
+	}
+
+	public ClientContraptionStatus getClientContraptionStatus() {
+		return clientContraptionStatus;
 	}
 }

--- a/src/main/java/com/simibubi/create/content/contraptions/ClientContraptionStatus.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/ClientContraptionStatus.java
@@ -1,0 +1,7 @@
+package com.simibubi.create.content.contraptions;
+
+public enum ClientContraptionStatus {
+	ALIVE,
+	MARKED_FOR_REMOVAL,
+	DO_REMOVE,
+}

--- a/src/main/java/com/simibubi/create/content/contraptions/ContraptionInClientLevel.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/ContraptionInClientLevel.java
@@ -1,0 +1,67 @@
+package com.simibubi.create.content.contraptions;
+
+import com.simibubi.create.content.contraptions.pulley.PulleyContraption;
+
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.world.entity.Entity.RemovalReason;
+import net.minecraft.world.level.entity.EntityInLevelCallback;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ContraptionInClientLevel implements EntityInLevelCallback {
+	EntityInLevelCallback base;
+	AbstractContraptionEntity entity;
+	final int maxDelayTicks = 2;
+	static Map<ContraptionInClientLevel, Integer> delayedRemovals = new HashMap<>();
+
+	ContraptionInClientLevel(EntityInLevelCallback base, AbstractContraptionEntity entity) {
+		this.base = base;
+		this.entity = entity;
+	}
+
+	@Override
+	public void onMove() {
+		this.base.onMove();
+	}
+
+	@Override
+	public void onRemove(@NotNull RemovalReason removalReason) {
+		if (entity.level() instanceof ClientLevel && removalReason == RemovalReason.DISCARDED
+			&& !delayedRemovals.containsKey(this) && entity.contraption != null) {
+			entity.collidingEntities.clear();
+			int forced_tick = 0;
+			if (entity.getContraption() instanceof PulleyContraption)
+				forced_tick = 2;
+			delayedRemovals.put(this, -forced_tick);
+		} else {
+			this.base.onRemove(removalReason);
+		}
+	}
+
+	public void remove() {
+		this.base.onRemove(RemovalReason.DISCARDED);
+	}
+
+	public static void tick() {
+		delayedRemovals.entrySet().removeIf(entry -> {
+			ContraptionInClientLevel callback = entry.getKey();
+			int ticks = entry.getValue();
+			entry.setValue(ticks + 1);
+			if (ticks < 0)
+				return false;
+
+			AbstractContraptionEntity e = callback.entity;
+			ClientContraptionStatus status = e.getClientContraptionStatus();
+			if (ticks >= callback.maxDelayTicks || status == ClientContraptionStatus.DO_REMOVE) {
+				callback.remove();
+				return true;
+			}
+			if (status == ClientContraptionStatus.ALIVE)
+				e.setClientContraptionStatus(ClientContraptionStatus.MARKED_FOR_REMOVAL);
+			return false;
+		});
+	}
+}

--- a/src/main/java/com/simibubi/create/content/contraptions/ContraptionInClientLevel.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/ContraptionInClientLevel.java
@@ -29,7 +29,7 @@ public class ContraptionInClientLevel implements EntityInLevelCallback {
 
 	@Override
 	public void onRemove(@NotNull RemovalReason removalReason) {
-		if (entity.level() instanceof ClientLevel && removalReason == RemovalReason.DISCARDED
+		if (entity.level().isClientSide && removalReason == RemovalReason.DISCARDED
 			&& !delayedRemovals.containsKey(this) && entity.contraption != null) {
 			entity.collidingEntities.clear();
 			int forced_tick = 0;

--- a/src/main/java/com/simibubi/create/content/contraptions/render/ContraptionEntityRenderer.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/render/ContraptionEntityRenderer.java
@@ -1,5 +1,10 @@
 package com.simibubi.create.content.contraptions.render;
 
+import com.simibubi.create.content.contraptions.ClientContraptionStatus;
+import com.simibubi.create.foundation.mixin.accessor.ClientLevelAccessor;
+
+import net.minecraft.client.renderer.LevelRenderer;
+
 import org.apache.commons.lang3.tuple.Pair;
 
 import com.mojang.blaze3d.vertex.PoseStack;
@@ -13,6 +18,7 @@ import com.simibubi.create.foundation.render.BlockEntityRenderHelper;
 import com.simibubi.create.foundation.virtualWorld.VirtualRenderWorld;
 
 import dev.engine_room.flywheel.api.visualization.VisualizationManager;
+import dev.engine_room.flywheel.impl.visualization.VisualizationEventHandler;
 import dev.engine_room.flywheel.lib.transform.TransformStack;
 import net.createmod.catnip.animation.AnimationTickHolder;
 import net.createmod.catnip.render.ShadedBlockSbbBuilder;
@@ -106,6 +112,23 @@ public class ContraptionEntityRenderer<C extends AbstractContraptionEntity> exte
 	@Override
 	public void render(C entity, float yaw, float partialTicks, PoseStack poseStack, MultiBufferSource buffers,
 		int overlay) {
+		ClientContraptionStatus status = entity.getClientContraptionStatus();
+		Level level = entity.level();
+
+		switch (status) {
+			case MARKED_FOR_REMOVAL -> {
+				LevelRenderer levelRenderer = ((ClientLevelAccessor) level).create$getLevelRenderer();
+				if (levelRenderer.isSectionCompiled(entity.blockPosition())) {
+					entity.setClientContraptionStatus(ClientContraptionStatus.DO_REMOVE);
+				}
+			}
+			case DO_REMOVE -> {
+				if (VisualizationManager.supportsVisualization(entity.level()))
+					VisualizationEventHandler.onEntityLeaveLevel(entity.level(), entity);
+				return;
+			}
+		}
+
 		super.render(entity, yaw, partialTicks, poseStack, buffers, overlay);
 
 		Contraption contraption = entity.getContraption();
@@ -113,7 +136,6 @@ public class ContraptionEntityRenderer<C extends AbstractContraptionEntity> exte
 			return;
 		}
 
-		Level level = entity.level();
 		ClientContraption clientContraption = contraption.getOrCreateClientContraptionLazy();
 		VirtualRenderWorld renderWorld = clientContraption.getRenderLevel();
 		ContraptionMatrices matrices = clientContraption.getMatrices();

--- a/src/main/java/com/simibubi/create/foundation/events/CommonEvents.java
+++ b/src/main/java/com/simibubi/create/foundation/events/CommonEvents.java
@@ -66,6 +66,7 @@ import com.simibubi.create.foundation.recipe.trie.RecipeTrieFinder;
 import com.simibubi.create.foundation.utility.ServerSpeedProvider;
 import com.simibubi.create.foundation.utility.TickBasedCache;
 import com.simibubi.create.infrastructure.command.AllCommands;
+import com.simibubi.create.content.contraptions.ContraptionInClientLevel;
 
 import net.createmod.catnip.data.WorldAttached;
 import net.minecraft.server.level.ServerPlayer;
@@ -109,6 +110,11 @@ public class CommonEvents {
 		TrainMapSync.serverTick(event);
 		ServerChainConveyorHandler.tick();
 		TickBasedCache.tick();
+	}
+
+	@SubscribeEvent
+	public static void onPreClientTick(net.neoforged.neoforge.client.event.ClientTickEvent.Pre event) {
+		ContraptionInClientLevel.tick();
 	}
 
 	@SubscribeEvent

--- a/src/main/java/com/simibubi/create/foundation/mixin/accessor/ClientLevelAccessor.java
+++ b/src/main/java/com/simibubi/create/foundation/mixin/accessor/ClientLevelAccessor.java
@@ -1,0 +1,13 @@
+package com.simibubi.create.foundation.mixin.accessor;
+
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.renderer.LevelRenderer;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(ClientLevel.class)
+public interface ClientLevelAccessor {
+	@Accessor("levelRenderer")
+	LevelRenderer create$getLevelRenderer();
+}

--- a/src/main/resources/create.mixins.json
+++ b/src/main/resources/create.mixins.json
@@ -52,6 +52,7 @@
   ],
   "client": [
     "accessor.AgeableListModelAccessor",
+    "accessor.ClientLevelAccessor",
     "accessor.EntityRenderDispatcherAccessor",
     "accessor.FontAccessor",
     "accessor.GuiAccessor",


### PR DESCRIPTION
Contraptions disappear for a few frames when disassembling

https://github.com/user-attachments/assets/2dbde8ed-63de-4c12-ae3f-44e866755a2a

This happens because entities disappear immediately when they are discarded, while terrain sections need to be compiled and uploaded before they can be rendered.
Section compiling is asynchronous.

Workflow:
```
Client Side:

Render thread:
-> Discard Contraption Entity
-> SetBlock
-> Mark Section Dirty
-> Render entities (the contraption was discarded, so it no longer renders)

Worker thread:
-> Compile dirty section
-> Mark section not dirty
-> Upload section
-> Refresh section (now it becomes visible)
```

This PR delays client-side contraption discarding by overriding setLevelCallback in Entity, and discards the entity after the section has been compiled.

https://github.com/user-attachments/assets/4c8bc7cc-9711-4a72-aae9-b53f09a6c267

However, section compiling done ≠ section visible, and we don't know exactly when the section will actually be rendered.
So the contraption may still disappear for a few frames sometimes, but it should be better than before.
From 26.1, there is a method called isSectionCompiledAndVisible, so this PR may work better with 26.1.

Sodium tends to have lower latency between compiling and showing sections than vanilla, so contraptions will flicker less when using Sodium.

Notes

This PR is a dirty hack, because:
* It modifies an entity during the render method
* It calls Flywheel internal functions