### PR TITLE
Fix stock ticker crash when saving chunks with cc

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/stockTicker/StockTickerBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/stockTicker/StockTickerBlockEntity.java
@@ -106,7 +106,8 @@ public class StockTickerBlockEntity extends StockCheckingBlockEntity implements 
 	@Override
 	public void invalidate() {
 		super.invalidate();
-		computerBehaviour.removePeripheral();
+		if (computerBehaviour != null)
+			computerBehaviour.removePeripheral();
 	}
 
 	public void refreshClientStockSnapshot() {


### PR DESCRIPTION
Fixes the following crash I get when saving chunks(both unloading/reloading) that have a stock ticker.
Definitely a hotfix, didnt dive into why it'd be null.
```
[09:32:48] [Server thread/ERROR] [minecraft/ChunkMap]: Failed to save chunk [-3, -14]
java.util.concurrent.CompletionException: java.lang.NullPointerException: Cannot invoke "com.simibubi.create.compat.computercraft.AbstractComputerBehaviour.removePeripheral()" because "this.computerBehaviour" is null
	at java.base/java.util.concurrent.CompletableFuture.wrapInCompletionException(CompletableFuture.java:323) ~[?:?] {re:mixin}
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:359) [?:?] {re:mixin}
	at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:364) [?:?] {re:mixin}
	at java.base/java.util.concurrent.CompletableFuture$UniRun.tryFire(CompletableFuture.java:812) [?:?] {}
	at java.base/java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:503) [?:?] {}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.level.ChunkMap.processUnloads(ChunkMap.java:492) [client-1.21.1-20240808.144430-srg.jar%23313!/:?] {re:mixin,pl:accesstransformer:B,pl:connector_pre_launch:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:smoothchunk.mixins.json:ChunkMapMixin from mod smoothchunk,pl:mixin:APP:smoothchunk.mixins.json:ChunkMapSlowUnload from mod smoothchunk,pl:mixin:APP:railways-common.mixins.json:conductor_possession.CameraChunkTrackingMixin from mod railways,pl:mixin:APP:railways.mixins.json:ChunkMapAccessor from mod railways,pl:mixin:APP:fabric-networking-api-v1.mixins.json:accessor.ServerChunkLoadingManagerAccessor from mod fabric_networking_api_v1,pl:mixin:APP:ae2.mixins.json:chunkloading.ChunkMapMixin from mod ae2,pl:mixin:A,pl:connector_pre_launch:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.level.ChunkMap.tick(ChunkMap.java:448) [client-1.21.1-20240808.144430-srg.jar%23313!/:?] {re:mixin,pl:accesstransformer:B,pl:connector_pre_launch:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:smoothchunk.mixins.json:ChunkMapMixin from mod smoothchunk,pl:mixin:APP:smoothchunk.mixins.json:ChunkMapSlowUnload from mod smoothchunk,pl:mixin:APP:railways-common.mixins.json:conductor_possession.CameraChunkTrackingMixin from mod railways,pl:mixin:APP:railways.mixins.json:ChunkMapAccessor from mod railways,pl:mixin:APP:fabric-networking-api-v1.mixins.json:accessor.ServerChunkLoadingManagerAccessor from mod fabric_networking_api_v1,pl:mixin:APP:ae2.mixins.json:chunkloading.ChunkMapMixin from mod ae2,pl:mixin:A,pl:connector_pre_launch:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.level.ServerChunkCache.tick(ServerChunkCache.java:326) [client-1.21.1-20240808.144430-srg.jar%23313!/:?] {re:mixin,pl:accesstransformer:B,pl:connector_pre_launch:A,re:classloading,pl:accesstransformer:B,pl:mixin:A,pl:connector_pre_launch:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.MinecraftServer.stopServer(MinecraftServer.java:616) [client-1.21.1-20240808.144430-srg.jar%23313!/:?] {re:mixin,pl:accesstransformer:B,pl:connector_pre_launch:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:balm.neoforge.mixins.json:MinecraftServerMixin from mod balm,pl:mixin:APP:exposure-common.mixins.json:MinecraftServerMixin from mod exposure,pl:mixin:APP:xaerohud.mixins.json:MixinMinecraftServer from mod xaerominimap,pl:mixin:APP:fabric-message-api-v1.mixins.json:MinecraftServerMixin from mod fabric_message_api_v1,pl:mixin:APP:xaeroworldmap.mixins.json:MixinMinecraftServer from mod xaeroworldmap,pl:mixin:APP:fabric-lifecycle-events-v1.mixins.json:MinecraftServerMixin from mod fabric_lifecycle_events_v1,pl:mixin:APP:fabric-resource-loader-v0.mixins.json:MinecraftServerMixin from mod fabric_resource_loader_v0,pl:mixin:APP:ae2.mixins.json:spatial.MinecraftServerMixin from mod ae2,pl:mixin:APP:ponder-common.mixins.json:accessor.MinecraftServerAccessor from mod ponder,pl:mixin:A,pl:connector_pre_launch:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.client.server.IntegratedServer.stopServer(IntegratedServer.java:221) [client-1.21.1-20240808.144430-srg.jar%23313!/:?] {re:mixin,pl:connector_pre_launch:A,pl:runtimedistcleaner:A,re:classloading,pl:mixin:APP:ok_zoomer.mixins.json:IntegratedServerMixin from mod ok_zoomer,pl:mixin:A,pl:connector_pre_launch:A,pl:runtimedistcleaner:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:742) [client-1.21.1-20240808.144430-srg.jar%23313!/:?] {re:mixin,pl:accesstransformer:B,pl:connector_pre_launch:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:balm.neoforge.mixins.json:MinecraftServerMixin from mod balm,pl:mixin:APP:exposure-common.mixins.json:MinecraftServerMixin from mod exposure,pl:mixin:APP:xaerohud.mixins.json:MixinMinecraftServer from mod xaerominimap,pl:mixin:APP:fabric-message-api-v1.mixins.json:MinecraftServerMixin from mod fabric_message_api_v1,pl:mixin:APP:xaeroworldmap.mixins.json:MixinMinecraftServer from mod xaeroworldmap,pl:mixin:APP:fabric-lifecycle-events-v1.mixins.json:MinecraftServerMixin from mod fabric_lifecycle_events_v1,pl:mixin:APP:fabric-resource-loader-v0.mixins.json:MinecraftServerMixin from mod fabric_resource_loader_v0,pl:mixin:APP:ae2.mixins.json:spatial.MinecraftServerMixin from mod ae2,pl:mixin:APP:ponder-common.mixins.json:accessor.MinecraftServerAccessor from mod ponder,pl:mixin:A,pl:connector_pre_launch:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:267) [client-1.21.1-20240808.144430-srg.jar%23313!/:?] {re:mixin,pl:accesstransformer:B,pl:connector_pre_launch:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:balm.neoforge.mixins.json:MinecraftServerMixin from mod balm,pl:mixin:APP:exposure-common.mixins.json:MinecraftServerMixin from mod exposure,pl:mixin:APP:xaerohud.mixins.json:MixinMinecraftServer from mod xaerominimap,pl:mixin:APP:fabric-message-api-v1.mixins.json:MinecraftServerMixin from mod fabric_message_api_v1,pl:mixin:APP:xaeroworldmap.mixins.json:MixinMinecraftServer from mod xaeroworldmap,pl:mixin:APP:fabric-lifecycle-events-v1.mixins.json:MinecraftServerMixin from mod fabric_lifecycle_events_v1,pl:mixin:APP:fabric-resource-loader-v0.mixins.json:MinecraftServerMixin from mod fabric_resource_loader_v0,pl:mixin:APP:ae2.mixins.json:spatial.MinecraftServerMixin from mod ae2,pl:mixin:APP:ponder-common.mixins.json:accessor.MinecraftServerAccessor from mod ponder,pl:mixin:A,pl:connector_pre_launch:A}
	at java.base/java.lang.Thread.run(Thread.java:1474) [?:?] {re:mixin}
Caused by: java.lang.NullPointerException: Cannot invoke "com.simibubi.create.compat.computercraft.AbstractComputerBehaviour.removePeripheral()" because "this.computerBehaviour" is null
	at TRANSFORMER/create@6.0.9/com.simibubi.create.content.logistics.stockTicker.StockTickerBlockEntity.invalidate(StockTickerBlockEntity.java:109) ~[create-1.21.1-6.0.9.jar%23349!/:6.0.9] {re:mixin,re:classloading,pl:mixin:APP:emiforcreatestock.mixins.json:StockTickerBlockEntityMixin$StockTickerBlockEntityMixin_ from mod emiforcreatestock,pl:mixin:APP:emiforcreatestock.mixins.json:StockTickerBlockEntityMixin from mod emiforcreatestock,pl:mixin:A}
	at TRANSFORMER/create@6.0.9/com.simibubi.create.foundation.blockEntity.SmartBlockEntity.setRemoved(SmartBlockEntity.java:138) ~[create-1.21.1-6.0.9.jar%23349!/:6.0.9] {re:mixin,re:classloading,pl:mixin:APP:create_enchantment_industry.mixins.json:SmartBlockEntityMixin from mod create_enchantment_industry,pl:mixin:A}
	at MC-BOOTSTRAP/it.unimi.dsi.fastutil@8.5.12/it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap$1.forEach(Object2ObjectOpenHashMap.java:1188) ~[fastutil-8.5.12.jar%23133!/:?] {}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.level.chunk.LevelChunk.clearAllBlockEntities(LevelChunk.java:618) ~[client-1.21.1-20240808.144430-srg.jar%23313!/:?] {re:mixin,pl:accesstransformer:B,pl:connector_pre_launch:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:xaerohud.mixins.json:MixinWorldChunk from mod xaerominimap,pl:mixin:APP:xaeroworldmap.mixins.json:MixinWorldChunk from mod xaeroworldmap,pl:mixin:APP:fabric-lifecycle-events-v1.client.mixins.json:WorldChunkMixin from mod fabric_lifecycle_events_v1,pl:mixin:APP:copycats-common.mixins.json:foundation.copycat.migration.LevelChunkMixin from mod copycats,pl:mixin:APP:flywheel.impl.mixins.json:visualmanage.LevelChunkMixin from mod flywheel,pl:mixin:A,pl:connector_pre_launch:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.level.ServerLevel.unload(ServerLevel.java:954) ~[client-1.21.1-20240808.144430-srg.jar%23313!/:?] {re:mixin,pl:accesstransformer:B,pl:connector_pre_launch:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:cupboard.mixins.json:ServerAddEntityMixin from mod cupboard,pl:mixin:APP:polymorph.mixins.json:MixinServerLevel from mod polymorph,pl:mixin:APP:xaeroworldmap.mixins.json:MixinServerWorld from mod xaeroworldmap,pl:mixin:APP:fabric-api-lookup-api-v1.mixins.json:ServerWorldMixin from mod fabric_api_lookup_api_v1,pl:mixin:APP:fabric-lifecycle-events-v1.mixins.json:ServerWorldMixin from mod fabric_lifecycle_events_v1,pl:mixin:APP:comforts.mixins.json:MixinServerSleepStatus from mod comforts,pl:mixin:APP:axiom.mixins.json:world_properties.MixinServerLevel from mod axiom,pl:mixin:APP:create.mixins.json:accessor.ServerLevelAccessor from mod create,pl:mixin:A,pl:connector_pre_launch:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.level.ChunkMap.lambda$scheduleUnload$12(ChunkMap.java:521) ~[client-1.21.1-20240808.144430-srg.jar%23313!/:?] {re:mixin,pl:accesstransformer:B,pl:connector_pre_launch:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:smoothchunk.mixins.json:ChunkMapMixin from mod smoothchunk,pl:mixin:APP:smoothchunk.mixins.json:ChunkMapSlowUnload from mod smoothchunk,pl:mixin:APP:railways-common.mixins.json:conductor_possession.CameraChunkTrackingMixin from mod railways,pl:mixin:APP:railways.mixins.json:ChunkMapAccessor from mod railways,pl:mixin:APP:fabric-networking-api-v1.mixins.json:accessor.ServerChunkLoadingManagerAccessor from mod fabric_networking_api_v1,pl:mixin:APP:ae2.mixins.json:chunkloading.ChunkMapMixin from mod ae2,pl:mixin:A,pl:connector_pre_launch:A}
	at java.base/java.util.concurrent.CompletableFuture$UniRun.tryFire(CompletableFuture.java:808) ~[?:?] {}
	... 9 more
```