### PR TITLE
Fix Punch and Power enchantment not being applied to PotatoCannon

### DIFF
--- a/src/main/java/com/simibubi/create/content/equipment/potatoCannon/PotatoProjectileEntity.java
+++ b/src/main/java/com/simibubi/create/content/equipment/potatoCannon/PotatoProjectileEntity.java
@@ -1,5 +1,7 @@
 package com.simibubi.create.content.equipment.potatoCannon;
 
+import net.minecraft.world.item.enchantment.Enchantments;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -75,9 +77,14 @@ public class PotatoProjectileEntity extends AbstractHurtingProjectile implements
 		Registry<Enchantment> enchantmentRegistry = registryAccess().registryOrThrow(Registries.ENCHANTMENT);
 
 		int recovery = cannon.getEnchantmentLevel(enchantmentRegistry.getHolderOrThrow(AllEnchantments.POTATO_RECOVERY));
+		int power = cannon.getEnchantmentLevel(enchantmentRegistry.getHolderOrThrow(Enchantments.POWER));
+		int knockback = cannon.getEnchantmentLevel(enchantmentRegistry.getHolderOrThrow(Enchantments.PUNCH));
 
 		if (recovery > 0)
 			recoveryChance = .125f + recovery * .125f;
+
+		additionalDamageMult = power * 0.2f;
+		additionalKnockback = knockback * 0.5f;
 	}
 
 	public ItemStack getItem() {


### PR DESCRIPTION
This pull request attempts to fix the issue of Power (and Punch) enchantment not applied to Potato Cannon, as it has been pointed out in #8030.

## Description
Fixed PotatoProjectileEntity so that it reads enchantment levels and set the damage multiplier and knockback accordingly.
The calculations are based on the calculations found in `appendHoverText()` from `PotatoCannonItem.java`.