### PR TITLE
Set working directory explicitly when running git command

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -160,7 +160,7 @@ dependencies {
         implementation("maven.modrinth:farmers-delight:${farmers_delight_version}")
     }
 
-    runtimeOnly("dev.architectury:architectury-neoforge:13d.0.8")
+    runtimeOnly("dev.architectury:architectury-neoforge:13.0.8")
     implementation("dev.ftb.mods:ftb-chunks-neoforge:2101.1.1")
     implementation("dev.ftb.mods:ftb-teams-neoforge:2101.1.0")
     implementation("dev.ftb.mods:ftb-library-neoforge:2101.1.3")

--- a/build.gradle
+++ b/build.gradle
@@ -313,6 +313,7 @@ publishMods {
 String calculateGitHash() {
     try {
         ExecOutput output = providers.exec {
+            it.workingDir(project.projectDir)
             commandLine("git", "rev-parse", "HEAD")
         }
         return output.standardOutput.asText.get().trim()
@@ -324,6 +325,7 @@ String calculateGitHash() {
 boolean hasUnstaged() {
     try {
         ExecOutput output = providers.exec {
+            it.workingDir(project.projectDir)
             commandLine("git", "status", "--porcelain")
         }
         String result = output.standardOutput.asText.get().replace("/M gradlew(\\.bat)?/", "").trim()


### PR DESCRIPTION
I recently tried to include Create using composite build but it tried to run git command from my root project, not inside of Create.
This PR sets working directory when running git command so that it can be included to elsewhere more easily.
Closes #10122
This is continuation of previous PR #10131 as it tried to merge wrong branch.