### PR TITLE
Fix: Components sanitization 

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/CreateNBTProcessors.java
+++ b/src/main/java/com/simibubi/create/foundation/CreateNBTProcessors.java
@@ -12,13 +12,17 @@ import net.createmod.catnip.nbt.NBTProcessors;
 import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtOps;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.RegistryOps;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.Filterable;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.component.WrittenBookContent;
 import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.neoforged.neoforge.server.ServerLifecycleHooks;
 
 public class CreateNBTProcessors {
 	public static void register() {
@@ -30,11 +34,11 @@ public class CreateNBTProcessors {
 			// Writable books can't have click events, so they're safe to keep
 			ResourceLocation writableBookResource = BuiltInRegistries.ITEM.getKey(Items.WRITABLE_BOOK);
 			if (writableBookResource != BuiltInRegistries.ITEM.getDefaultKey() && book.getString("id").equals(writableBookResource.toString()))
-				return data;
+				return null;
 
 			WrittenBookContent bookContent = CatnipCodecUtils.decodeOrNull(WrittenBookContent.CODEC, book);
 			if (bookContent == null)
-				return data;
+				return null;
 
 			for (Filterable<Component> page : bookContent.pages()) {
 				if (NBTProcessors.textComponentHasClickEvent(page.get(false)))
@@ -51,18 +55,44 @@ public class CreateNBTProcessors {
 
 	public static CompoundTag clipboardProcessor(CompoundTag data) {
 		DataComponentMap components = CatnipCodecUtils.decodeOrNull(DataComponentMap.CODEC, data.getCompound("components"));
-		if (components == null)
-			return data;
+		boolean needsReEncode = false;
+
+		if (components == null) {
+			MinecraftServer server = ServerLifecycleHooks.getCurrentServer();
+			if (server == null)
+				return null;
+
+			RegistryOps<Tag> ops = RegistryOps.create(NbtOps.INSTANCE, server.registryAccess());
+			components = CatnipCodecUtils.decodeOrNull(DataComponentMap.CODEC, ops, data.getCompound("components"));
+
+			if (components == null)
+				return null;
+
+			needsReEncode = true;
+		}
+
 
 		ClipboardContent content = components.get(AllDataComponents.CLIPBOARD_CONTENT);
 		if (content == null)
-			return data;
+			return null;
 
 		for (List<ClipboardEntry> entries : content.pages()) {
 			for (ClipboardEntry entry : entries) {
 				if (NBTProcessors.textComponentHasClickEvent(entry.text))
 					return null;
 			}
+		}
+
+		if (needsReEncode) {
+			components = DataComponentMap.builder().set(AllDataComponents.CLIPBOARD_CONTENT, content).build();
+			var result = DataComponentMap.CODEC.encodeStart(NbtOps.INSTANCE, components);
+			result.result().ifPresent(tag -> data.put("components", tag));
+
+			if (result.result().isEmpty())
+				return null;
+
+			data.put("components", result.result().get());
+
 		}
 
 		return data;


### PR DESCRIPTION
This pull request fixes an illegal component bug in CreateNBTProcessor.

The core issue I found is that [decodeOrNull](https://github.com/Creators-of-Create/Create/blob/0a17a7243c3e5e6e3ceb34450d9c6df240af1b83/src/main/java/com/simibubi/create/foundation/CreateNBTProcessors.java#L53) returns null when illegal components like enchantments are present. The current code checks if the result is null, and if it is, it returns the original data anyway at [line 55](https://github.com/Creators-of-Create/Create/blob/0a17a7243c3e5e6e3ceb34450d9c6df240af1b83/src/main/java/com/simibubi/create/foundation/CreateNBTProcessors.java#L55). This means illegal components can slip through and get applied when they shouldn't. I changed the relevant return statements to properly return null instead of the data when illegal components are detected.

I also added clipboard sanitization that strips out any illegal components while keeping the clipboard related data intact. I went with the stripping approach because if someone builds something and saves it as a schematic that accidentally includes extra components from creative mode, we don't want to wipe the whole thing. That way the build still works without requiring everyone to manually edit every clipboard before uploading.

If you wanted to do it without striping, you could just change the return data to return null.



In the following video I demonstrate, how it is handled before the fix:




https://github.com/user-attachments/assets/a5b753d5-8600-48d8-ab47-35f67e272ad1






After the fix:


https://github.com/user-attachments/assets/1a01a2d9-3ac7-49b9-a8e6-bf09debbceda


