### PR TITLE
Fix stock keeper inventory desync

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/stockTicker/StockKeeperRequestMenu.java
+++ b/src/main/java/com/simibubi/create/content/logistics/stockTicker/StockKeeperRequestMenu.java
@@ -30,7 +30,7 @@ public class StockKeeperRequestMenu extends MenuBase<StockTickerBlockEntity> {
 
 	public static AbstractContainerMenu create(int pContainerId, Inventory pPlayerInventory,
 		StockTickerBlockEntity stockTickerBlockEntity) {
-		return new StockKeeperCategoryMenu(AllMenuTypes.STOCK_KEEPER_REQUEST.get(), pContainerId, pPlayerInventory,
+		return new StockKeeperRequestMenu(AllMenuTypes.STOCK_KEEPER_REQUEST.get(), pContainerId, pPlayerInventory,
 			stockTickerBlockEntity);
 	}
 


### PR DESCRIPTION
Picking up items while stock keeper GUI being opened causes temporary inventory desync.
Correcting this typo (apparently) in StockKeeperRequestMenu seems to fix the problem.

Without this change:
<img width="400" alt="2026-06-07 003536" src="https://github.com/user-attachments/assets/9d41133b-56af-4c0d-80dc-68c40d51c6d5" />
<img width="400" alt="2026-06-07 003550" src="https://github.com/user-attachments/assets/cc7bd85f-a58d-4d66-bedc-31fc53466024" />
<img width="400" alt="2026-06-07 003607" src="https://github.com/user-attachments/assets/927d7229-651a-4f7b-967d-bac878ed17ff" />
Slot 6 overwritten.
<img width="400" alt="2026-06-07 004942" src="https://github.com/user-attachments/assets/558a01b4-d5e0-4bc8-84ab-373cec664d75" />
Moving items synchronizes inventory.

With this change:
<img width="400" alt="2026-06-07 004134" src="https://github.com/user-attachments/assets/9bebc9ee-deb5-4429-b0d2-a3090b716e92" />
