### PR TITLE
Add biome tag for diving helmet fog scaling

### DIFF
--- a/src/main/java/com/simibubi/create/AllTags.java
+++ b/src/main/java/com/simibubi/create/AllTags.java
@@ -30,6 +30,7 @@ import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeSerializer;
+import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Fluid;
@@ -328,6 +329,24 @@ public class AllTags {
 
 		public boolean matches(Entity entity) {
 			return matches(entity.getType());
+		}
+	}
+
+	public enum AllBiomeTags {
+		WITHOUT_DIVING_HELMET_FOG_SCALING;
+
+		public final TagKey<Biome> tag;
+
+		AllBiomeTags() {
+			this(MOD);
+		}
+
+		AllBiomeTags(NameSpace namespace) {
+			this(namespace, null);
+		}
+
+		AllBiomeTags(NameSpace namespace, @Nullable String pathOverride) {
+			this.tag = TagKey.create(Registries.BIOME, namespace.id(this, pathOverride));
 		}
 	}
 

--- a/src/main/java/com/simibubi/create/foundation/events/ClientEvents.java
+++ b/src/main/java/com/simibubi/create/foundation/events/ClientEvents.java
@@ -5,6 +5,7 @@ import java.util.function.Supplier;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.simibubi.create.AllItems;
+import com.simibubi.create.AllTags.AllBiomeTags;
 import com.simibubi.create.Create;
 import com.simibubi.create.CreateClient;
 import com.simibubi.create.content.contraptions.ContraptionHandler;
@@ -329,7 +330,9 @@ public class ClientEvents {
 
 		ItemStack divingHelmet = DivingHelmetItem.getWornItem(entity);
 		if (!divingHelmet.isEmpty()) {
-			if (FluidHelper.isWater(fluid)) {
+			boolean shouldScaleWaterFog = !level.getBiome(blockPos)
+				.is(AllBiomeTags.WITHOUT_DIVING_HELMET_FOG_SCALING.tag);
+			if (FluidHelper.isWater(fluid) && shouldScaleWaterFog) {
 				event.scaleFarPlaneDistance(6.25f);
 				event.setCanceled(true);
 				return;

--- a/src/main/resources/data/create/tags/worldgen/biome/without_diving_helmet_fog_scaling.json
+++ b/src/main/resources/data/create/tags/worldgen/biome/without_diving_helmet_fog_scaling.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "alexscaves:abyssal_chasm",
+      "required": false
+    }
+  ]
+}


### PR DESCRIPTION
### What changed

- Replaces the old config-based approach from #7917 with a biome tag gate for Create diving helmet water fog scaling.
- Adds `create:without_diving_helmet_fog_scaling` for biomes where Create should not extend underwater fog distance.
- Includes `alexscaves:abyssal_chasm` as an optional default tag entry, so Alex's Caves keeps its own low-visibility fog behavior when installed.

### Screenshots from #7917

Before:

![2025-03-12_10 48 10](https://github.com/user-attachments/assets/77363ddb-87ce-4b87-b008-fa6d7199e36f)

After:

![2025-03-12_10 48 35](https://github.com/user-attachments/assets/4a4ad589-98c7-4d02-af24-b8b1f68aa681)

### Why

The previous PR disabled the behavior through config and also moved `event.setCanceled(true)` outside the fog branches. Review feedback asked for a biome tag instead and noted that canceling fog when Create does not handle it can break other mods. This version only skips the water scaling in tagged biomes and leaves event cancellation inside the existing water/lava handling branches.

### Validation

- `./gradlew compileJava`
- `./gradlew runData`
- Local client launch with Alex's Caves (Unofficial Port) 2.0.10 and Citadel 2.7.6 on NeoForge 21.1.219, using a fresh Quick Play creative test world with a datapack that filled the player area as `alexscaves:abyssal_chasm`, equipped a Create diving helmet, and surrounded the player with water. The client loaded Create, Alex's Caves, and Citadel together and entered the integrated world without a crash.

Notes from the runtime check: the copied template world logged unknown `piglinproliferation`/`luminous_*` data attachments; those came from the reused local template save and are unrelated to this change.

### Related

- 1.20.1 draft PR: https://github.com/Creators-of-Create/Create/pull/10446