### PR TITLE
Fix drawer mods compatibility

### DIFF
--- a/src/main/java/com/simibubi/create/impl/unpacking/DefaultUnpackingHandler.java
+++ b/src/main/java/com/simibubi/create/impl/unpacking/DefaultUnpackingHandler.java
@@ -3,11 +3,6 @@ package com.simibubi.create.impl.unpacking;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.simibubi.create.AllEntityTypes;
-
-import com.simibubi.create.content.logistics.box.PackageItem;
-import com.simibubi.create.content.logistics.box.PackageStyles;
-
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.phys.Vec3;
 

--- a/src/main/java/com/simibubi/create/impl/unpacking/DefaultUnpackingHandler.java
+++ b/src/main/java/com/simibubi/create/impl/unpacking/DefaultUnpackingHandler.java
@@ -61,13 +61,15 @@ public enum DefaultUnpackingHandler implements UnpackingHandler {
 			return true;
 		}
 
+		List<ItemStack> compressedItems = new ArrayList<>();
+
 		for (int boxSlot = 0; boxSlot < items.size(); boxSlot++) {
 			ItemStack boxItemStack = items.get(boxSlot);
 			if (boxItemStack.isEmpty())
 				continue;
 
 			int amountToInsert = 0;
-			// iterate over contents of the box and count similar items
+			// iterate over contents of the package and count similar items
 			for (int otherBoxSlot = boxSlot; otherBoxSlot < items.size(); otherBoxSlot++) {
 				ItemStack otherBoxItemStack = items.get(otherBoxSlot);
 				if (!ItemStack.isSameItemSameComponents(boxItemStack, otherBoxItemStack))
@@ -78,13 +80,27 @@ public enum DefaultUnpackingHandler implements UnpackingHandler {
 				items.set(otherBoxSlot, otherBoxItemStack.copyWithCount(0));
 			}
 
-			// compress similar items into one stack so that it's easier to work with
-			ItemStack itemToInsert = boxItemStack.copyWithCount(amountToInsert);
-			for (int invSlot = 0; invSlot < targetInv.getSlots(); invSlot++) {
-				itemToInsert = targetInv.insertItem(invSlot, itemToInsert.copy(), true);
-			}
+			// compress similar items into one stack, so that it's easier to work with
+			compressedItems.add(boxItemStack.copyWithCount(amountToInsert));
+		}
 
-			if (!itemToInsert.isEmpty()) {
+		for (int invSlot = 0; invSlot < targetInv.getSlots(); invSlot++) {
+			for (int itemIndex = 0; itemIndex < compressedItems.size(); itemIndex++) {
+				ItemStack itemToInsert = compressedItems.get(itemIndex);
+				ItemStack remainder = targetInv.insertItem(invSlot, itemToInsert.copy(), true);
+
+				compressedItems.set(itemIndex, remainder);
+
+				// if there's remainder or inserted amount is equal to slot limit,
+				// then this slot is full, no need to check other items in the package
+				if (!remainder.isEmpty() || targetInv.getSlotLimit(invSlot) == itemToInsert.getCount()) {
+					break;
+				}
+			}
+		}
+
+		for (ItemStack stack : compressedItems) {
+			if (!stack.isEmpty()) {
 				return false;
 			}
 		}

--- a/src/main/java/com/simibubi/create/impl/unpacking/DefaultUnpackingHandler.java
+++ b/src/main/java/com/simibubi/create/impl/unpacking/DefaultUnpackingHandler.java
@@ -1,6 +1,15 @@
 package com.simibubi.create.impl.unpacking;
 
+import java.util.ArrayList;
 import java.util.List;
+
+import com.simibubi.create.AllEntityTypes;
+
+import com.simibubi.create.content.logistics.box.PackageItem;
+import com.simibubi.create.content.logistics.box.PackageStyles;
+
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.phys.Vec3;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -31,63 +40,24 @@ public enum DefaultUnpackingHandler implements UnpackingHandler {
 		if (targetInv == null)
 			return false;
 
-		if (!simulate) {
-			/*
-			 * Some mods do not support slot-by-slot precision during simulate = false.
-			 * Faulty interactions may lead to voiding of items, but the simulate pass should
-			 * already have correctly identified there to be enough space for everything.
-			 */
-			for (ItemStack itemStack : items)
-				ItemHandlerHelper.insertItemStacked(targetInv, itemStack.copy(), false);
-			return true;
-		}
+		List<ItemStack> remainderList = new ArrayList<>();
 
-		for (int slot = 0; slot < targetInv.getSlots(); slot++) {
-			ItemStack itemInSlot = targetInv.getStackInSlot(slot);
-			int itemsAddedToSlot = 0;
-
-			for (int boxSlot = 0; boxSlot < items.size(); boxSlot++) {
-				ItemStack toInsert = items.get(boxSlot);
-				if (toInsert.isEmpty())
-					continue;
-
-				if (targetInv.insertItem(slot, toInsert, true)
-					.getCount() == toInsert.getCount())
-					continue;
-
-				if (itemInSlot.isEmpty()) {
-					int maxStackSize = targetInv.getSlotLimit(slot);
-					if (maxStackSize < toInsert.getCount()) {
-						toInsert.shrink(maxStackSize);
-						toInsert = toInsert.copyWithCount(maxStackSize);
-					} else
-						items.set(boxSlot, ItemStack.EMPTY);
-
-					itemInSlot = toInsert;
-					targetInv.insertItem(slot, toInsert, simulate);
-					continue;
+		for (ItemStack itemStack : items) {
+			var remainder = ItemHandlerHelper.insertItemStacked(targetInv, itemStack.copy(), simulate);
+			if (!remainder.isEmpty()) {
+				if (simulate) {
+					return false;
+				} else {
+					remainderList.add(remainder);
 				}
-
-				if (!ItemStack.isSameItemSameComponents(toInsert, itemInSlot))
-					continue;
-
-				int insertedAmount = toInsert.getCount() - targetInv.insertItem(slot, toInsert, simulate)
-					.getCount();
-				int slotLimit = Math.min(itemInSlot.getMaxStackSize(), targetInv.getSlotLimit(slot));
-				int insertableAmountWithPreviousItems =
-					Math.min(toInsert.getCount(), slotLimit - itemInSlot.getCount() - itemsAddedToSlot);
-
-				int added = Math.min(insertedAmount, Math.max(0, insertableAmountWithPreviousItems));
-				itemsAddedToSlot += added;
-
-				items.set(boxSlot, toInsert.copyWithCount(toInsert.getCount() - added));
 			}
 		}
 
-		for (ItemStack stack : items) {
-			if (!stack.isEmpty()) {
-				// something failed to be inserted
-				return false;
+		if (!simulate && !remainderList.isEmpty()) {
+			var itemPos = Vec3.atCenterOf(pos);
+			for (var itemStack : remainderList) {
+				var itemEntity = new ItemEntity(level, itemPos.x, itemPos.y, itemPos.z, itemStack);
+				level.addFreshEntity(itemEntity);
 			}
 		}
 

--- a/src/main/java/com/simibubi/create/impl/unpacking/DefaultUnpackingHandler.java
+++ b/src/main/java/com/simibubi/create/impl/unpacking/DefaultUnpackingHandler.java
@@ -36,7 +36,30 @@ public enum DefaultUnpackingHandler implements UnpackingHandler {
 		if (targetInv == null)
 			return false;
 
-		List<ItemStack> remainderList = new ArrayList<>();
+		if (!simulate) {
+			List<ItemStack> remainderList = new ArrayList<>();
+
+			for (ItemStack stack : items) {
+				ItemStack remainder = ItemHandlerHelper.insertItemStacked(targetInv, stack.copy(), false);
+				if (!remainder.isEmpty()) {
+					remainderList.add(remainder);
+				}
+			}
+
+			/*
+			 * Some mods may have inconsistency between simulate pass and actually pushing items
+			 * and possibly yield some leftover items
+			 */
+			if (!remainderList.isEmpty()) {
+				var itemPos = Vec3.atCenterOf(pos);
+				for (var itemStack : remainderList) {
+					var itemEntity = new ItemEntity(level, itemPos.x, itemPos.y, itemPos.z, itemStack);
+					level.addFreshEntity(itemEntity);
+				}
+			}
+
+			return true;
+		}
 
 		for (int boxSlot = 0; boxSlot < items.size(); boxSlot++) {
 			ItemStack boxItemStack = items.get(boxSlot);
@@ -58,25 +81,11 @@ public enum DefaultUnpackingHandler implements UnpackingHandler {
 			// compress similar items into one stack so that it's easier to work with
 			ItemStack itemToInsert = boxItemStack.copyWithCount(amountToInsert);
 			for (int invSlot = 0; invSlot < targetInv.getSlots(); invSlot++) {
-				itemToInsert = targetInv.insertItem(invSlot, itemToInsert.copy(), simulate);
+				itemToInsert = targetInv.insertItem(invSlot, itemToInsert.copy(), true);
 			}
 
 			if (!itemToInsert.isEmpty()) {
-				if (simulate) {
-					return false;
-				} else {
-					remainderList.add(itemToInsert);
-				}
-			}
-		}
-
-		// if there's inconsistency between simulate on and off results there may be some leftover items
-		// so drop them on the ground
-		if (!simulate && !remainderList.isEmpty()) {
-			var itemPos = Vec3.atCenterOf(pos);
-			for (var itemStack : remainderList) {
-				var itemEntity = new ItemEntity(level, itemPos.x, itemPos.y, itemPos.z, itemStack);
-				level.addFreshEntity(itemEntity);
+				return false;
 			}
 		}
 

--- a/src/main/java/com/simibubi/create/impl/unpacking/DefaultUnpackingHandler.java
+++ b/src/main/java/com/simibubi/create/impl/unpacking/DefaultUnpackingHandler.java
@@ -3,6 +3,7 @@ package com.simibubi.create.impl.unpacking;
 import java.util.ArrayList;
 import java.util.List;
 
+import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.phys.Vec3;
 
@@ -37,17 +38,40 @@ public enum DefaultUnpackingHandler implements UnpackingHandler {
 
 		List<ItemStack> remainderList = new ArrayList<>();
 
-		for (ItemStack itemStack : items) {
-			var remainder = ItemHandlerHelper.insertItemStacked(targetInv, itemStack.copy(), simulate);
-			if (!remainder.isEmpty()) {
+		for (int boxSlot = 0; boxSlot < items.size(); boxSlot++) {
+			ItemStack boxItemStack = items.get(boxSlot);
+			if (boxItemStack.isEmpty())
+				continue;
+
+			int amountToInsert = 0;
+			// iterate over contents of the box and count similar items
+			for (int otherBoxSlot = boxSlot; otherBoxSlot < items.size(); otherBoxSlot++) {
+				ItemStack otherBoxItemStack = items.get(otherBoxSlot);
+				if (!ItemStack.isSameItemSameComponents(boxItemStack, otherBoxItemStack))
+					continue;
+
+				int stackSize = otherBoxItemStack.getCount();
+				amountToInsert += stackSize;
+				items.set(otherBoxSlot, otherBoxItemStack.copyWithCount(0));
+			}
+
+			// compress similar items into one stack so that it's easier to work with
+			ItemStack itemToInsert = boxItemStack.copyWithCount(amountToInsert);
+			for (int invSlot = 0; invSlot < targetInv.getSlots(); invSlot++) {
+				itemToInsert = targetInv.insertItem(invSlot, itemToInsert.copy(), simulate);
+			}
+
+			if (!itemToInsert.isEmpty()) {
 				if (simulate) {
 					return false;
 				} else {
-					remainderList.add(remainder);
+					remainderList.add(itemToInsert);
 				}
 			}
 		}
 
+		// if there's inconsistency between simulate on and off results there may be some leftover items
+		// so drop them on the ground
 		if (!simulate && !remainderList.isEmpty()) {
 			var itemPos = Vec3.atCenterOf(pos);
 			for (var itemStack : remainderList) {

--- a/src/main/java/com/simibubi/create/impl/unpacking/DefaultUnpackingHandler.java
+++ b/src/main/java/com/simibubi/create/impl/unpacking/DefaultUnpackingHandler.java
@@ -85,15 +85,18 @@ public enum DefaultUnpackingHandler implements UnpackingHandler {
 		}
 
 		for (int invSlot = 0; invSlot < targetInv.getSlots(); invSlot++) {
+			ItemStack itemInSlot = targetInv.getStackInSlot(invSlot);
+
 			for (int itemIndex = 0; itemIndex < compressedItems.size(); itemIndex++) {
 				ItemStack itemToInsert = compressedItems.get(itemIndex);
 				ItemStack remainder = targetInv.insertItem(invSlot, itemToInsert.copy(), true);
 
 				compressedItems.set(itemIndex, remainder);
 
-				// if there's remainder or inserted amount is equal to slot limit,
+				// if there's remainder or new item amount is equal to slot limit,
 				// then this slot is full, no need to check other items in the package
-				if (!remainder.isEmpty() || targetInv.getSlotLimit(invSlot) == itemToInsert.getCount()) {
+				if (!remainder.isEmpty() ||
+					itemToInsert.getCount() + itemInSlot.getCount() == targetInv.getSlotLimit(invSlot)) {
 					break;
 				}
 			}

--- a/src/main/java/com/simibubi/create/impl/unpacking/DefaultUnpackingHandler.java
+++ b/src/main/java/com/simibubi/create/impl/unpacking/DefaultUnpackingHandler.java
@@ -89,6 +89,9 @@ public enum DefaultUnpackingHandler implements UnpackingHandler {
 
 			for (int itemIndex = 0; itemIndex < compressedItems.size(); itemIndex++) {
 				ItemStack itemToInsert = compressedItems.get(itemIndex);
+				if (itemToInsert.isEmpty())
+					continue;
+
 				ItemStack remainder = targetInv.insertItem(invSlot, itemToInsert.copy(), true);
 
 				compressedItems.set(itemIndex, remainder);


### PR DESCRIPTION
# Unpacking logic changes
Items are compressed into bigger stacks (as in, 8 stacks of 64 apples will be compressed into 1 stack of 512) before running check for whether items can be inserted, then it tries to fill target inventory with these stacks, while overwriting the stacks with remainder. By the end, if there's still some items left, consider that package can't be unpacked into target inventory

Some storage show inconsistency between simulate and actual pass, which is largely bug on the storage mod side and can lead to voided items in some cases. Instead of voiding items excess items are stored in the list and then dropped on the ground, so that they're at least not being lost forever