### PR TITLE
Add biome tag for diving helmet fog scaling

### DIFF
--- a/src/main/java/com/simibubi/create/AllTags.java
+++ b/src/main/java/com/simibubi/create/AllTags.java
@@ -26,6 +26,7 @@ import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeSerializer;
+import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Fluid;
@@ -344,6 +345,28 @@ public class AllTags {
 
 		public boolean matches(Entity entity) {
 			return matches(entity.getType());
+		}
+
+	}
+
+	public enum AllBiomeTags {
+
+		WITHOUT_DIVING_HELMET_FOG_SCALING,
+
+		;
+
+		public final TagKey<Biome> tag;
+
+		AllBiomeTags() {
+			this(MOD);
+		}
+
+		AllBiomeTags(NameSpace namespace) {
+			this(namespace, null);
+		}
+
+		AllBiomeTags(NameSpace namespace, @Nullable String pathOverride) {
+			this.tag = TagKey.create(Registries.BIOME, namespace.id(this, pathOverride));
 		}
 
 	}

--- a/src/main/java/com/simibubi/create/foundation/events/ClientEvents.java
+++ b/src/main/java/com/simibubi/create/foundation/events/ClientEvents.java
@@ -4,6 +4,7 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.simibubi.create.AllItems;
 import com.simibubi.create.AllPackets;
+import com.simibubi.create.AllTags.AllBiomeTags;
 import com.simibubi.create.Create;
 import com.simibubi.create.CreateClient;
 import com.simibubi.create.content.contraptions.ContraptionHandler;
@@ -320,7 +321,9 @@ public class ClientEvents {
 
 		ItemStack divingHelmet = DivingHelmetItem.getWornItem(entity);
 		if (!divingHelmet.isEmpty()) {
-			if (FluidHelper.isWater(fluid)) {
+			boolean shouldScaleWaterFog = !level.getBiome(blockPos)
+				.is(AllBiomeTags.WITHOUT_DIVING_HELMET_FOG_SCALING.tag);
+			if (FluidHelper.isWater(fluid) && shouldScaleWaterFog) {
 				event.scaleFarPlaneDistance(6.25f);
 				event.setCanceled(true);
 				return;

--- a/src/main/resources/data/create/tags/worldgen/biome/without_diving_helmet_fog_scaling.json
+++ b/src/main/resources/data/create/tags/worldgen/biome/without_diving_helmet_fog_scaling.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "alexscaves:abyssal_chasm",
+      "required": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a biome tag that lets specific biomes opt out of Create's diving helmet water fog distance scaling.

This keeps the existing water/lava event cancellation behavior scoped to the same branches, so other mods can continue handling fog when Create is not actively overriding it.

The default tag entry is optional and targets Alex's Caves' `alexscaves:abyssal_chasm` biome.

A separate 1.21.1 draft PR is kept at https://github.com/Creators-of-Create/Create/pull/10445.

## Old PR screenshots

Before:

![2025-03-12_10 48 10](https://github.com/user-attachments/assets/77363ddb-87ce-4b87-b008-fa6d7199e36f)

After:

![2025-03-12_10 48 35](https://github.com/user-attachments/assets/4a4ad589-98c7-4d02-af24-b8b1f68aa681)

## Testing

- `./gradlew compileJava`
- `./gradlew runData`
- `./gradlew runClient -PquickPlayWorld=Create_AlexCaves_1201_Fog_Test_2` with ForgeGradle-remapped Alex's Caves 2.0.2 and Citadel 2.6.0 in `run/mods`; the client selected `alexscaves.mixins.json`, initialized Create 6.0.8, loaded Alex's Caves client resources, loaded the temporary test datapack, connected to the integrated modded server, and logged the player into the Quick Play world.
