### PR TITLE
Add support for configuring fluid threshold conditions by millibucket amount

### DIFF
--- a/src/main/java/com/simibubi/create/content/redstone/thresholdSwitch/ConfigureThresholdSwitchPacket.java
+++ b/src/main/java/com/simibubi/create/content/redstone/thresholdSwitch/ConfigureThresholdSwitchPacket.java
@@ -17,6 +17,7 @@ public class ConfigureThresholdSwitchPacket extends BlockEntityConfigurationPack
 			ByteBufCodecs.INT, packet -> packet.onAbove,
 			ByteBufCodecs.BOOL, packet -> packet.invert,
 			ByteBufCodecs.BOOL, packet -> packet.inStacks,
+			ByteBufCodecs.BOOL, packet -> packet.inBuckets,
 			ConfigureThresholdSwitchPacket::new
 	);
 
@@ -24,13 +25,15 @@ public class ConfigureThresholdSwitchPacket extends BlockEntityConfigurationPack
 	private final int onAbove;
 	private final boolean invert;
 	private final boolean inStacks;
+	private final boolean inBuckets;
 
-	public ConfigureThresholdSwitchPacket(BlockPos pos, int offBelow, int onAbove, boolean invert, boolean inStacks) {
+	public ConfigureThresholdSwitchPacket(BlockPos pos, int offBelow, int onAbove, boolean invert, boolean inStacks, boolean inBuckets) {
 		super(pos);
 		this.offBelow = offBelow;
 		this.onAbove = onAbove;
 		this.invert = invert;
 		this.inStacks = inStacks;
+		this.inBuckets = inBuckets;
 	}
 
 	@Override
@@ -39,6 +42,7 @@ public class ConfigureThresholdSwitchPacket extends BlockEntityConfigurationPack
 		be.onWhenAbove = onAbove;
 		be.setInverted(invert);
 		be.inStacks = inStacks;
+		be.inBuckets = inBuckets;
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/redstone/thresholdSwitch/ThresholdSwitchBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/redstone/thresholdSwitch/ThresholdSwitchBlockEntity.java
@@ -48,6 +48,7 @@ public class ThresholdSwitchBlockEntity extends SmartBlockEntity implements Clea
 	public int currentLevel;
 	public int currentMaxLevel;
 	public boolean inStacks;
+	public boolean inBuckets;
 
 	private boolean redstoneState;
 	private boolean inverted;
@@ -83,6 +84,7 @@ public class ThresholdSwitchBlockEntity extends SmartBlockEntity implements Clea
 		currentMinLevel = compound.getInt("CurrentMinAmount");
 		currentMaxLevel = compound.getInt("CurrentMaxAmount");
 		inStacks = compound.getBoolean("InStacks");
+		inBuckets = compound.getBoolean("InBuckets");
 		redstoneState = compound.getBoolean("Powered");
 		inverted = compound.getBoolean("Inverted");
 		poweredAfterDelay = compound.getBoolean("PoweredAfterDelay");
@@ -102,6 +104,7 @@ public class ThresholdSwitchBlockEntity extends SmartBlockEntity implements Clea
 		compound.putInt("CurrentMinAmount", currentMinLevel);
 		compound.putInt("CurrentMaxAmount", currentMaxLevel);
 		compound.putBoolean("InStacks", inStacks);
+		compound.putBoolean("InBuckets", inBuckets);
 		compound.putBoolean("Powered", redstoneState);
 		compound.putBoolean("PoweredAfterDelay", poweredAfterDelay);
 		super.write(compound, registries, clientPacket);

--- a/src/main/java/com/simibubi/create/content/redstone/thresholdSwitch/ThresholdSwitchScreen.java
+++ b/src/main/java/com/simibubi/create/content/redstone/thresholdSwitch/ThresholdSwitchScreen.java
@@ -36,6 +36,7 @@ public class ThresholdSwitchScreen extends AbstractSimiScreen {
 	private ScrollInput offBelow;
 	private ScrollInput onAbove;
 	private SelectionScrollInput inStacks;
+	private SelectionScrollInput inBuckets;
 
 	private IconButton confirmButton;
 	private IconButton flipSignals;
@@ -69,6 +70,12 @@ public class ThresholdSwitchScreen extends AbstractSimiScreen {
 			.titled(CreateLang.translateDirect("schedule.condition.threshold.item_measure"))
 			.setState(blockEntity.inStacks ? 1 : 0);
 
+		inBuckets = (SelectionScrollInput) new SelectionScrollInput(x + 100, y + 23, 52, 42)
+			.forOptions(List.of(CreateLang.translateDirect("schedule.condition.threshold.millibuckets"),
+				CreateLang.translateDirect("schedule.condition.threshold.buckets")))
+			.titled(CreateLang.translateDirect("schedule.condition.threshold.fluid_measure"))
+			.setState(blockEntity.inBuckets ? 1 : 0);
+
 		offBelow = new ScrollInput(x + 48, y + 47, 1, 18)
 			.withRange(blockEntity.getMinLevel(), blockEntity.getMaxLevel() + 1 - getValueStep())
 			.titled(CreateLang.translateDirect("gui.threshold_switch.lower_threshold"))
@@ -78,13 +85,13 @@ public class ThresholdSwitchScreen extends AbstractSimiScreen {
 
 				if (onAbove.getState() / valueStep == 0 && state / valueStep == 0)
 					return;
-				
+
 				if (onAbove.getState() / valueStep <= state / valueStep) {
 					onAbove.setState((state + valueStep) / valueStep * valueStep);
 					onAbove.onChanged();
 				}
 			})
-			.withStepFunction(sc -> sc.shift ? 10 * getValueStep() : getValueStep())
+			.withStepFunction(sc -> sc.shift ? getShiftValueStep() : getValueStep())
 			.setState(blockEntity.offWhenBelow);
 
 		onAbove = new ScrollInput(x + 48, y + 23, 1, 18)
@@ -102,7 +109,7 @@ public class ThresholdSwitchScreen extends AbstractSimiScreen {
 					offBelow.onChanged();
 				}
 			})
-			.withStepFunction(sc -> sc.shift ? 10 * getValueStep() : getValueStep())
+			.withStepFunction(sc -> sc.shift ? getShiftValueStep() : getValueStep())
 			.setState(blockEntity.onWhenAbove);
 
 		onAbove.onChanged();
@@ -111,6 +118,7 @@ public class ThresholdSwitchScreen extends AbstractSimiScreen {
 		addRenderableWidget(onAbove);
 		addRenderableWidget(offBelow);
 		addRenderableWidget(inStacks);
+		addRenderableWidget(inBuckets);
 
 		confirmButton =
 			new IconButton(x + background.getWidth() - 33, y + background.getHeight() - 24, AllIcons.I_CONFIRM);
@@ -146,36 +154,43 @@ public class ThresholdSwitchScreen extends AbstractSimiScreen {
 
 		ThresholdType typeOfCurrentTarget = blockEntity.getTypeOfCurrentTarget();
 		boolean forItems = typeOfCurrentTarget == ThresholdType.ITEM;
+		boolean forFluids = typeOfCurrentTarget == ThresholdType.FLUID;
 		AllGuiTextures inputBg =
-			forItems ? AllGuiTextures.THRESHOLD_SWITCH_ITEMCOUNT_INPUTS : AllGuiTextures.THRESHOLD_SWITCH_MISC_INPUTS;
+			forItems || forFluids ? AllGuiTextures.THRESHOLD_SWITCH_ITEMCOUNT_INPUTS : AllGuiTextures.THRESHOLD_SWITCH_MISC_INPUTS;
 
 		inputBg.render(graphics, x + 44, y + 21);
 		inputBg.render(graphics, x + 44, y + 21 + 24);
 
 		int valueStep = 1;
 		boolean stacks = inStacks.getState() == 1;
-		if (typeOfCurrentTarget == ThresholdType.FLUID)
-			valueStep = 1000;
+		boolean buckets = inBuckets.getState() == 1;
 
 		if (forItems) {
 			Component suffix =
-				inStacks.getState() == 0 ? CreateLang.translateDirect("schedule.condition.threshold.items")
-					: CreateLang.translateDirect("schedule.condition.threshold.stacks");
-			valueStep = inStacks.getState() == 0 ? 1 : 64;
+				stacks ? CreateLang.translateDirect("schedule.condition.threshold.stacks")
+					: CreateLang.translateDirect("schedule.condition.threshold.items");
+			valueStep = stacks ? 64 : 1;
 			graphics.drawString(font, suffix, x + 105, y + 28, 0xFFFFFFFF, true);
 			graphics.drawString(font, suffix, x + 105, y + 28 + 24, 0xFFFFFFFF, true);
 
+		} else if (forFluids){
+			Component suffix =
+				buckets ? CreateLang.translateDirect("schedule.condition.threshold.buckets")
+					: CreateLang.translateDirect("schedule.condition.threshold.millibuckets");
+			valueStep = buckets ? 1000 : 1;
+			graphics.drawString(font, suffix, x + 105, y + 28, 0xFFFFFFFF, true);
+			graphics.drawString(font, suffix, x + 105, y + 28 + 24, 0xFFFFFFFF, true);
 		}
 
 		graphics.drawString(font,
 			Component.literal("\u2265 " + (typeOfCurrentTarget == ThresholdType.UNSUPPORTED ? ""
-				: forItems ? onAbove.getState() / valueStep
+				: forItems || forFluids ? onAbove.getState() / valueStep
 				: blockEntity.format(onAbove.getState() / valueStep, stacks)
 				.getString())),
 			x + 53, y + 28, 0xFFFFFFFF, true);
 		graphics.drawString(font,
 			Component.literal("\u2264 " + (typeOfCurrentTarget == ThresholdType.UNSUPPORTED ? ""
-				: forItems ? offBelow.getState() / valueStep
+				: forItems || forFluids ? offBelow.getState() / valueStep
 				: blockEntity.format(offBelow.getState() / valueStep, stacks)
 				.getString())),
 			x + 53, y + 28 + 24, 0xFFFFFFFF, true);
@@ -299,10 +314,12 @@ public class ThresholdSwitchScreen extends AbstractSimiScreen {
 	private void updateInputBoxes() {
 		ThresholdType typeOfCurrentTarget = blockEntity.getTypeOfCurrentTarget();
 		boolean forItems = typeOfCurrentTarget == ThresholdType.ITEM;
+		boolean forFluids = typeOfCurrentTarget == ThresholdType.FLUID;
 		final int valueStep = getValueStep();
 		inStacks.active = inStacks.visible = forItems;
-		onAbove.setWidth(forItems ? 48 : 103);
-		offBelow.setWidth(forItems ? 48 : 103);
+		inBuckets.active = inBuckets.visible = forFluids;
+		onAbove.setWidth(forItems || forFluids ? 48 : 103);
+		offBelow.setWidth(forItems || forFluids ? 48 : 103);
 
 		onAbove.visible = typeOfCurrentTarget != ThresholdType.UNSUPPORTED;
 		offBelow.visible = typeOfCurrentTarget != ThresholdType.UNSUPPORTED;
@@ -328,12 +345,31 @@ public class ThresholdSwitchScreen extends AbstractSimiScreen {
 
 	private int getValueStep() {
 		boolean stacks = inStacks.getState() == 1;
+		boolean buckets = inBuckets.getState() == 1;
 		int valueStep = 1;
-		if (blockEntity.getTypeOfCurrentTarget() == ThresholdType.FLUID)
-			valueStep = 1000;
-		else if (stacks)
-			valueStep = 64;
+		switch (blockEntity.getTypeOfCurrentTarget()) {
+			case ThresholdType.FLUID:
+			valueStep = buckets ? 1000 : 25;
+			break;
+			case ThresholdType.ITEM:
+			valueStep = stacks ? 64 : 1;
+			break;
+		}
 		return valueStep;
+	}
+
+	private int getShiftValueStep() {
+		boolean stacks = inStacks.getState() == 1;
+		boolean buckets = inBuckets.getState() == 1;
+		int shiftValueStep = 10;
+		switch (blockEntity.getTypeOfCurrentTarget()) {
+			case ThresholdType.FLUID:
+			shiftValueStep = buckets ? 10000 : 100;
+			break;
+			case ThresholdType.ITEM:
+			shiftValueStep = stacks ? 640 : 10;
+		}
+		return shiftValueStep;
 	}
 
 	@Override
@@ -343,7 +379,7 @@ public class ThresholdSwitchScreen extends AbstractSimiScreen {
 
 	protected void send(boolean invert) {
 		CatnipServices.NETWORK.sendToServer(new ConfigureThresholdSwitchPacket(blockEntity.getBlockPos(), offBelow.getState(),
-				onAbove.getState(), invert, inStacks.getState() == 1));
+				onAbove.getState(), invert, inStacks.getState() == 1, inBuckets.getState() == 1));
 	}
 
 }

--- a/src/main/java/com/simibubi/create/content/trains/schedule/condition/FluidThresholdCondition.java
+++ b/src/main/java/com/simibubi/create/content/trains/schedule/condition/FluidThresholdCondition.java
@@ -31,7 +31,7 @@ public class FluidThresholdCondition extends CargoThresholdCondition {
 
 	@Override
 	protected Component getUnit() {
-		return Component.literal("b");
+		return Component.literal(inBuckets() ? "b" : "mB");
 	}
 
 	@Override
@@ -43,6 +43,7 @@ public class FluidThresholdCondition extends CargoThresholdCondition {
 	protected boolean test(Level level, Train train, CompoundTag context) {
 		Ops operator = getOperator();
 		int target = getThreshold();
+		boolean buckets = inBuckets();
 
 		int foundFluid = 0;
 		for (Carriage carriage : train.carriages) {
@@ -55,8 +56,9 @@ public class FluidThresholdCondition extends CargoThresholdCondition {
 			}
 		}
 
-		requestStatusToUpdate(foundFluid / 1000, context);
-		return operator.test(foundFluid, target * 1000);
+		int valueMult = buckets ? 1000 : 1;
+		requestStatusToUpdate(foundFluid / valueMult, context);
+		return operator.test(foundFluid, target * valueMult);
 	}
 
 	@Override
@@ -88,7 +90,7 @@ public class FluidThresholdCondition extends CargoThresholdCondition {
 			CreateLang.translateDirect("schedule.condition.threshold.train_holds",
 				CreateLang.translateDirect("schedule.condition.threshold." + Lang.asId(getOperator().name()))),
 			CreateLang.translateDirect("schedule.condition.threshold.x_units_of_item", getThreshold(),
-				CreateLang.translateDirect("schedule.condition.threshold.buckets"),
+				CreateLang.translateDirect("schedule.condition.threshold." + (inBuckets() ? "buckets" : "millibuckets")),
 				compareStack.isEmpty() ? CreateLang.translateDirect("schedule.condition.threshold.anything")
 					: compareStack.isFilterItem()
 						? CreateLang.translateDirect("schedule.condition.threshold.matching_content")
@@ -106,6 +108,10 @@ public class FluidThresholdCondition extends CargoThresholdCondition {
 		return compareStack.item();
 	}
 
+	private boolean inBuckets() {
+		return intData("Measure") == 0;
+	}
+
 	@Override
 	public ResourceLocation getId() {
 		return Create.asResource("fluid_threshold");
@@ -116,8 +122,9 @@ public class FluidThresholdCondition extends CargoThresholdCondition {
 	public void initConfigurationWidgets(ModularGuiLineBuilder builder) {
 		super.initConfigurationWidgets(builder);
 		builder.addSelectionScrollInput(71, 50, (i, l) -> {
-			i.forOptions(ImmutableList.of(CreateLang.translateDirect("schedule.condition.threshold.buckets")))
-				.titled(null);
+			i.forOptions(ImmutableList.of(CreateLang.translateDirect("schedule.condition.threshold.buckets"),
+				CreateLang.translateDirect("schedule.condition.threshold.millibuckets")))
+				.titled(CreateLang.translateDirect("schedule.condition.threshold.fluid_measure"));
 		}, "Measure");
 	}
 
@@ -128,7 +135,8 @@ public class FluidThresholdCondition extends CargoThresholdCondition {
             return Component.empty();
 		int offset = getOperator() == Ops.LESS ? -1 : getOperator() == Ops.GREATER ? 1 : 0;
 		return CreateLang.translateDirect("schedule.condition.threshold.status", lastDisplaySnapshot,
-			Math.max(0, getThreshold() + offset), CreateLang.translateDirect("schedule.condition.threshold.buckets"));
+			Math.max(0, getThreshold() + offset),
+			CreateLang.translateDirect("schedule.condition.threshold." + (inBuckets() ? "buckets" : "millibuckets")));
 	}
 
 }


### PR DESCRIPTION
- When configuring a threshold switch facing into a fluid container, there is now an option to switch between millibuckets (mB) and buckets
  - This means for fluid containers, the menu now uses the same texture when configuring thresholds for item counts.
  - When using a mB value, will increase/decrease by increments of 25mB, or 100mB if shift is held.
    - I am not sure if these step sizes are the most-appropriate.
- When configuring a fluid cargo condition for a train schedule, there is now an option to switch between millibuckets (mB) and buckets.

---

Screenshots:
<img width="826" height="393" alt="Screenshot_20260505_234408" src="https://github.com/user-attachments/assets/c77e92a5-13dc-426c-93e4-a8d7a5bffe9f" />
<img width="847" height="320" alt="Screenshot_20260505_234301" src="https://github.com/user-attachments/assets/9f9240f0-d3ba-4e37-9cb8-e80df19ecd7e" />

---

TODO:
- [ ] Language entries for new strings
  - I manually added 'en/us' entries for the above screenshots, but I'm not sure what the proper workflow is for translations so I decided against including them in this PR.
- [ ] Texture for configuration menu?
  - Currently, both item and fluid threshold configuring uses `AllGuiTextures.THRESHOLD_SWITCH_ITEMCOUNT_INPUTS`. At minimum the constant probably warrants renaming since it is no longer being used for exclusively item counts, but I didn't want to go ahead with that change in case it was decided a different menu texture should be used for fluid amounts.
- [ ] Backporting?
  - I could not find a contribution guide, and I am very new to contributing to open source, so if this feature were to be backported I would appreciate any help or guidance in accomplishing that.