### PR TITLE
Use passed ItemStack when inserting hand into the item hatch

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/itemHatch/ItemHatchBlock.java
+++ b/src/main/java/com/simibubi/create/content/logistics/itemHatch/ItemHatchBlock.java
@@ -122,7 +122,7 @@ public class ItemHatchBlock extends HorizontalDirectionalBlock
 				continue;
 			if (depositItemInHand && i != inventory.selected)
 				continue;
-			ItemStack item = inventory.getItem(i);
+			ItemStack item = depositItemInHand ? stack : inventory.getItem(i);
 			if (item.isEmpty())
 				continue;
 			if (!item.getItem()
@@ -136,9 +136,14 @@ public class ItemHatchBlock extends HorizontalDirectionalBlock
 			if (remainder.getCount() == item.getCount())
 				continue;
 
-			ItemStack extracted = inventory.removeItem(i, item.getCount() - remainder.getCount());
+			ItemStack extracted = depositItemInHand ? stack.copy() : inventory.removeItem(i, item.getCount() - remainder.getCount());
 			remainder = ItemHandlerHelper.insertItemStacked(targetInv, extracted, false);
 			anyInserted = true;
+
+			if(depositItemInHand) {
+				stack.setCount(remainder.getCount());
+				remainder.setCount(0); // clear it because we already set the count and don't want to duplicate it
+			}
 
 			// remainder might not be empty in itemhandler edge cases
 			if (!remainder.isEmpty())


### PR DESCRIPTION
This PR makes the Item Hatch directly modify the passed item stack when right-clicked if the player is depositing the item in their hand. This prevents unexpected behaviour with my mod Satchels, as described in vercte/satchels#3:  
Before these changes, it would always deposit the selected slot in the normal hotbar, which may be unexpected to the player as their held item would not be deposited and the slot below the satchel would be. These changes always deposit the held item correctly instead of directly checking the player inventory. 
