### PR TITLE
Fix mechanical arm animation in ponder

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/mechanicalArm/ArmBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/mechanicalArm/ArmBlockEntity.java
@@ -552,9 +552,6 @@ public class ArmBlockEntity extends KineticBlockEntity implements TransformableB
 		boolean hadGoggles = goggles;
 		goggles = tag.getBoolean("Goggles");
 
-		if (!clientPacket)
-			return;
-
 		if (hadGoggles != goggles && CatnipServices.PLATFORM.getEnv().isClient())
 			Client.queueUpdate(this);
 


### PR DESCRIPTION
Hi there,

This fixes https://github.com/Creators-of-Create/Create/issues/8925.

In my testing removing this check has no negative consequences (aside from a little extra computation), but I might be overlooking or misunderstanding something about what this check does. 

Basically the cause of the bug was that when we read the new target data from NBT (which ponder relies on when setting instructions), the previous target and existing angle are not taken into account as this check skips their calculation. The arm then assumes it is starting from it's default rotation (as the previous angle is never set), and thus snaps back.

Thanks