### PR TITLE
Fix brass funnels not extracting items onto mechanical saws in some scenarios

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/saw/SawBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/saw/SawBlockEntity.java
@@ -111,7 +111,7 @@ public class SawBlockEntity extends BlockBreakingKineticBlockEntity implements C
 		super.addBehaviours(behaviours);
 		filtering = new FilteringBehaviour(this, new SawFilterSlot()).forRecipes();
 		behaviours.add(filtering);
-		behaviours.add(new DirectBeltInputBehaviour(this).allowingBeltFunnelsWhen(this::canProcess));
+		behaviours.add(new DirectBeltInputBehaviour(this).allowingBeltFunnelsWhen(this::canProcess).considerOccupiedWhen((d) -> !inventory.isEmpty()));
 		registerAwardables(behaviours, AllAdvancements.SAW_PROCESSING);
 	}
 

--- a/src/main/java/com/simibubi/create/content/logistics/funnel/FunnelBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/funnel/FunnelBlockEntity.java
@@ -220,10 +220,8 @@ public class FunnelBlockEntity extends SmartBlockEntity implements IHaveHovering
 		}
 
 		ItemStack remaining = inputBehaviour.handleInsertion(stack, facing, true);
-		if (remaining.getCount() == stack.getCount()) {
-			invVersionTracker.awaitNewVersion(invManipulation);
+		if (remaining.getCount() == stack.getCount())
 			return;
-		}
 
 		stack = invManipulation.extract(mode, stack.getCount() - remaining.getCount());
 		if (stack.isEmpty())

--- a/src/main/java/com/simibubi/create/content/logistics/funnel/FunnelBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/funnel/FunnelBlockEntity.java
@@ -213,19 +213,21 @@ public class FunnelBlockEntity extends SmartBlockEntity implements IHaveHovering
 
 		int amountToExtract = getAmountToExtract();
 		ExtractionCountMode mode = getModeToExtract();
-		MutableBoolean deniedByInsertion = new MutableBoolean(false);
-		ItemStack stack = invManipulation.extract(mode, amountToExtract, s -> {
-			ItemStack handleInsertion = inputBehaviour.handleInsertion(s, facing, true);
-			if (handleInsertion.isEmpty())
-				return true;
-			deniedByInsertion.setTrue();
-			return false;
-		});
+		ItemStack stack = invManipulation.simulate().extract(mode, amountToExtract);
 		if (stack.isEmpty()) {
-			if (deniedByInsertion.isFalse())
-				invVersionTracker.awaitNewVersion(invManipulation.getInventory());
+			invVersionTracker.awaitNewVersion(invManipulation);
 			return;
 		}
+
+		ItemStack remaining = inputBehaviour.handleInsertion(stack, facing, true);
+		if (remaining.getCount() == stack.getCount()) {
+			invVersionTracker.awaitNewVersion(invManipulation);
+			return;
+		}
+
+		stack = invManipulation.extract(mode, stack.getCount() - remaining.getCount());
+		if (stack.isEmpty())
+			return;
 		flap(false);
 		onTransfer(stack);
 		inputBehaviour.handleInsertion(stack, facing, false);


### PR DESCRIPTION
Hi there,

This fixes a bug which as far as I can tell has not been reported, where the brass funnel will not extract items onto the saw when using the mechanical saw with funnels in this configuration:

<img width="1280" height="720" alt="2026-04-12_00 42 09" src="https://github.com/user-attachments/assets/22a6f427-86ff-4f4a-b34a-8ecd61b2ae1a" />

Currently, if you use an andesite funnel it works fine, and if you use a brass funnel with the amount set to 1 it works or if the stack size in the inventory is 1. I think this bug is potentially a byproduct of when the input inventory for the saw was reduced (which may be a bug(???) and thus fixing that would most likely fix this), as I remember it used to stack up everything on the saw then would process items one by one, but this was years ago and on Create Fabric 0.5 when 1.18 was still newish so my memory is a bit murky or that may not have been intended.

The fix I've put in place is based on the behaviour for the normal funnel extraction and in my testing works and looks to be the same logically to my eyes; but as this is dealing with item stacks in such a critical place in combination with the inventory versioning I'd definitely want someone to double check this as I don't really want to inadvertently cause a big duplication glitch or break something somehow.

Let me know if you want anything changed or if you have any questions.

Thanks,
Jensen