### PR TITLE
Fix contraption collision null axis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ local.properties
 
 .DS_Store
 /libs/
+/gradle-home/

--- a/src/main/java/com/simibubi/create/foundation/collision/ContinuousOBBCollider.java
+++ b/src/main/java/com/simibubi/create/foundation/collision/ContinuousOBBCollider.java
@@ -157,7 +157,7 @@ public class ContinuousOBBCollider {
 					timeOfImpact = 0;
 				}
 
-				if (timeOfImpact >= 0 && temporalResponse > timeOfImpact) {
+				if (timeOfImpact >= 0 && temporalResponse > timeOfImpact && mf.normalAxis != null) {
 					double scale = ContinuousSeparationManifold.withSignedEpsilon(mf.normalSeparation);
 					normalX = mf.normalAxis.x * scale;
 					normalY = mf.normalAxis.y * scale;

--- a/src/main/java/com/simibubi/create/foundation/collision/ContinuousOBBCollider.java
+++ b/src/main/java/com/simibubi/create/foundation/collision/ContinuousOBBCollider.java
@@ -141,6 +141,9 @@ public class ContinuousOBBCollider {
 
 				double timeOfImpact = mf.getTimeOfImpact();
 				boolean isTemporal = timeOfImpact > 0 && timeOfImpact < 1;
+				Vec3 responseAxis = mf.axis != null ? mf.axis
+					: (mf.normalAxis != null ? mf.normalAxis : mf.stepSeparationAxis);
+				Vec3 responseNormal = mf.normalAxis != null ? mf.normalAxis : responseAxis;
 
 				if (!isTemporal && mf.isDiscreteCollision) {
 					if (mf.stepSeparation <= entityMaxStep) {
@@ -150,18 +153,18 @@ public class ContinuousOBBCollider {
 						collisionResponseZ += mf.stepSeparationAxis.z * sep;
 					} else {
 						double sep = ContinuousSeparationManifold.withSignedEpsilon(mf.separation);
-						collisionResponseX += mf.axis.x * sep;
-						collisionResponseY += mf.axis.y * sep;
-						collisionResponseZ += mf.axis.z * sep;
+						collisionResponseX += responseAxis.x * sep;
+						collisionResponseY += responseAxis.y * sep;
+						collisionResponseZ += responseAxis.z * sep;
 					}
 					timeOfImpact = 0;
 				}
 
-				if (timeOfImpact >= 0 && temporalResponse > timeOfImpact && mf.normalAxis != null) {
+				if (timeOfImpact >= 0 && temporalResponse > timeOfImpact) {
 					double scale = ContinuousSeparationManifold.withSignedEpsilon(mf.normalSeparation);
-					normalX = mf.normalAxis.x * scale;
-					normalY = mf.normalAxis.y * scale;
-					normalZ = mf.normalAxis.z * scale;
+					normalX = responseNormal.x * scale;
+					normalY = responseNormal.y * scale;
+					normalZ = responseNormal.z * scale;
 
 					locationX = mf.collisionX;
 					locationY = mf.collisionY;
@@ -247,7 +250,7 @@ public class ContinuousOBBCollider {
 				earliestCollisionExitTime = Math.min(exitTime, earliestCollisionExitTime);
 			}
 
-			if (axisOfObjA && distance != 0 && -(diff) <= abs(normalSeparation)) {
+			if (axisOfObjA && -(diff) <= abs(normalSeparation)) {
 				normalAxis = axis;
 				normalSeparation = separation;
 			}
@@ -274,7 +277,7 @@ public class ContinuousOBBCollider {
 				}
 			}
 
-			if (distance != 0 && -(diff) <= abs(this.separation)) {
+			if (-(diff) <= abs(this.separation)) {
 				this.axis = axis;
 				this.separation = separation;
 				double scale = signum(TL) * (axisOfObjA ? -rA : -rB) - signum(separation) * 0.125;


### PR DESCRIPTION
## Summary

Fix a server crash in Create contraption collision handling when the continuous collision manifold ends up without a valid separation axis.

## In-game bug

The server can crash when a contraption mounted on a Mechanical Bearing starts rotating. In affected setups, starting rotation causes Create's contraption collision code to process an overlap case where the manifold does not record a valid `axis`, and the server later crashes in `ContinuousOBBCollider.collideMany()` when it dereferences that null value.

This appears in crash reports as:

`java.lang.NullPointerException: Cannot read field "x" because "mf.axis" is null`

## How to reproduce

1. Place a Mechanical Bearing.
2. Attach a contraption to it.
3. Power the bearing with a Water Wheel.
4. Start rotating the bearing.
5. The server crashes during contraption collision processing.

This has been observed with ordinary Create contraptions and does not require Aeronautics-specific blocks to be present on the contraption itself.

## Root cause

`ContinuousOBBCollider` assumes the separation manifold will always record a non-null `axis` and `normalAxis`. In exact-overlap or degenerate collision cases, that assumption can fail, especially in modded contraption collision paths where third-party mixins affect `ContraptionCollider`.

When that happens, the discrete collision branch reaches this code path with `mf.axis == null`, which causes the server tick crash.

## Fix

This patch makes the collision code more robust in two ways:

- it allows the manifold to record `axis` and `normalAxis` even when the tested separation distance is exactly zero
- it adds a defensive fallback axis/normal in `collideMany()` so collision response and normal resolution do not hard-crash if an axis is still missing

Together, these changes prevent the null dereference while preserving normal collision behavior.

## Why this change is useful even when another mod triggers the state

Some reports suggest the invalid manifold state may be triggered by compatibility mixins from other mods that hook Create contraption collision. Even if the upstream trigger is outside Create, `ContinuousOBBCollider` currently treats that state as impossible and crashes the server.

This patch makes Create fail safely instead of crashing the entire server tick loop.

## Related issues

This appears to address or mitigate crashes reported in:
- ryanhcode/sable#87
- ryanhcode/sable#147
- Creators-of-Aeronautics/Simulated-Project#752

## Testing

Tested by reproducing the in-game scenario with a Mechanical Bearing powered by a Water Wheel and verifying that starting rotation no longer crashes the server in the affected collision path.
