### PR TITLE
Fix Punch, Power and Flame enchament having no effect on potato cannon

### DIFF
--- a/src/main/java/com/simibubi/create/content/equipment/potatoCannon/PotatoProjectileEntity.java
+++ b/src/main/java/com/simibubi/create/content/equipment/potatoCannon/PotatoProjectileEntity.java
@@ -83,7 +83,7 @@ public class PotatoProjectileEntity extends AbstractHurtingProjectile implements
 		if (recovery > 0)
 			recoveryChance = .125f + recovery * .125f;
 
-		additionalDamageMult = power * 0.2f;
+		additionalDamageMult = 1 + power * 0.2f;
 		additionalKnockback = knockback * 0.5f;
 	}
 

--- a/src/main/java/com/simibubi/create/content/equipment/potatoCannon/PotatoProjectileEntity.java
+++ b/src/main/java/com/simibubi/create/content/equipment/potatoCannon/PotatoProjectileEntity.java
@@ -1,7 +1,5 @@
 package com.simibubi.create.content.equipment.potatoCannon;
 
-import net.minecraft.world.item.enchantment.Enchantments;
-
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -28,17 +26,23 @@ import net.minecraft.network.protocol.game.ClientboundGameEventPacket;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.tags.DamageTypeTags;
+import net.minecraft.tags.EntityTypeTags;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.MobCategory;
+import net.minecraft.world.entity.boss.enderdragon.EnderDragon;
 import net.minecraft.world.entity.boss.wither.WitherBoss;
+import net.minecraft.world.entity.monster.Spider;
+import net.minecraft.world.entity.monster.Witch;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.projectile.AbstractHurtingProjectile;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
+import net.minecraft.world.item.enchantment.Enchantments;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.EntityHitResult;
@@ -58,6 +62,7 @@ public class PotatoProjectileEntity extends AbstractHurtingProjectile implements
 
 	protected float additionalDamageMult = 1;
 	protected float additionalKnockback = 0;
+	protected boolean additionalFlame = false;
 	protected float recoveryChance = 0;
 
 	public PotatoProjectileEntity(EntityType<? extends AbstractHurtingProjectile> type, Level level) {
@@ -79,12 +84,14 @@ public class PotatoProjectileEntity extends AbstractHurtingProjectile implements
 		int recovery = cannon.getEnchantmentLevel(enchantmentRegistry.getHolderOrThrow(AllEnchantments.POTATO_RECOVERY));
 		int power = cannon.getEnchantmentLevel(enchantmentRegistry.getHolderOrThrow(Enchantments.POWER));
 		int knockback = cannon.getEnchantmentLevel(enchantmentRegistry.getHolderOrThrow(Enchantments.PUNCH));
+		int flame = cannon.getEnchantmentLevel(enchantmentRegistry.getHolderOrThrow(Enchantments.FLAME));
 
 		if (recovery > 0)
 			recoveryChance = .125f + recovery * .125f;
 
 		additionalDamageMult = 1 + power * 0.2f;
 		additionalKnockback = knockback * 0.5f;
+		additionalFlame = flame > 0;
 	}
 
 	public ItemStack getItem() {
@@ -101,6 +108,7 @@ public class PotatoProjectileEntity extends AbstractHurtingProjectile implements
 		setItem(ItemStack.parseOptional(this.registryAccess(), nbt.getCompound("Item")));
 		additionalDamageMult = nbt.getFloat("AdditionalDamage");
 		additionalKnockback = nbt.getFloat("AdditionalKnockback");
+		additionalFlame = nbt.getBoolean("AdditionalFlame");
 		recoveryChance = nbt.getFloat("Recovery");
 		super.readAdditionalSaveData(nbt);
 	}
@@ -110,6 +118,7 @@ public class PotatoProjectileEntity extends AbstractHurtingProjectile implements
 		nbt.put("Item", stack.saveOptional(this.registryAccess()));
 		nbt.putFloat("AdditionalDamage", additionalDamageMult);
 		nbt.putFloat("AdditionalKnockback", additionalKnockback);
+		nbt.putBoolean("AdditionalFlame", additionalFlame);
 		nbt.putFloat("Recovery", recoveryChance);
 		super.addAdditionalSaveData(nbt);
 	}
@@ -172,7 +181,7 @@ public class PotatoProjectileEntity extends AbstractHurtingProjectile implements
 
 	@Override
 	protected boolean shouldBurn() {
-		return false;
+		return additionalFlame;
 	}
 
 	@Override
@@ -208,12 +217,16 @@ public class PotatoProjectileEntity extends AbstractHurtingProjectile implements
 
 		if (target instanceof WitherBoss && ((WitherBoss) target).isPowered())
 			return;
-		if (type.preEntityHit(stack, ray))
+
+		if (type.preEntityHit(stack, ray)) {
 			return;
+		}
 
 		boolean targetIsEnderman = target.getType() == EntityType.ENDERMAN;
+		boolean immuneToPoison = target.getType().is(EntityTypeTags.IGNORES_POISON_AND_REGEN) || (target instanceof Spider) || (target instanceof EnderDragon) || (target instanceof Witch);
 		int k = target.getRemainingFireTicks();
-		if (this.isOnFire() && !targetIsEnderman)
+
+		if (this.isOnFire() && !targetIsEnderman && (!getItem().is(Items.POISONOUS_POTATO) || immuneToPoison))
 			target.igniteForSeconds(5);
 
 		boolean onServer = !level().isClientSide;

--- a/src/main/java/com/simibubi/create/content/equipment/potatoCannon/PotatoProjectileEntity.java
+++ b/src/main/java/com/simibubi/create/content/equipment/potatoCannon/PotatoProjectileEntity.java
@@ -1,5 +1,7 @@
 package com.simibubi.create.content.equipment.potatoCannon;
 
+import net.minecraft.world.item.enchantment.Enchantments;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -75,9 +77,14 @@ public class PotatoProjectileEntity extends AbstractHurtingProjectile implements
 		Registry<Enchantment> enchantmentRegistry = registryAccess().registryOrThrow(Registries.ENCHANTMENT);
 
 		int recovery = cannon.getEnchantmentLevel(enchantmentRegistry.getHolderOrThrow(AllEnchantments.POTATO_RECOVERY));
+		int power = cannon.getEnchantmentLevel(enchantmentRegistry.getHolderOrThrow(Enchantments.POWER));
+		int knockback = cannon.getEnchantmentLevel(enchantmentRegistry.getHolderOrThrow(Enchantments.PUNCH));
 
 		if (recovery > 0)
 			recoveryChance = .125f + recovery * .125f;
+
+		additionalDamageMult = power * 0.2f;
+		additionalKnockback = knockback * 0.5f;
 	}
 
 	public ItemStack getItem() {


### PR DESCRIPTION
This PR fixes Punch, Power and Flame enchantment having no effect on the damage of potato cannon. This is an issue that has persisted for a long time and was first discussed in #8030.

https://github.com/user-attachments/assets/3d7c76c2-fa8a-40df-968c-a71e70c45c07

## Reasons
None of the enchantments are referenced in `PotatoProjectileEntity.java`, and damage was calculated using only base values. The issue was resolved by fixing mainly `setEnchantmentEffectsFromCannon` and `onHitEntity` method.

## Details
The behavior of the enchantments are based on existing codes and [create fandom wiki](https://create.fandom.com/wiki/Potato_Cannon).

### Power & Punch
* Power adds 20% damage per level. The code now reads the enchantment level of Power and sets `additionalDamageMult` to `1 + 0.2 * (level)`. 
* Punch works in a similar way, setting `additionalKnockback` to `0.5 * (level)`.

### Flame
* Applying the flame enchantment sets the projectile on fire. 
* When it hits an entity, it sets the entity on fire for 5 seconds, just like a [regular flame enchantment](https://minecraft.fandom.com/wiki/Flame).
  *  If the used projectile sets entity on fire as a default, only the longer flaming effect applies. For example, shooting a baked potato sets entity on fire for 5 seconds, but shooting a blaze cake makes it burn for 12 seconds.
* If a poisonous potato is used, the flame effect applies only if the mob is immune to poison.
  * List of mobs immune to poison are from [minecraft wiki](https://minecraft.wiki/w/Poison).
  * Shooting a witch will set it on fire although it is not immune to poison but has 85% resistance.
