### PR TITLE
Fix Create Item Filters to allow vanilla use behavior to work

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/filter/FilterItem.java
+++ b/src/main/java/com/simibubi/create/content/logistics/filter/FilterItem.java
@@ -85,17 +85,7 @@ public abstract class FilterItem extends Item implements MenuProvider, SupportsI
 			return InteractionResultHolder.success(heldItem);
 		}
 		else {
-			FoodProperties foodproperties = heldItem.getFoodProperties(player);
-			if (foodproperties != null) {
-				if (player.canEat(foodproperties.canAlwaysEat())) {
-					player.startUsingItem(hand);
-					return InteractionResultHolder.consume(heldItem);
-				} else {
-					return InteractionResultHolder.fail(heldItem);
-				}
-			} else {
-				return InteractionResultHolder.pass(player.getItemInHand(hand));
-			}
+			return super.use(world, player, hand);
 		}
 	}
 

--- a/src/main/java/com/simibubi/create/content/logistics/filter/FilterItem.java
+++ b/src/main/java/com/simibubi/create/content/logistics/filter/FilterItem.java
@@ -3,6 +3,8 @@ package com.simibubi.create.content.logistics.filter;
 import java.util.List;
 import java.util.Objects;
 
+import net.minecraft.world.food.FoodProperties;
+
 import org.jetbrains.annotations.NotNull;
 
 import com.simibubi.create.AllDataComponents;
@@ -82,7 +84,19 @@ public abstract class FilterItem extends Item implements MenuProvider, SupportsI
 				});
 			return InteractionResultHolder.success(heldItem);
 		}
-		return InteractionResultHolder.pass(heldItem);
+		else {
+			FoodProperties foodproperties = heldItem.getFoodProperties(player);
+			if (foodproperties != null) {
+				if (player.canEat(foodproperties.canAlwaysEat())) {
+					player.startUsingItem(hand);
+					return InteractionResultHolder.consume(heldItem);
+				} else {
+					return InteractionResultHolder.fail(heldItem);
+				}
+			} else {
+				return InteractionResultHolder.pass(player.getItemInHand(hand));
+			}
+		}
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/logistics/filter/FilterItem.java
+++ b/src/main/java/com/simibubi/create/content/logistics/filter/FilterItem.java
@@ -3,8 +3,6 @@ package com.simibubi.create.content.logistics.filter;
 import java.util.List;
 import java.util.Objects;
 
-import net.minecraft.world.food.FoodProperties;
-
 import org.jetbrains.annotations.NotNull;
 
 import com.simibubi.create.AllDataComponents;

--- a/src/main/java/com/simibubi/create/content/logistics/filter/FilterItemStack.java
+++ b/src/main/java/com/simibubi/create/content/logistics/filter/FilterItemStack.java
@@ -43,6 +43,7 @@ public class FilterItemStack {
 	private static void trimFilterComponents(ItemStack filter) {
 		filter.remove(DataComponents.ENCHANTMENTS);
 		filter.remove(DataComponents.ATTRIBUTE_MODIFIERS);
+		filter.remove(DataComponents.FOOD); // Prevent schematics from abusing the food using_converts_to component
 	}
 
 	public boolean isEmpty() {


### PR DESCRIPTION
Fixes #10335

If the player is sneaking, instead of immediately passing, calls super.use().

This also fixes any behavior modifications of Item.use provided by mixins from other mods.

Schematics will sanitize food components when setting filters in order to prevent players from abusing #10373 to obtain arbitrary items via schematic nbt preservation exploit.