### PR TITLE
Fix correct shape not being applied to funnels when placed on other funnels

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/funnel/FunnelItem.java
+++ b/src/main/java/com/simibubi/create/content/logistics/funnel/FunnelItem.java
@@ -41,10 +41,12 @@ public class FunnelItem extends BlockItem {
 
 		Direction direction = state.getValue(FunnelBlock.FACING);
 		FunnelBlock block = (FunnelBlock) getBlock();
-		Block beltFunnelBlock = block.getEquivalentBeltFunnel(world, pos, state)
-			.getBlock();
+		Block beltFunnelBlock = block.getEquivalentBeltFunnel(world, pos, state).getBlock();
+		boolean sneaking = ctx.getPlayer() != null && ctx.getPlayer().isShiftKeyDown();
+		BeltFunnelBlock.Shape shape = BeltFunnelBlock.getShapeForPosition(world, pos, direction, !sneaking);
 		BlockState equivalentBeltFunnel = beltFunnelBlock.getStateForPlacement(ctx)
-			.setValue(BeltFunnelBlock.HORIZONTAL_FACING, direction);
+			.setValue(BeltFunnelBlock.HORIZONTAL_FACING, direction)
+			.setValue(BeltFunnelBlock.SHAPE, shape);
 		if (BeltFunnelBlock.isOnValidBelt(equivalentBeltFunnel, world, pos))
 			return equivalentBeltFunnel;
 


### PR DESCRIPTION
Hi there,

This fixes https://github.com/Creators-of-Create/Create/issues/8945

I'm not terribly sure if this is the right way to fix this, but it's probably the simplest and least invasive. I feel a "cleaner" fix might be better suited within `BeltFunnelBlock.getStateForPlacement()` to reduce code duplication as the shape is also calculated there but the direction of the belt funnel is modified here after to make the funnel face the correct direction (which is calculated above) when placed on the side of another funnel. This happens without updating the funnel shape which caused the initial bug.
Let me know if you want anything changed or have any questions. 

Thanks,
Jensen