### PR TITLE
Add Clearable to Millstone, Table Cloth, and Brass Tunnel

### DIFF
--- a/src/main/java/com/simibubi/create/content/kinetics/millstone/MillstoneBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/kinetics/millstone/MillstoneBlockEntity.java
@@ -137,6 +137,7 @@ public class MillstoneBlockEntity extends KineticBlockEntity implements Clearabl
 	@Override
 	public void clearContent() {
 		((ItemStackHandlerAccessor) inputInv).create$getStacks().clear();
+		((ItemStackHandlerAccessor) outputInv).create$getStacks().clear();
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/logistics/tableCloth/TableClothBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/tableCloth/TableClothBlockEntity.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import net.minecraft.world.Clearable;
 import org.jetbrains.annotations.Nullable;
 
 import com.simibubi.create.AllBlockEntityTypes;
@@ -57,7 +58,7 @@ import net.minecraft.world.phys.Vec3;
 
 import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
 
-public class TableClothBlockEntity extends SmartBlockEntity implements TransformableBlockEntity {
+public class TableClothBlockEntity extends SmartBlockEntity implements TransformableBlockEntity, Clearable {
 
 	public AbstractComputerBehaviour computerBehaviour;
 
@@ -365,6 +366,11 @@ public class TableClothBlockEntity extends SmartBlockEntity implements Transform
 	public void invalidate() {
 		super.invalidate();
 		computerBehaviour.removePeripheral();
+	}
+
+	@Override
+	public void clearContent() {
+		manuallyAddedItems.clear();
 	}
 
 	public void transform(BlockEntity blockEntity, StructureTransform transform) {

--- a/src/main/java/com/simibubi/create/content/logistics/tunnel/BrassTunnelBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/tunnel/BrassTunnelBlockEntity.java
@@ -8,6 +8,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import com.simibubi.create.foundation.mixin.accessor.ItemStackHandlerAccessor;
+import net.minecraft.world.Clearable;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.Nullable;
 
@@ -56,7 +58,7 @@ import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
 import net.neoforged.neoforge.items.IItemHandler;
 
-public class BrassTunnelBlockEntity extends BeltTunnelBlockEntity implements IHaveGoggleInformation {
+public class BrassTunnelBlockEntity extends BeltTunnelBlockEntity implements IHaveGoggleInformation, Clearable {
 
 	SidedFilteringBehaviour filtering;
 
@@ -730,9 +732,8 @@ public class BrassTunnelBlockEntity extends BeltTunnelBlockEntity implements IHa
 	}
 
 	@Override
-	public void invalidate() {
-		super.invalidate();
-		invalidateCapabilities();
+	public void clearContent() {
+		((ItemStackHandlerAccessor) tunnelCapability).create$getStacks().clear();
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/create/content/logistics/tunnel/BrassTunnelBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/tunnel/BrassTunnelBlockEntity.java
@@ -732,6 +732,12 @@ public class BrassTunnelBlockEntity extends BeltTunnelBlockEntity implements IHa
 	}
 
 	@Override
+	public void invalidate() {
+		super.invalidate();
+		invalidateCapabilities();
+	}
+
+	@Override
 	public void clearContent() {
 		((ItemStackHandlerAccessor) tunnelCapability).create$getStacks().clear();
 	}


### PR DESCRIPTION
Implements Clearable properly for the last few blocks. Millstones implement clearable, but don't currently clear their output items.