### PR TITLE
Fix Game Crashing When Searching in Creative Tab With Unbound Modifier Keybinds

### DIFF
--- a/src/main/java/com/simibubi/create/AllKeys.java
+++ b/src/main/java/com/simibubi/create/AllKeys.java
@@ -104,9 +104,9 @@ public enum AllKeys {
 	}
 
 	public static boolean isKeyDown(int key) {
-		return InputConstants.isKeyDown(Minecraft.getInstance()
+		return (key != -1 && InputConstants.isKeyDown(Minecraft.getInstance()
 			.getWindow()
-			.getWindow(), key);
+			.getWindow(), key));
 	}
 
 	public static boolean isMouseButtonDown(int button) {


### PR DESCRIPTION
Fixes #10209

The `isKeyDown` method now checks if the `key` argument is invalid before proceeding. Prevents a client crash that happens upon searching items in the creative tab while the modifier keybinds are unbound.