### PR TITLE
Apply SpawnerMovement config to trial spawners

### DIFF
--- a/src/main/java/com/simibubi/create/AllContraptionMovementSettings.java
+++ b/src/main/java/com/simibubi/create/AllContraptionMovementSettings.java
@@ -8,6 +8,7 @@ import net.minecraft.world.level.block.Blocks;
 public class AllContraptionMovementSettings {
 	public static void registerDefaults() {
 		ContraptionMovementSetting.REGISTRY.register(Blocks.SPAWNER, () -> AllConfigs.server().kinetics.spawnerMovement.get());
+		ContraptionMovementSetting.REGISTRY.register(Blocks.TRIAL_SPAWNER, () -> AllConfigs.server().kinetics.spawnerMovement.get());
 		ContraptionMovementSetting.REGISTRY.register(Blocks.BUDDING_AMETHYST, () -> AllConfigs.server().kinetics.amethystMovement.get());
 		ContraptionMovementSetting.REGISTRY.register(Blocks.OBSIDIAN, () -> AllConfigs.server().kinetics.obsidianMovement.get());
 		ContraptionMovementSetting.REGISTRY.register(Blocks.CRYING_OBSIDIAN, () -> AllConfigs.server().kinetics.obsidianMovement.get());


### PR DESCRIPTION
Hi!

I've noticed that the SpawnerMovement config isn't applied to trial spawners.
This feels like an unintentional oversight, so I went ahead and fixed this.

Thanks for creating and maintaining such a great mod!