### PR TITLE
perf: reduce impact of clipboard migrations

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/mixin/ItemStackMixin.java
+++ b/src/main/java/com/simibubi/create/foundation/mixin/ItemStackMixin.java
@@ -16,7 +16,6 @@ import com.simibubi.create.content.equipment.clipboard.ClipboardContent;
 
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.core.component.PatchedDataComponentMap;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ItemLike;
 

--- a/src/main/java/com/simibubi/create/foundation/mixin/ItemStackMixin.java
+++ b/src/main/java/com/simibubi/create/foundation/mixin/ItemStackMixin.java
@@ -2,6 +2,8 @@ package com.simibubi.create.foundation.mixin;
 
 import java.util.function.BiFunction;
 
+import com.simibubi.create.content.equipment.clipboard.ClipboardBlockItem;
+
 import org.jetbrains.annotations.ApiStatus.ScheduledForRemoval;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
@@ -14,7 +16,6 @@ import com.simibubi.create.content.equipment.clipboard.ClipboardContent;
 
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.core.component.PatchedDataComponentMap;
-import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ItemLike;
@@ -23,12 +24,9 @@ import net.minecraft.world.level.ItemLike;
 @Deprecated(since = "6.0.7", forRemoval = true)
 @Mixin(ItemStack.class)
 public class ItemStackMixin {
-	@Unique
-	private static final ResourceLocation create$CLIPBOARD_ID = ResourceLocation.fromNamespaceAndPath("create", "clipboard");
-
 	@Inject(method = "<init>(Lnet/minecraft/world/level/ItemLike;ILnet/minecraft/core/component/PatchedDataComponentMap;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/Item;verifyComponentsAfterLoad(Lnet/minecraft/world/item/ItemStack;)V"))
 	private void create$migrateOldClipboardComponents(ItemLike item, int count, PatchedDataComponentMap components, CallbackInfo ci) {
-		if (!BuiltInRegistries.ITEM.getKey(item.asItem()).equals(create$CLIPBOARD_ID))
+		if (!(item.asItem() instanceof ClipboardBlockItem) || components.isPatchEmpty() || components.has(AllDataComponents.CLIPBOARD_CONTENT))
 			return;
 
 		ClipboardContent content = ClipboardContent.EMPTY;


### PR DESCRIPTION
`instanceof ClipboardBlockItem` is faster than checking the registry. 
we can also short circuit if the component patch is empty or already has the new component.
considering how often itemstacks are created, the performance of this injection is quite critical, and shows up in profiles quite prominently.

[sparkprofile.zip](https://github.com/user-attachments/files/28015952/atm3.sparkprofile.zip)

Bottom-up view
<img width="1365" height="837" alt="image" src="https://github.com/user-attachments/assets/ad05ceee-3427-4303-bcd1-f9a0149a0bb3" />