### PR TITLE
Optimise belt cauldron

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/belt/transport/BeltInventory.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/transport/BeltInventory.java
@@ -485,7 +485,7 @@ public class BeltInventory {
 					x, y, z,
 					1,
 					0.1, 0.1, 0.1,
-					0.022
+					0.020
 				);
 			}
 		}

--- a/src/main/java/com/simibubi/create/content/kinetics/belt/transport/BeltInventory.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/transport/BeltInventory.java
@@ -485,7 +485,7 @@ public class BeltInventory {
 					x, y, z,
 					1,
 					0.1, 0.1, 0.1,
-					0.025
+					0.024
 				);
 			}
 		}

--- a/src/main/java/com/simibubi/create/content/kinetics/belt/transport/BeltInventory.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/transport/BeltInventory.java
@@ -8,6 +8,15 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Function;
 
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.level.block.Blocks;
+
+import net.neoforged.neoforge.common.Tags;
+
 import org.jetbrains.annotations.Nullable;
 
 import com.simibubi.create.content.kinetics.belt.BeltBlock;
@@ -230,6 +239,15 @@ public class BeltInventory {
 				belt.notifyUpdate();
 				continue;
 			}
+
+			if(ending == Ending.TRASHED){
+				if(trash(currentItem, nextPosition)){
+					iterator.remove();
+					flapTunnel(this, lastOffset, movementFacing, false);
+					belt.notifyUpdate();
+					continue;
+				}
+			}
 		}
 	}
 
@@ -311,7 +329,7 @@ public class BeltInventory {
 	}
 
 	private enum Ending {
-		UNRESOLVED(0), EJECT(0), INSERT(.25f), FUNNEL(.5f), BLOCKED(.45f);
+		UNRESOLVED(0), EJECT(0), INSERT(.25f), FUNNEL(.5f), BLOCKED(.45f), TRASHED(-.25f);
 
 		private float margin;
 
@@ -331,6 +349,9 @@ public class BeltInventory {
 			BlockEntityBehaviour.get(world, nextPosition, DirectBeltInputBehaviour.TYPE);
 		if (inputBehaviour != null)
 			return Ending.INSERT;
+
+		if(world.getBlockState(nextPosition).is(Blocks.LAVA_CAULDRON))
+			return Ending.TRASHED;
 
 		if (BlockHelper.hasBlockSolidSide(world.getBlockState(nextPosition), world, nextPosition,
 			belt.getMovementFacing()
@@ -429,6 +450,46 @@ public class BeltInventory {
 			nbt.put("LazyItem", lazyClientItem.serializeNBT(registries));
 		nbt.putBoolean("PositiveOrder", beltMovementPositive);
 		return nbt;
+	}
+
+	public boolean trash(TransportedItemStack stack, BlockPos nextPos){
+		if(stack.stack.has(DataComponents.FIRE_RESISTANT))
+			return false;
+
+		if(belt.getLevel() != null){
+			if (belt.getLevel() instanceof ServerLevel serverLevel) {
+				BlockPos abovePosition = nextPos.above();
+				double x = abovePosition.getX() + 0.5;
+				double y = abovePosition.getY() + 0.2;
+				double z = abovePosition.getZ() + 0.5;
+
+				belt.getLevel().playSound(
+					null,
+					abovePosition,
+					SoundEvents.LAVA_EXTINGUISH,
+					SoundSource.BLOCKS,
+					0.5F,
+					0.8F + belt.getLevel().random.nextFloat() * 0.4F
+				);
+
+				serverLevel.getLevel().sendParticles(
+					ParticleTypes.LAVA,
+					x, y, z,
+					2,
+					0.2, 0.1, 0.2,
+					0.05
+				);
+
+				serverLevel.sendParticles(
+					ParticleTypes.LARGE_SMOKE,
+					x, y, z,
+					1,
+					0.1, 0.1, 0.1,
+					0.02
+				);
+			}
+		}
+		return true;
 	}
 
 	public void eject(TransportedItemStack stack) {

--- a/src/main/java/com/simibubi/create/content/kinetics/belt/transport/BeltInventory.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/transport/BeltInventory.java
@@ -485,7 +485,7 @@ public class BeltInventory {
 					x, y, z,
 					1,
 					0.1, 0.1, 0.1,
-					0.020
+					0.021
 				);
 			}
 		}

--- a/src/main/java/com/simibubi/create/content/kinetics/belt/transport/BeltInventory.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/transport/BeltInventory.java
@@ -485,7 +485,7 @@ public class BeltInventory {
 					x, y, z,
 					1,
 					0.1, 0.1, 0.1,
-					0.024
+					0.023
 				);
 			}
 		}

--- a/src/main/java/com/simibubi/create/content/kinetics/belt/transport/BeltInventory.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/transport/BeltInventory.java
@@ -485,7 +485,7 @@ public class BeltInventory {
 					x, y, z,
 					1,
 					0.1, 0.1, 0.1,
-					0.023
+					0.022
 				);
 			}
 		}

--- a/src/main/java/com/simibubi/create/content/kinetics/belt/transport/BeltInventory.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/transport/BeltInventory.java
@@ -485,7 +485,7 @@ public class BeltInventory {
 					x, y, z,
 					1,
 					0.1, 0.1, 0.1,
-					0.021
+					0.02
 				);
 			}
 		}

--- a/src/main/java/com/simibubi/create/content/kinetics/belt/transport/BeltInventory.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/transport/BeltInventory.java
@@ -485,7 +485,7 @@ public class BeltInventory {
 					x, y, z,
 					1,
 					0.1, 0.1, 0.1,
-					0.02
+					0.025
 				);
 			}
 		}

--- a/src/main/java/com/simibubi/create/content/kinetics/deployer/DeployerHandler.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/deployer/DeployerHandler.java
@@ -6,6 +6,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import net.minecraft.world.level.block.DirectionalBlock;
+
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.Nullable;
 
@@ -424,6 +426,7 @@ public class DeployerHandler {
 		List<ItemEntity> drops = new ArrayList<>(4);
 		CAPTURED_BLOCK_DROPS.put(pos, drops);
 		try {
+
 			InteractionResult result = BlockHelper.invokeUse(state, world, player, hand, ray);
 			for (ItemEntity itemEntity : drops)
 				player.getInventory().placeItemBackInInventory(itemEntity.getItem());


### PR DESCRIPTION
If a lava cauldron is directly at the end of a belt flammable items will be voided instead of thrown off the belt as item entities

i added suggestion from Create discord by @Plasma
<img width="1061" height="424" alt="изображение" src="https://github.com/user-attachments/assets/009cba9e-dc58-4a7c-b8c0-6f1e70c84ce1" />


showcase:

https://github.com/user-attachments/assets/1b868d94-0e38-493e-93ec-2c4b2b0b9a08

