### PR TITLE
Fixed factory gauge unlinking from display links when moved

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/factoryBoard/FactoryPanelBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/logistics/factoryBoard/FactoryPanelBehaviour.java
@@ -11,6 +11,8 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.UUID;
 
+import com.simibubi.create.content.redstone.displayLink.DisplayLinkBlockEntity;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.joml.Math;
@@ -215,11 +217,15 @@ public class FactoryPanelBehaviour extends FilteringBehaviour implements MenuPro
 				return;
 
 		// Disconnect links
+		Map<BlockPos, FactoryPanelConnection> displayLinks = new HashMap<>();
 		for (BlockPos pos : targetedByLinks.keySet()) {
 			FactoryPanelSupportBehaviour at = linkAt(level, new FactoryPanelPosition(pos, slot));
-			if (at != null)
+			if (at != null) {
 				at.disconnect(this);
+				if(at.blockEntity instanceof DisplayLinkBlockEntity) displayLinks.put(pos, targetedByLinks.get(pos));
+			}
 		}
+		displayLinks.keySet().forEach(key -> targetedByLinks.remove(key));
 
 		SmartBlockEntity oldBE = blockEntity;
 		FactoryPanelPosition oldPos = getPanelPosition();
@@ -264,6 +270,7 @@ public class FactoryPanelBehaviour extends FilteringBehaviour implements MenuPro
 		}
 
 		// Reconnect links
+		targetedByLinks.putAll(displayLinks);
 		for (BlockPos pos : targetedByLinks.keySet()) {
 			FactoryPanelSupportBehaviour at = linkAt(level, new FactoryPanelPosition(pos, slot));
 			if (at != null)


### PR DESCRIPTION
This pull request tries to solve a simple issue happening with factory gauges & display links:
## Steps to reproduce
- Place down a display link connected to any target
- Place down a factory gauge, set it up and connect it with the display link
- Open the Display link screen so that the factory gauge is detected
- Open the factory gauge screen
- Move the gauge to any slot (even in the same block)

The display link will still be connected to the gauge, but it will not update anymore unless you open the screen again

## The solution
I'll first show the pipeline of what happens to then explain my solution
- Method [moveTo](https://github.com/LIUKRAST/Create/blob/ee314e6526577d70a6b2df3b9087f1719a74b0d8/src/main/java/com/simibubi/create/content/logistics/factoryBoard/FactoryPanelBehaviour.java#L194) is invoked to start moving all the panels
- Arrives to the line commented with [Disconnect links](https://github.com/LIUKRAST/Create/blob/ee314e6526577d70a6b2df3b9087f1719a74b0d8/src/main/java/com/simibubi/create/content/logistics/factoryBoard/FactoryPanelBehaviour.java#L220-L227). **Here is very important because our display link is now disconnected from the panel**
- Arrives to line commented with [add to new BE](https://github.com/LIUKRAST/Create/blob/ee314e6526577d70a6b2df3b9087f1719a74b0d8/src/main/java/com/simibubi/create/content/logistics/factoryBoard/FactoryPanelBehaviour.java#L235-L241) where it calls `attachBehaviourLate(this)`
- Attach behaviour late calls `behaviour.initialize()`, which in `FactoryPanelBehaviour` calls `notifyRedstoneOutputs()`
- Notify redstone outputs iterates all links including, guess what, our display link! Calling `linkAt.notifyLink()`
- NotifyLink calls `onNotify.run()` which in our display link calls [updateGatheredData()](https://github.com/LIUKRAST/Create/blob/ee314e6526577d70a6b2df3b9087f1719a74b0d8/src/main/java/com/simibubi/create/content/redstone/displayLink/DisplayLinkBlockEntity.java#L70)
- Update gathered data now calls `getSourcePosition`, which will NOT return our factory panel position because as we said before, it's now unlinked. Now the display link is successfully unlinked from our panel, and it will be re-linked later, but this resets all the information, requiring, as said before, **to setup everything again from the screen**.
## The Solution, now for real
My solution was simple, we store all the connection with display links inside a map, remove them from the `targetedByLinks` map of the moving factory panel, so that on behaviour initialize it will not broadcast his update to display links, thinking he is not connected to any. Finally, after initializing, we re-add all the connections from the map to our gauge, successfully tricking the display link into thinking he never disconnected

## Moral of the story
I know this is a small issue, but working on my addons I find myself in these small edge-situations and being scared this was my code's problem, I solved it. Hope this PR can help!