### PR TITLE
Add enchantment glint when placing belts

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/belt/item/BeltConnectorItem.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/belt/item/BeltConnectorItem.java
@@ -267,4 +267,9 @@ public class BeltConnectorItem extends BlockItem {
 		return true;
 	}
 
+	@Override
+	public boolean isFoil(ItemStack stack) {
+		return stack.has(AllDataComponents.BELT_FIRST_SHAFT);
+	}
+
 }


### PR DESCRIPTION
Hi there, 

This adds the enchanted glint to mechanical belts when they are being placed. This makes it consistent with train tracks and other logistics blocks which can be linked such as factory gauges.

Thanks,
Jensen