### PR TITLE
Fix vault size being zero when printed via schematic

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/vault/ItemVaultBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/vault/ItemVaultBlockEntity.java
@@ -316,6 +316,14 @@ public class ItemVaultBlockEntity extends SmartBlockEntity implements IMultiBloc
 	}
 
 	@Override
+	public void writeSafe(CompoundTag compound, HolderLookup.Provider registries) {
+		if (isController()) {
+			compound.putInt("Size", radius);
+			compound.putInt("Length", length);
+		}
+	}
+
+	@Override
 	public void clearContent() {
 		((ItemStackHandlerAccessor) inventory).create$getStacks().clear();
 	}


### PR DESCRIPTION
When printing a vault using a schematic, the Length and Size NBT values are ignored, resulting in a vault with zero capacity.

This issue does not manifest in multi-block vaults because structure updates recalculate the correct size. However, single-cell vaults are affected and remain at zero capacity.

A similar issue previously affected tanks and was resolved in commit [1491ed3](https://github.com/Creators-of-Create/Create/commit/1491ed3a620b3f78f02fc09386f3b98bee37b637). This PR applies a similar fix to vaults.

<img width="1920" height="986" alt="2026-03-24_10 35 24" src="https://github.com/user-attachments/assets/719ff9e4-8359-42a9-af62-25398a298932" />
