### PR TITLE
Fix stock link priority being ignored by inventory grouping logic

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/packagerLink/LogisticsManager.java
+++ b/src/main/java/com/simibubi/create/content/logistics/packagerLink/LogisticsManager.java
@@ -2,7 +2,6 @@ package com.simibubi.create.content.logistics.packagerLink;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -109,26 +108,18 @@ public class LogisticsManager {
 		Iterable<LogisticallyLinkedBehaviour> allAvailableLinks = LogisticallyLinkedBehaviour.getAllPresent(freqId,
 			true);
 
-		// Group links by InventoryIdentifier and randomly select one from each group
-		Map<InventoryIdentifier, List<LogisticallyLinkedBehaviour>> linksByInventory = new HashMap<>();
+		// Select one link per inventory, preserving priority order (allAvailableLinks is sorted by redstonePower)
+		Set<InventoryIdentifier> seenInventories = new HashSet<>();
 		List<LogisticallyLinkedBehaviour> availableLinks = new ArrayList<>();
 
-		// Group links by their inventory identifier
 		for (LogisticallyLinkedBehaviour link : allAvailableLinks) {
 			InventoryIdentifier inventoryId = getInventoryIdentifierFromLink(link);
 			if (inventoryId != null) {
-				linksByInventory.computeIfAbsent(inventoryId, k -> new ArrayList<>()).add(link);
+				if (seenInventories.add(inventoryId))
+					availableLinks.add(link);
+				// Skip lower-priority links for already-seen inventories
 			} else {
-				// Links without inventory identifier are added directly
 				availableLinks.add(link);
-			}
-		}
-
-		// Randomly select one link from each inventory group
-		for (List<LogisticallyLinkedBehaviour> linkGroup : linksByInventory.values()) {
-			if (!linkGroup.isEmpty()) {
-				LogisticallyLinkedBehaviour selectedLink = linkGroup.get(r.nextInt(linkGroup.size()));
-				availableLinks.add(selectedLink);
 			}
 		}
 

--- a/src/main/java/com/simibubi/create/content/logistics/packagerLink/LogisticsManager.java
+++ b/src/main/java/com/simibubi/create/content/logistics/packagerLink/LogisticsManager.java
@@ -2,6 +2,7 @@ package com.simibubi.create.content.logistics.packagerLink;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -109,15 +110,26 @@ public class LogisticsManager {
 			true);
 
 		// Select one link per inventory, preserving priority order (allAvailableLinks is sorted by redstonePower)
-		Set<InventoryIdentifier> seenInventories = new HashSet<>();
+		// Links tied on priority for the same inventory are load-balanced randomly.
+		Map<InventoryIdentifier, Integer> inventoryLinkIndex = new HashMap<>();
+		Map<InventoryIdentifier, Integer> inventoryTieCount = new HashMap<>();
 		List<LogisticallyLinkedBehaviour> availableLinks = new ArrayList<>();
 
 		for (LogisticallyLinkedBehaviour link : allAvailableLinks) {
 			InventoryIdentifier inventoryId = getInventoryIdentifierFromLink(link);
 			if (inventoryId != null) {
-				if (seenInventories.add(inventoryId))
+				Integer existingIndex = inventoryLinkIndex.get(inventoryId);
+				if (existingIndex == null) {
+					inventoryLinkIndex.put(inventoryId, availableLinks.size());
+					inventoryTieCount.put(inventoryId, 1);
 					availableLinks.add(link);
-				// Skip lower-priority links for already-seen inventories
+				} else if (availableLinks.get(existingIndex).redstonePower == link.redstonePower) {
+					// Tied priority — reservoir sample to load-balance randomly
+					int count = inventoryTieCount.merge(inventoryId, 1, Integer::sum);
+					if (r.nextInt(count) == 0)
+						availableLinks.set(existingIndex, link);
+				}
+				// else: lower priority (higher redstonePower), skip
 			} else {
 				availableLinks.add(link);
 			}


### PR DESCRIPTION
Fix stock link priority being ignored by inventory grouping logic

The load balancing change in a [previous PR](https://github.com/Creators-of-Create/Create/pull/9210) grouped links by InventoryIdentifier 
and randomly selected one per group, discarding the priority sort.

Replaced with a single pass deduplication over the already sorted link list.
First occurrence of each inventory = highest priority link.

Closes #9689
