### PR TITLE
Render train HUD above armor level

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/events/ClientEvents.java
+++ b/src/main/java/com/simibubi/create/foundation/events/ClientEvents.java
@@ -373,7 +373,7 @@ public class ClientEvents {
 	public static void registerGuiOverlays(RegisterGuiLayersEvent event) {
 		// Register overlays in reverse order
 		event.registerAbove(VanillaGuiLayers.AIR_LEVEL, Create.asResource("remaining_air"), RemainingAirOverlay.INSTANCE);
-		event.registerAbove(VanillaGuiLayers.EXPERIENCE_BAR, Create.asResource("train_hud"), TrainHUD.OVERLAY);
+		event.registerAbove(VanillaGuiLayers.ARMOR_LEVEL, Create.asResource("train_hud"), TrainHUD.OVERLAY);
 		event.registerAbove(VanillaGuiLayers.HOTBAR, Create.asResource("value_settings"), CreateClient.VALUE_SETTINGS_HANDLER);
 		event.registerAbove(VanillaGuiLayers.HOTBAR, Create.asResource("track_placement"), TrackPlacementOverlay.INSTANCE);
 		event.registerAbove(VanillaGuiLayers.HOTBAR, Create.asResource("goggle_info"), GoggleOverlayRenderer.OVERLAY);


### PR DESCRIPTION
Hi there,
This fixes https://github.com/Creators-of-Create/Create/issues/9828. 

There was another *minor* thing I thought about when doing this change, currently the experience level renders above the train hud as well as seen in below screenshot which can block the direction arrow slightly. I think it's okay as is but if you wanted it changed it's easy enough.

<img width="1586" height="497" alt="2026-04-08_11 51 43" src="https://github.com/user-attachments/assets/2382868b-7c75-4d3e-8a30-db97a983bb39" />

Thanks,
Jensen