### PR TITLE
Fixed redstone requester misalignment

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/redstoneRequester/RedstoneRequesterScreen.java
+++ b/src/main/java/com/simibubi/create/content/logistics/redstoneRequester/RedstoneRequesterScreen.java
@@ -69,11 +69,10 @@ public class RedstoneRequesterScreen extends AbstractSimiContainerScreen<Redston
 		int x = getGuiLeft();
 		int y = getGuiTop();
 
-		if (addressBox == null) {
-			addressBox = new AddressEditBox(this, new NoShadowFontWrapper(font), x + 55, y + 68, 110, 10, false);
-			addressBox.setValue(menu.contentHolder.encodedTargetAdress);
-			addressBox.setTextColor(0x555555);
-		}
+		String previouslyUsedAddress = addressBox == null ? menu.contentHolder.encodedTargetAdress : addressBox.getValue();
+		addressBox = new AddressEditBox(this, new NoShadowFontWrapper(font), x + 55, y + 68, 110, 10, false);
+		addressBox.setTextColor(0x555555);
+		addressBox.setValue(previouslyUsedAddress);
 		addRenderableWidget(addressBox);
 
 		confirmButton = new IconButton(x + bgWidth - 30, y + bgHeight - 25, AllIcons.I_CONFIRM);


### PR DESCRIPTION
This is a small visual bug that I've already reported in [this](https://github.com/Creators-of-Create/Create/issues/10094) issue. 

## Steps to reproduce
- Place a redstone requester
- Open the menu
- Resize your screen
Your address box will now be out of place
## Solution
In `init`, the address box was only initialized on first init call. Instead, I solved by re-instanciating the address box, but setting the old text, just like it was done in https://github.com/Creators-of-Create/Create/blob/0a17a7243c3e5e6e3ceb34450d9c6df240af1b83/src/main/java/com/simibubi/create/content/logistics/stockTicker/StockKeeperRequestScreen.java#L246