### PR TITLE
Fix Threshold Switch capacity/stack calculation for low-stacking items (#7688)

### DIFF
--- a/src/generated/resources/assets/create/lang/en_ud.json
+++ b/src/generated/resources/assets/create/lang/en_ud.json
@@ -1434,6 +1434,7 @@
   "create.gui.threshold_switch.pulley_y_level": "ʎ%1$s",
   "create.gui.threshold_switch.range": ")%2$s oʇ %1$s(",
   "create.gui.threshold_switch.range_max": ")%1$s ˙xɐɯ(",
+  "create.gui.threshold_switch.slots": "sʇoןS",
   "create.gui.threshold_switch.title": "ɥɔʇıʍS pןoɥsǝɹɥ⟘",
   "create.gui.threshold_switch.upper_threshold": ":ǝʌoqɐ ɹo ʇɐ˙˙˙",
   "create.gui.toolmenu.cycle": "ǝןɔʎƆ oʇ ]ꞀꞀOᴚƆS[",

--- a/src/generated/resources/assets/create/lang/en_us.json
+++ b/src/generated/resources/assets/create/lang/en_us.json
@@ -1434,6 +1434,7 @@
   "create.gui.threshold_switch.pulley_y_level": "%1$sy",
   "create.gui.threshold_switch.range": "(%1$s to %2$s)",
   "create.gui.threshold_switch.range_max": "(max. %1$s)",
+  "create.gui.threshold_switch.slots": "Slots",
   "create.gui.threshold_switch.title": "Threshold Switch",
   "create.gui.threshold_switch.upper_threshold": "...at or above:",
   "create.gui.toolmenu.cycle": "[SCROLL] to Cycle",

--- a/src/main/java/com/simibubi/create/content/redstone/thresholdSwitch/ThresholdSwitchBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/redstone/thresholdSwitch/ThresholdSwitchBlockEntity.java
@@ -23,7 +23,6 @@ import com.simibubi.create.foundation.utility.CreateLang;
 import net.createmod.catnip.math.BlockFace;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
-import net.minecraft.core.component.DataComponents;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.util.Mth;
@@ -57,6 +56,9 @@ public class ThresholdSwitchBlockEntity extends SmartBlockEntity implements Clea
 	private InvManipulationBehaviour observedInventory;
 	private TankManipulationBehaviour observedTank;
 	private VersionedInventoryTrackerBehaviour invVersionTracker;
+
+	/** Number of items represented by a single stack/slot when measuring fullness. */
+	private static final int STACK_SIZE = 64;
 
 	private static final List<ThresholdSwitchCompat> COMPAT = List.of(
 		new FunctionalStorage(),
@@ -162,6 +164,12 @@ public class ThresholdSwitchBlockEntity extends SmartBlockEntity implements Clea
 
 				} else {
 					invVersionTracker.awaitNewVersion(inv);
+
+					// Reference stack size for the "items" mode: sizing every slot uniformly
+					// keeps the maximum capacity stable as non-stackable (or low-stacking) items
+					// are inserted. Uses the filtered item's stack size, or 64 when unfiltered.
+					int stackSize = filtering.getMaxStackSize();
+
 					for (int slot = 0; slot < inv.getSlots(); slot++) {
 						ItemStack stackInSlot = inv.getStackInSlot(slot);
 
@@ -171,15 +179,28 @@ public class ThresholdSwitchBlockEntity extends SmartBlockEntity implements Clea
 							.filter(compat -> compat.isFromThisMod(targetBlockEntity))
 							.map(compat -> compat.getSpaceInSlot(inv, finalSlot))
 							.findFirst()
-							.orElseGet(() -> (long) Math.min(stackInSlot.getOrDefault(DataComponents.MAX_STACK_SIZE, 64), inv.getSlotLimit(finalSlot)));
+							.orElseGet(() -> (long) Math.min(stackSize, inv.getSlotLimit(finalSlot)));
 
-						int count = stackInSlot.getCount();
 						if (space == 0)
 							continue;
 
-						currentMaxLevel += space;
-						if (filtering.test(stackInSlot))
-							currentLevel += count;
+						if (inStacks) {
+							// "Stacks" measures slot occupancy: a slot counts as a full stack as
+							// soon as it holds anything, no matter how full it is. The container
+							// therefore reads as full once no empty slots remain - the point at
+							// which it can no longer accept an arbitrary new item. Setting the
+							// threshold just below the slot count keeps a free slot available for
+							// incoming items at all times.
+							currentMaxLevel += STACK_SIZE;
+							if (!stackInSlot.isEmpty() && filtering.test(stackInSlot))
+								currentLevel += STACK_SIZE;
+
+						} else {
+							// "Items" counts individual items against the theoretical capacity.
+							currentMaxLevel += space;
+							if (filtering.test(stackInSlot))
+								currentLevel += stackInSlot.getCount();
+						}
 					}
 				}
 			}
@@ -266,7 +287,7 @@ public class ThresholdSwitchBlockEntity extends SmartBlockEntity implements Clea
 				return tso.format(value);
 
 		String suffix = type == ThresholdType.ITEM
-			? stacks ? "schedule.condition.threshold.stacks" : "schedule.condition.threshold.items"
+			? stacks ? "gui.threshold_switch.slots" : "schedule.condition.threshold.items"
 			: "schedule.condition.threshold.buckets";
 		return CreateLang.text(value + " ")
 			.add(CreateLang.translate(suffix))

--- a/src/main/java/com/simibubi/create/content/redstone/thresholdSwitch/ThresholdSwitchScreen.java
+++ b/src/main/java/com/simibubi/create/content/redstone/thresholdSwitch/ThresholdSwitchScreen.java
@@ -65,7 +65,7 @@ public class ThresholdSwitchScreen extends AbstractSimiScreen {
 
 		inStacks = (SelectionScrollInput) new SelectionScrollInput(x + 100, y + 23, 52, 42)
 			.forOptions(List.of(CreateLang.translateDirect("schedule.condition.threshold.items"),
-				CreateLang.translateDirect("schedule.condition.threshold.stacks")))
+				CreateLang.translateDirect("gui.threshold_switch.slots")))
 			.titled(CreateLang.translateDirect("schedule.condition.threshold.item_measure"))
 			.setState(blockEntity.inStacks ? 1 : 0);
 
@@ -160,7 +160,7 @@ public class ThresholdSwitchScreen extends AbstractSimiScreen {
 		if (forItems) {
 			Component suffix =
 				inStacks.getState() == 0 ? CreateLang.translateDirect("schedule.condition.threshold.items")
-					: CreateLang.translateDirect("schedule.condition.threshold.stacks");
+					: CreateLang.translateDirect("gui.threshold_switch.slots");
 			valueStep = inStacks.getState() == 0 ? 1 : 64;
 			graphics.drawString(font, suffix, x + 105, y + 28, 0xFFFFFFFF, true);
 			graphics.drawString(font, suffix, x + 105, y + 28 + 24, 0xFFFFFFFF, true);

--- a/src/main/resources/assets/create/lang/default/interface.json
+++ b/src/main/resources/assets/create/lang/default/interface.json
@@ -285,6 +285,7 @@
 	"create.gui.threshold_switch.currently": "Currently %1$s",
 	"create.gui.threshold_switch.range": "(%1$s to %2$s)",
 	"create.gui.threshold_switch.range_max": "(max. %1$s)",
+	"create.gui.threshold_switch.slots": "Slots",
 	"create.gui.threshold_switch.pulley_y_level": "%1$sy",
 	"create.gui.threshold_switch.not_attached": "Not attached to a block",
 	"create.gui.threshold_switch.incompatible": "Incompatible block",


### PR DESCRIPTION
Closes #7688
  Closes #9489
  Closes #9490

  ### Problem
  The Threshold Switch sized each slot's capacity from the stack currently in it.
  Inserting non-stackable or low-stacking items (tools, snowballs, ender pearls...)
  shrank the reported maximum — and the reduced value persisted even after the
  container was emptied — so absolute thresholds became unreachable. In "Stacks"
  mode the unit was also hardcoded to 64, making it behave identically to "Items".

  ### Changes
  - **Items mode** now sizes every slot from the filtered item's stack size
    (or 64 when unfiltered), so the maximum stays stable as items are inserted.
  - **Stacks mode** now measures slot occupancy: a slot counts as one full stack
    as soon as it holds anything, regardless of the item's stack size. A full slot
    of snowballs (16) or a single tool both count as one stack, and the container
    reads as full once no empty slots remain — the point at which it can no longer
    accept an arbitrary new item. Set the threshold just below the slot count to
    always keep a free slot for incoming items.
  - Renamed the stacks-mode label to **"Slots"** via a dedicated lang key, so the
    train schedule and factory panel keep their original "Stacks" wording.

  ### Notes
  - `en_us.json` / `en_ud.json` regenerated via datagen. Other-language translations
    intentionally left for Crowdin per the lang README.