### PR TITLE
[fix] Fix Redstone Link desyncs

### DIFF
--- a/src/main/java/com/simibubi/create/content/redstone/link/LinkBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/redstone/link/LinkBehaviour.java
@@ -113,6 +113,17 @@ public class LinkBehaviour extends BlockEntityBehaviour implements IRedstoneLink
 		newPosition = true;
 	}
 
+	public void ensureIsInNetwork() {
+		//Quite frequently, without any call to removeFromNetwork, a LinkBehaviour disappears from its network, we ensure it's corrected as fast as possible
+		for( IRedstoneLinkable linkable : getHandler().getNetworkOf(getWorld(), this))
+		{
+			if(linkable == this)
+				return;
+		}
+
+		getHandler().addToNetwork(getWorld(), this);
+	}
+
 	@Override
 	public Couple<Frequency> getNetworkKey() {
 		return Couple.create(frequencyFirst, frequencyLast);

--- a/src/main/java/com/simibubi/create/content/redstone/link/LinkBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/redstone/link/LinkBehaviour.java
@@ -95,6 +95,8 @@ public class LinkBehaviour extends BlockEntityBehaviour implements IRedstoneLink
 
 	@Override
 	public void setReceivedStrength(int networkPower) {
+		if (!newPosition)
+			return;
 		signalCallback.accept(networkPower);
 	}
 

--- a/src/main/java/com/simibubi/create/content/redstone/link/LinkBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/redstone/link/LinkBehaviour.java
@@ -95,8 +95,6 @@ public class LinkBehaviour extends BlockEntityBehaviour implements IRedstoneLink
 
 	@Override
 	public void setReceivedStrength(int networkPower) {
-		if (!newPosition)
-			return;
 		signalCallback.accept(networkPower);
 	}
 

--- a/src/main/java/com/simibubi/create/content/redstone/link/RedstoneLinkBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/redstone/link/RedstoneLinkBlockEntity.java
@@ -118,6 +118,8 @@ public class RedstoneLinkBlockEntity extends SmartBlockEntity {
 		if (receivedSignalChanged) {
 			updateSelfAndAttached(blockState);
 		}
+
+		link.ensureIsInNetwork();
 	}
 
 	@Override


### PR DESCRIPTION
Hello, 
This pull request is an attempt to fix the problems with Redstone Links de-linking from one another during chunk reloads on certain conditions. These issues have been reported in https://github.com/Creators-of-Create/Create/issues/3467 https://github.com/Creators-of-Create/Create/issues/5009 https://github.com/Creators-of-Create/Create/issues/8934 https://github.com/Creators-of-Create/Create/issues/8806 https://github.com/Creators-of-Create/Create/issues/6690 https://github.com/Creators-of-Create/Create/issues/4276

Since this is a little hard to reproduce, I tested my fix in those conditions: I placed 1 emitter and receptor and while it was off, I made a "F3+I" copy of the receptor, capturing it in this state. I then turned on the contraption, and using a command block I replaced the receptor (at that point turned on) by its off copy. The pair would now be out of sync, with the receptor staying off. Note that the same thing would happen with a copy of the receptor turned on pasted onto an off receptor. After my fix, attempting to replace the receptor by its "opposite copy" result in it almost immediately switching back to the right state.

While investigating, I found that what prevented the receptor from updating itself in the bug condition was the "if (!newPosition)" check of "setReceivedStrength". I'm new to coding for the Create mod, so I could be disrupting something important, but I noticed that the check dated back from 2020 and that under normal circumstances (a pair of working links), the code never returns because of this check and the rest of the function is executed every frame.