### PR TITLE
Fix blueprint shop result tooltip cycling

### DIFF
--- a/src/main/java/com/simibubi/create/content/equipment/blueprint/BlueprintOverlayRenderer.java
+++ b/src/main/java/com/simibubi/create/content/equipment/blueprint/BlueprintOverlayRenderer.java
@@ -390,26 +390,26 @@ public class BlueprintOverlayRenderer {
 				x += 21;
 			}
 		}
-
+	
 		if (shopContext != null && !shopContext.checkout()) {
-			int cycle = 0;
-			for (boolean count : Iterate.trueAndFalse)
-				for (int i = 0; i < results.size(); i++) {
-					ItemStack result = results.get(i);
-					List<Component> tooltipLines = result.getTooltipLines(TooltipContext.of(mc.level), mc.player, TooltipFlag.NORMAL);
-					if (tooltipLines.size() <= 1)
-						continue;
-					if (count) {
-						cycle++;
-						continue;
-					}
-					if ((mc.gui.getGuiTicks() / 40) % cycle != i)
-						continue;
-					guiGraphics.renderComponentTooltip(mc.gui.getFont(), tooltipLines, mc.getWindow()
-							.getGuiScaledWidth(),
-						mc.getWindow()
-							.getGuiScaledHeight());
-				}
+			List<List<Component>> resultTooltips = new ArrayList<>();
+
+			for (ItemStack result : results) {
+				List<Component> tooltipLines =
+					result.getTooltipLines(TooltipContext.of(mc.level), mc.player, TooltipFlag.NORMAL);
+				if (tooltipLines.size() > 1)
+					resultTooltips.add(tooltipLines);
+			}
+
+			if (!resultTooltips.isEmpty()) {
+				int index = (mc.gui.getGuiTicks() / 40) % resultTooltips.size();
+				guiGraphics.renderComponentTooltip(
+					mc.gui.getFont(),
+					resultTooltips.get(index),
+					mc.getWindow().getGuiScaledWidth(),
+					mc.getWindow().getGuiScaledHeight()
+				);
+			}
 		}
 
 		RenderSystem.disableBlend();


### PR DESCRIPTION
Fix blueprint shop result tooltip cycling

The tooltip cycling logic counted only result stacks with multi-line tooltips, but compared the cycle index against the raw result list index. When some results did not have eligible tooltips, the modulo result could never match later raw indices, preventing valid tooltips from being rendered.

This now collects eligible result tooltips first and cycles directly over that filtered list, avoiding modulo-by-zero and keeping the cycling index aligned with the rendered tooltip candidates.