### PR TITLE
Fix packagers and other peripheral-blocks not being valid inventory targets for CC

### DIFF
--- a/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/SyncedPeripheral.java
+++ b/src/main/java/com/simibubi/create/compat/computercraft/implementation/peripherals/SyncedPeripheral.java
@@ -62,6 +62,11 @@ public abstract class SyncedPeripheral<T extends SmartBlockEntity> implements IP
 
 	public void prepareComputerEvent(@NotNull ComputerEvent event) {}
 
+	@Override
+	public @Nullable Object getTarget() {
+		return blockEntity;
+	}
+
 	/**
 	 * Queue an event to all attached computers. Adds the peripheral attachment name as 1st event argument, followed by
 	 * any optional arguments passed to this method.


### PR DESCRIPTION
This PR fixes Packagers (and other smart block entity peripherals) not being valid inventory targets for CC despite having inventories that can be interacted with outside CC