### PR TITLE
Fix voxelshape collisions of press, mixer and deployer

### DIFF
--- a/src/main/java/com/simibubi/create/AllShapes.java
+++ b/src/main/java/com/simibubi/create/AllShapes.java
@@ -264,8 +264,6 @@ public class AllShapes {
 		HEATER_BLOCK_SPECIAL_COLLISION_SHAPE = shape(0, 0, 0, 16, 4, 16).build(),
 		CRUSHING_WHEEL_COLLISION_SHAPE = cuboid(0, 0, 0, 16, 16, 16), SEAT = cuboid(0, 0, 0, 16, 8, 16),
 		SEAT_COLLISION = cuboid(0, 0, 0, 16, 6, 16), SEAT_COLLISION_PLAYERS = cuboid(0, 0, 0, 16, 3, 16),
-		MECHANICAL_PROCESSOR_SHAPE = shape(Shapes.block()).erase(4, 0, 4, 12, 16, 12)
-			.build(),
 		TURNTABLE_SHAPE = shape(1, 4, 1, 15, 8, 15).add(5, 0, 5, 11, 4, 11)
 			.build(),
 		CRATE_BLOCK_SHAPE = cuboid(1, 0, 1, 15, 14, 15),

--- a/src/main/java/com/simibubi/create/content/kinetics/mixer/MechanicalMixerBlock.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/mixer/MechanicalMixerBlock.java
@@ -10,14 +10,12 @@ import com.simibubi.create.foundation.block.IBE;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Direction.Axis;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.pathfinder.PathComputationType;
 import net.minecraft.world.phys.shapes.CollisionContext;
-import net.minecraft.world.phys.shapes.EntityCollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
 
 public class MechanicalMixerBlock extends KineticBlock implements IBE<MechanicalMixerBlockEntity>, ICogWheel {
@@ -33,11 +31,7 @@ public class MechanicalMixerBlock extends KineticBlock implements IBE<Mechanical
 
 	@Override
 	public VoxelShape getShape(BlockState state, BlockGetter worldIn, BlockPos pos, CollisionContext context) {
-		if (context instanceof EntityCollisionContext
-			&& ((EntityCollisionContext) context).getEntity() instanceof Player)
-			return AllShapes.CASING_14PX.get(Direction.DOWN);
-
-		return AllShapes.MECHANICAL_PROCESSOR_SHAPE;
+		return AllShapes.CASING_14PX.get(Direction.DOWN);
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/kinetics/press/MechanicalPressBlock.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/press/MechanicalPressBlock.java
@@ -9,7 +9,6 @@ import com.simibubi.create.foundation.block.IBE;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Direction.Axis;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.LevelReader;
@@ -17,7 +16,6 @@ import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.pathfinder.PathComputationType;
 import net.minecraft.world.phys.shapes.CollisionContext;
-import net.minecraft.world.phys.shapes.EntityCollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
 
 public class MechanicalPressBlock extends HorizontalKineticBlock implements IBE<MechanicalPressBlockEntity> {
@@ -28,11 +26,7 @@ public class MechanicalPressBlock extends HorizontalKineticBlock implements IBE<
 
 	@Override
 	public VoxelShape getShape(BlockState state, BlockGetter worldIn, BlockPos pos, CollisionContext context) {
-		if (context instanceof EntityCollisionContext
-			&& ((EntityCollisionContext) context).getEntity() instanceof Player)
-			return AllShapes.CASING_14PX.get(Direction.DOWN);
-
-		return AllShapes.MECHANICAL_PROCESSOR_SHAPE;
+		return AllShapes.CASING_14PX.get(Direction.DOWN);
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/foundation/mixin/FaceAttachedHorizontalDirectionBlockMixin.java
+++ b/src/main/java/com/simibubi/create/foundation/mixin/FaceAttachedHorizontalDirectionBlockMixin.java
@@ -1,0 +1,35 @@
+package com.simibubi.create.foundation.mixin;
+
+import com.simibubi.create.content.kinetics.deployer.DeployerBlock;
+import com.simibubi.create.content.kinetics.mixer.MechanicalMixerBlock;
+import com.simibubi.create.content.kinetics.press.MechanicalPressBlock;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.LevelReader;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.FaceAttachedHorizontalDirectionalBlock;
+import net.minecraft.world.level.block.state.BlockState;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import static com.simibubi.create.content.kinetics.base.DirectionalKineticBlock.FACING;
+
+@Mixin(FaceAttachedHorizontalDirectionalBlock.class)
+public class FaceAttachedHorizontalDirectionBlockMixin {
+
+	@Inject(method = "canAttach", at = @At("HEAD"), cancellable = true)
+	private static void create$canAttach(LevelReader level, BlockPos pos, Direction direction, CallbackInfoReturnable<Boolean> cir) {
+		BlockState state = level.getBlockState(pos.relative(direction));
+		Block block = state.getBlock();
+		if (block instanceof MechanicalMixerBlock || block instanceof MechanicalPressBlock)
+			cir.setReturnValue(!(direction == Direction.UP || direction == Direction.DOWN));
+		if (block instanceof DeployerBlock) {
+			Direction facing = state.getValue(FACING);
+			cir.setReturnValue(!(direction == facing || direction == facing.getOpposite()));
+		}
+	}
+}

--- a/src/main/resources/create.mixins.json
+++ b/src/main/resources/create.mixins.json
@@ -14,6 +14,7 @@
     "CustomItemUseEffectsMixin",
     "EnchantedCountIncreaseFunctionMixin",
     "EntityMixin",
+    "FaceAttachedHorizontalDirectionBlockMixin",
     "ItemStackMixin",
     "LavaSwimmingMixin",
     "MapItemSavedDataMixin",


### PR DESCRIPTION
Hi there,

This fixes https://github.com/Creators-of-Create/Create/issues/8961 using the suggestion IThundxr made on that issue. 
I did this within FaceAttachedHorizontalDirectionalBlock.canAttach instead of canPlace, as I figured it would be best to do this here, for best compatibility (perhaps?), as a mixin into just Button and Lever may leave some other edge case that's been forgotten? I've also added a case in this mixin for the deployer so placing levers/buttons on the side of it works the same as the mixer / deployer to make it consistent, as before you could only place a lever / button on the top face of it where the pole retracts.

Let me know if you want anything changed or have any questions.

Thanks