### PR TITLE
Fix culling / occlusion on saw, drill, deployer and portable storage interface

### DIFF
--- a/src/main/java/com/simibubi/create/AllBlocks.java
+++ b/src/main/java/com/simibubi/create/AllBlocks.java
@@ -1344,7 +1344,7 @@ public class AllBlocks {
 
 	public static final BlockEntry<DrillBlock> MECHANICAL_DRILL = REGISTRATE.block("mechanical_drill", DrillBlock::new)
 		.initialProperties(SharedProperties::stone)
-		.properties(p -> p.mapColor(MapColor.PODZOL))
+		.properties(p -> p.noOcclusion().mapColor(MapColor.PODZOL))
 		.transform(axeOrPickaxe())
 		.blockstate(BlockStateGen.directionalBlockProvider(true))
 		.transform(CStress.setImpact(4.0))
@@ -1357,7 +1357,7 @@ public class AllBlocks {
 	public static final BlockEntry<SawBlock> MECHANICAL_SAW = REGISTRATE.block("mechanical_saw", SawBlock::new)
 		.initialProperties(SharedProperties::stone)
 		.addLayer(() -> RenderType::cutoutMipped)
-		.properties(p -> p.mapColor(MapColor.PODZOL))
+		.properties(p -> p.noOcclusion().mapColor(MapColor.PODZOL))
 		.transform(axeOrPickaxe())
 		.blockstate(new SawGenerator()::generate)
 		.transform(CStress.setImpact(4.0))
@@ -1370,7 +1370,7 @@ public class AllBlocks {
 
 	public static final BlockEntry<DeployerBlock> DEPLOYER = REGISTRATE.block("deployer", DeployerBlock::new)
 		.initialProperties(SharedProperties::stone)
-		.properties(p -> p.mapColor(MapColor.PODZOL))
+		.properties(p -> p.noOcclusion().mapColor(MapColor.PODZOL))
 		.transform(axeOrPickaxe())
 		.blockstate(BlockStateGen.directionalAxisBlockProvider())
 		.transform(CStress.setImpact(4.0))
@@ -1384,7 +1384,7 @@ public class AllBlocks {
 	public static final BlockEntry<PortableStorageInterfaceBlock> PORTABLE_STORAGE_INTERFACE =
 		REGISTRATE.block("portable_storage_interface", PortableStorageInterfaceBlock::forItems)
 			.initialProperties(SharedProperties::stone)
-			.properties(p -> p.mapColor(MapColor.PODZOL))
+			.properties(p -> p.noOcclusion().mapColor(MapColor.PODZOL))
 			.transform(axeOrPickaxe())
 			.blockstate((c, p) -> p.directionalBlock(c.get(), AssetLookup.partialBaseModel(c, p)))
 			.onRegister(movementBehaviour(new PortableStorageInterfaceMovement()))


### PR DESCRIPTION
Hi there,

This fixes https://github.com/Creators-of-Create/Create/issues/6117 and the same issue for the drill, deployer and portable storage interface (this issue does not affect fluid interface as the model is different). Easiest to see by placing snow layers next to each of these blocks as mentioned in that linked issue.

I'm not sure if this is the cleanest way to fix this as it may be a little over the top to disable all occlusion for these blocks just for the tiny bit exposed on some faces, but the only other options I can think of are changing the voxel shape to more accurately reflect the model (which if I remember correctly(?) may incur a tiny extra performance cost for collisions etc), changing the model or cooking up something for occlusion on certain faces. But then again, I would think turning off occlusion on modern hardware for these blocks shouldn't have that much of a noticeable impact.

Thanks