### PR TITLE
optimize glue selection computation

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/glue/SuperGlueEntity.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/glue/SuperGlueEntity.java
@@ -69,7 +69,7 @@ public class SuperGlueEntity extends Entity implements IEntityWithComplexSpawn, 
 				if (glueEntity.contains(blockPos) && glueEntity.contains(targetPos))
 					return true;
 		for (SuperGlueEntity glueEntity : level.getEntitiesOfClass(SuperGlueEntity.class,
-			span(blockPos, targetPos).inflate(16))) {
+			span(blockPos, targetPos))) {
 			if (!glueEntity.contains(blockPos) || !glueEntity.contains(targetPos))
 				continue;
 			if (cached != null)
@@ -112,7 +112,10 @@ public class SuperGlueEntity extends Entity implements IEntityWithComplexSpawn, 
 	protected void defineSynchedData(SynchedEntityData.Builder builder) {}
 
 	public static boolean isValidFace(Level world, BlockPos pos, Direction direction) {
-		BlockState state = world.getBlockState(pos);
+		return isValidFace(world, pos, world.getBlockState(pos), direction);
+	}
+
+	public static boolean isValidFace(Level world, BlockPos pos, BlockState state, Direction direction) {
 		if (BlockMovementChecks.isBlockAttachedTowards(state, world, pos, direction))
 			return true;
 		if (!BlockMovementChecks.isMovementNecessary(state, world, pos))
@@ -123,7 +126,10 @@ public class SuperGlueEntity extends Entity implements IEntityWithComplexSpawn, 
 	}
 
 	public static boolean isSideSticky(Level world, BlockPos pos, Direction direction) {
-		BlockState state = world.getBlockState(pos);
+		return isSideSticky(world.getBlockState(pos), direction);
+	}
+
+	public static boolean isSideSticky(BlockState state, Direction direction) {
 		if (AllBlocks.STICKY_MECHANICAL_PISTON.has(state))
 			return state.getValue(DirectionalKineticBlock.FACING) == direction;
 

--- a/src/main/java/com/simibubi/create/content/contraptions/glue/SuperGlueSelectionHandler.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/glue/SuperGlueSelectionHandler.java
@@ -157,10 +157,7 @@ public class SuperGlueSelectionHandler {
 						.disableLineNormals()
 						.lineWidth(1 / 16f);
 
-				Outliner.getInstance().showCluster(clusterOutlineSlot, currentCluster)
-					.colored(0x4D9162)
-					.disableLineNormals()
-					.lineWidth(1 / 64f);
+				Outliner.getInstance().keep(clusterOutlineSlot);
 			}
 
 			return;
@@ -171,6 +168,11 @@ public class SuperGlueSelectionHandler {
 		Set<BlockPos> cluster = SuperGlueSelectionHelper.searchGlueGroup(mc.level, firstPos, hoveredPos, true);
 		currentCluster = cluster;
 		glueRequired = 1;
+		if (cluster != null)
+			Outliner.getInstance().showCluster(clusterOutlineSlot, cluster)
+				.colored(0x4D9162)
+				.disableLineNormals()
+				.lineWidth(1 / 64f);
 	}
 
 	private boolean isGlue(ItemStack stack) {

--- a/src/main/java/com/simibubi/create/content/contraptions/glue/SuperGlueSelectionHelper.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/glue/SuperGlueSelectionHelper.java
@@ -1,12 +1,15 @@
 package com.simibubi.create.content.contraptions.glue;
 
-import java.util.ArrayList;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import com.simibubi.create.api.contraption.BlockMovementChecks;
 
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongSet;
 import net.createmod.catnip.data.Iterate;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -15,52 +18,84 @@ import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 
 public class SuperGlueSelectionHelper {
 
 	public static Set<BlockPos> searchGlueGroup(Level level, BlockPos startPos, BlockPos endPos, boolean includeOther) {
+		return searchGlueGroup(level, startPos, endPos, includeOther, true);
+	}
+
+	public static boolean isGlueGroupConnected(Level level, BlockPos startPos, BlockPos endPos, boolean includeOther) {
+		return searchGlueGroup(level, startPos, endPos, includeOther, false) != null;
+	}
+
+	private static Set<BlockPos> searchGlueGroup(Level level, BlockPos startPos, BlockPos endPos, boolean includeOther,
+		boolean collectAttached) {
 		if (endPos == null || startPos == null)
+			return null;
+		if (startPos.equals(endPos))
 			return null;
 
 		AABB bb = SuperGlueEntity.span(startPos, endPos);
 
-		List<BlockPos> frontier = new ArrayList<>();
-		Set<BlockPos> visited = new HashSet<>();
-		Set<BlockPos> attached = new HashSet<>();
-		Set<SuperGlueEntity> cachedOther = new HashSet<>();
+		Deque<BlockPos> frontier = new ArrayDeque<>();
+		LongSet visited = new LongOpenHashSet();
+		Set<BlockPos> attached = collectAttached ? new HashSet<>() : null;
+		Set<SuperGlueEntity> cachedOther = includeOther ? new HashSet<>() : null;
+		Long2ObjectOpenHashMap<BlockState> stateCache = new Long2ObjectOpenHashMap<>();
 
-		visited.add(startPos);
+		visited.add(startPos.asLong());
 		frontier.add(startPos);
+		boolean foundEnd = false;
 
 		while (!frontier.isEmpty()) {
-			BlockPos currentPos = frontier.remove(0);
-			attached.add(currentPos);
+			BlockPos currentPos = frontier.removeFirst();
+			if (collectAttached)
+				attached.add(currentPos);
+			if (currentPos.equals(endPos))
+				foundEnd = true;
 
+			BlockState currentState = getState(level, stateCache, currentPos);
 			for (Direction d : Iterate.directions) {
 				BlockPos offset = currentPos.relative(d);
+				BlockState offsetState = getState(level, stateCache, offset);
 				boolean gluePresent = includeOther && SuperGlueEntity.isGlued(level, currentPos, d, cachedOther);
-				boolean alreadySticky = includeOther && SuperGlueEntity.isSideSticky(level, currentPos, d)
-					|| SuperGlueEntity.isSideSticky(level, offset, d.getOpposite());
+				boolean alreadySticky = includeOther && SuperGlueEntity.isSideSticky(currentState, d)
+					|| SuperGlueEntity.isSideSticky(offsetState, d.getOpposite());
 
 				if (!alreadySticky && !gluePresent && !bb.contains(Vec3.atCenterOf(offset)))
 					continue;
-				if (!BlockMovementChecks.isMovementNecessary(level.getBlockState(offset), level, offset))
+				if (!BlockMovementChecks.isMovementNecessary(offsetState, level, offset))
 					continue;
-				if (!SuperGlueEntity.isValidFace(level, currentPos, d)
-					|| !SuperGlueEntity.isValidFace(level, offset, d.getOpposite()))
+				if (!SuperGlueEntity.isValidFace(level, currentPos, currentState, d)
+					|| !SuperGlueEntity.isValidFace(level, offset, offsetState, d.getOpposite()))
 					continue;
 
-				if (visited.add(offset))
+				if (offset.equals(endPos) && !collectAttached)
+					return Set.of(endPos);
+
+				if (visited.add(offset.asLong()))
 					frontier.add(offset);
 			}
 		}
 
-		if (attached.size() < 2 && attached.contains(endPos))
+		if (!foundEnd)
 			return null;
 
 		return attached;
+	}
+
+	private static BlockState getState(Level level, Long2ObjectOpenHashMap<BlockState> cache, BlockPos pos) {
+		long key = pos.asLong();
+		BlockState cached = cache.get(key);
+		if (cached != null)
+			return cached;
+		BlockState state = level.getBlockState(pos);
+		cache.put(key, state);
+		return state;
 	}
 
 	public static boolean collectGlueFromInventory(Player player, int requiredAmount, boolean simulate) {

--- a/src/main/java/com/simibubi/create/content/contraptions/glue/SuperGlueSelectionPacket.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/glue/SuperGlueSelectionPacket.java
@@ -8,11 +8,7 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.phys.AABB;
-import net.minecraft.world.phys.Vec3;
-
-import java.util.Set;
 
 public record SuperGlueSelectionPacket(BlockPos from, BlockPos to) implements ServerboundPacketPayload {
 	public static final StreamCodec<ByteBuf, SuperGlueSelectionPacket> STREAM_CODEC = StreamCodec.composite(
@@ -28,10 +24,7 @@ public record SuperGlueSelectionPacket(BlockPos from, BlockPos to) implements Se
 		if (!to.closerThan(from, 25))
 			return;
 
-		Set<BlockPos> group = SuperGlueSelectionHelper.searchGlueGroup(player.level(), from, to, false);
-		if (group == null)
-			return;
-		if (!group.contains(to))
+		if (!SuperGlueSelectionHelper.isGlueGroupConnected(player.level(), from, to, false))
 			return;
 		if (!SuperGlueSelectionHelper.collectGlueFromInventory(player, 1, true))
 			return;


### PR DESCRIPTION
partial successor to https://github.com/Creators-of-Create/Create/pull/6229

problems/fixes:
- flood fill was using an `ArrayList` as a queue, which makes the bfs degrade towards quadratic time. replaced with an `ArrayDeque`
- scanning for entities in a much larger space than necessary for edge test
- cluster outline being rebuilt every frame; instead calls `Outliner.getInstance().keep` now
- server-side handler rebuilt the entire block set; now just confirms reachability