### PR TITLE
Fix enchantment glint always showing up on tank part of backtanks

### DIFF
--- a/src/main/java/com/simibubi/create/content/equipment/armor/BacktankArmorLayer.java
+++ b/src/main/java/com/simibubi/create/content/equipment/armor/BacktankArmorLayer.java
@@ -46,7 +46,7 @@ public class BacktankArmorLayer<T extends LivingEntity, M extends EntityModel<T>
 			return;
 
 		boolean hasGlint = entity.getItemBySlot(BacktankItem.SLOT).hasFoil();
-		VertexConsumer vc = ItemRenderer.getFoilBuffer(buffer, Sheets.cutoutBlockSheet(), false, true);
+		VertexConsumer vc = ItemRenderer.getFoilBuffer(buffer, Sheets.cutoutBlockSheet(), false, hasGlint);
 		BlockState renderedState = item.getBlock().defaultBlockState()
 			.setValue(BacktankBlock.HORIZONTAL_FACING, Direction.SOUTH);
 		SuperByteBuffer backtank = CachedBuffers.block(renderedState);


### PR DESCRIPTION
79b5d3b37e2d1970818dd97ca460b649cd0a456c accidentally didn't use the newly computed hasGlint variable, resulting in the fix for #9792 flipping the problem into the other direction.

Fixes - #10374 