### PR TITLE
Optimize Brass Funnel Performance in EXACTLY Mode

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/item/ItemHelper.java
+++ b/src/main/java/com/simibubi/create/foundation/item/ItemHelper.java
@@ -233,7 +233,7 @@ public class ItemHelper {
 					break;
 			}
 			if (!result.isEmpty()) {
-				amount = Math.min(slotRecord.totalAmount, result.getMaxStackSize());
+				amount = Math.min(slotRecord.totalAmount, maxExtractAmount);
 				result.setCount(amount);
 				if (!simulate) {
 					for (int slot: slotRecord.slots) {

--- a/src/main/java/com/simibubi/create/foundation/item/ItemHelper.java
+++ b/src/main/java/com/simibubi/create/foundation/item/ItemHelper.java
@@ -190,11 +190,11 @@ public class ItemHelper {
 			VisitedItemStackTracker tracker = new VisitedItemStackTracker();
 			for (int i = 0; i < inv.getSlots(); i++) {
 				ItemStack stackIn = inv.getStackInSlot(i);
-				if (stackIn.isEmpty() || stackIn.getMaxStackSize() < amount || !test.test(stackIn))
+				if (stackIn.isEmpty() || stackIn.getMaxStackSize() < amount)
 					continue;
 
-				ItemStack extracted = inv.extractItem(i, stackIn.getCount(), true);
-				if (extracted.isEmpty())
+				ItemStack extracted = inv.extractItem(i, Math.min(stackIn.getCount(), amount), true);
+				if (extracted.isEmpty() || !test.test(extracted))
 					continue;
 
 				VisitedItemStackTracker.SlotAmountRecord slotRecord = tracker.update(extracted.copy(), i);
@@ -215,12 +215,11 @@ public class ItemHelper {
 			int maxExtractAmount = amount;
 			for (int i = 0; i < inv.getSlots(); i++) {
 				ItemStack stackIn = inv.getStackInSlot(i);
-				if (stackIn.isEmpty() || (!result.isEmpty() && !ItemStack.isSameItemSameComponents(result, stackIn)) ||
-					!test.test(stackIn))
+				if (stackIn.isEmpty() || (!result.isEmpty() && !ItemStack.isSameItemSameComponents(result, stackIn)))
 					continue;
 
-				ItemStack extracted = inv.extractItem(i, stackIn.getCount(), true);
-				if (extracted.isEmpty())
+				ItemStack extracted = inv.extractItem(i, Math.min(stackIn.getCount(), maxExtractAmount), true);
+				if (extracted.isEmpty() || !test.test(extracted))
 					continue;
 
 				if (result.isEmpty()) {

--- a/src/main/java/com/simibubi/create/foundation/item/ItemHelper.java
+++ b/src/main/java/com/simibubi/create/foundation/item/ItemHelper.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import com.simibubi.create.foundation.utility.VisitedItemStackTracker;
+
 import org.jetbrains.annotations.Nullable;
 
 import org.apache.commons.lang3.mutable.MutableInt;
@@ -182,70 +184,41 @@ public class ItemHelper {
 
 	public static ItemStack extract(IItemHandler inv, Predicate<ItemStack> test, ExtractionCountMode mode, int amount,
 									boolean simulate) {
-		ItemStack extracting = ItemStack.EMPTY;
-		boolean amountRequired = mode == ExtractionCountMode.EXACTLY;
-		boolean checkHasEnoughItems = amountRequired;
-		boolean hasEnoughItems = !checkHasEnoughItems;
-		boolean potentialOtherMatch = false;
-		int maxExtractionCount = amount;
-
-		Extraction:
-		do {
-			extracting = ItemStack.EMPTY;
-
-			for (int slot = 0; slot < inv.getSlots(); slot++) {
-				ItemStack slotStack = inv.getStackInSlot(slot);
-				if (slotStack.isEmpty())
+		if (mode == ItemHelper.ExtractionCountMode.EXACTLY) {
+			VisitedItemStackTracker tracker = new VisitedItemStackTracker();
+			for (int i = 0; i < inv.getSlots(); i++) {
+				ItemStack stackIn = inv.getStackInSlot(i);
+				if (stackIn.isEmpty() || !test.test(stackIn))
 					continue;
-				int amountToExtractFromThisSlot =
-					Math.min(maxExtractionCount - extracting.getCount(), slotStack.getMaxStackSize());
-				ItemStack stack = inv.extractItem(slot, amountToExtractFromThisSlot, true);
 
-				if (stack.isEmpty())
+				ItemStack extracted = inv.extractItem(i, amount, true);
+				if (extracted.isEmpty())
 					continue;
-				if (!test.test(stack))
-					continue;
-				if (!extracting.isEmpty() && !canItemStackAmountsStack(stack, extracting)) {
-					potentialOtherMatch = true;
-					continue;
-				}
 
-				if (extracting.isEmpty())
-					extracting = stack.copy();
-				else
-					extracting.grow(stack.getCount());
-
-				if (!simulate && hasEnoughItems)
-					inv.extractItem(slot, stack.getCount(), false);
-
-				if (extracting.getCount() >= maxExtractionCount) {
-					if (checkHasEnoughItems) {
-						hasEnoughItems = true;
-						checkHasEnoughItems = false;
-						continue Extraction;
-					} else {
-						break Extraction;
+				VisitedItemStackTracker.SlotAmountRecord slotRecord = tracker.update(stackIn, i);
+				if (slotRecord.totalAmount >= amount) {
+					ItemStack result = extracted.copyWithCount(amount);
+					if (!simulate) {
+						for (int slot: slotRecord.slots) {
+							amount -= inv.extractItem(slot, amount, false).getCount();
+						}
 					}
+					return result;
 				}
 			}
+		} else {
+			for (int i = 0; i < inv.getSlots(); i++) {
+				ItemStack stackIn = inv.getStackInSlot(i);
+				if (stackIn.isEmpty() || !test.test(stackIn))
+					continue;
 
-			if (!extracting.isEmpty() && !hasEnoughItems && potentialOtherMatch) {
-				ItemStack blackListed = extracting.copy();
-				test = test.and(i -> !ItemStack.isSameItemSameComponents(i, blackListed));
-				continue;
+				ItemStack extracted = inv.extractItem(i, amount, simulate);
+				if (!extracted.isEmpty()) {
+					return extracted.copy();
+				}
 			}
-
-			if (checkHasEnoughItems)
-				checkHasEnoughItems = false;
-			else
-				break Extraction;
-
-		} while (true);
-
-		if (amountRequired && extracting.getCount() < amount)
-			return ItemStack.EMPTY;
-
-		return extracting;
+		}
+		return ItemStack.EMPTY;
 	}
 
 	public static ItemStack extract(IItemHandler inv, Predicate<ItemStack> test,

--- a/src/main/java/com/simibubi/create/foundation/item/ItemHelper.java
+++ b/src/main/java/com/simibubi/create/foundation/item/ItemHelper.java
@@ -7,6 +7,8 @@ import java.util.function.Predicate;
 
 import com.simibubi.create.foundation.utility.VisitedItemStackTracker;
 
+import com.simibubi.create.foundation.utility.VisitedItemStackTracker.SlotAmountRecord;
+
 import org.jetbrains.annotations.Nullable;
 
 import org.apache.commons.lang3.mutable.MutableInt;
@@ -188,34 +190,58 @@ public class ItemHelper {
 			VisitedItemStackTracker tracker = new VisitedItemStackTracker();
 			for (int i = 0; i < inv.getSlots(); i++) {
 				ItemStack stackIn = inv.getStackInSlot(i);
-				if (stackIn.isEmpty() || !test.test(stackIn))
+				if (stackIn.isEmpty() || stackIn.getMaxStackSize() < amount || !test.test(stackIn))
 					continue;
 
-				ItemStack extracted = inv.extractItem(i, amount, true);
+				ItemStack extracted = inv.extractItem(i, stackIn.getCount(), true);
 				if (extracted.isEmpty())
 					continue;
 
-				VisitedItemStackTracker.SlotAmountRecord slotRecord = tracker.update(stackIn, i);
+				VisitedItemStackTracker.SlotAmountRecord slotRecord = tracker.update(extracted.copy(), i);
 				if (slotRecord.totalAmount >= amount) {
 					ItemStack result = extracted.copyWithCount(amount);
 					if (!simulate) {
 						for (int slot: slotRecord.slots) {
-							amount -= inv.extractItem(slot, amount, false).getCount();
+							int extractAmount = Math.min(inv.getStackInSlot(slot).getCount(), amount);
+							amount -= inv.extractItem(slot, extractAmount, false).getCount();
 						}
 					}
 					return result;
 				}
 			}
 		} else {
+			VisitedItemStackTracker.SlotAmountRecord slotRecord = new SlotAmountRecord();
+			ItemStack result = ItemStack.EMPTY;
+			int maxExtractAmount = amount;
 			for (int i = 0; i < inv.getSlots(); i++) {
 				ItemStack stackIn = inv.getStackInSlot(i);
-				if (stackIn.isEmpty() || !test.test(stackIn))
+				if (stackIn.isEmpty() || (!result.isEmpty() && !ItemStack.isSameItemSameComponents(result, stackIn)) ||
+					!test.test(stackIn))
 					continue;
 
-				ItemStack extracted = inv.extractItem(i, amount, simulate);
-				if (!extracted.isEmpty()) {
-					return extracted.copy();
+				ItemStack extracted = inv.extractItem(i, stackIn.getCount(), true);
+				if (extracted.isEmpty())
+					continue;
+
+				if (result.isEmpty()) {
+					result = extracted.copy();
+					maxExtractAmount = Math.min(amount, extracted.getMaxStackSize());
 				}
+
+				slotRecord.add(i, extracted.getCount());
+				if (slotRecord.totalAmount >= maxExtractAmount)
+					break;
+			}
+			if (!result.isEmpty()) {
+				amount = Math.min(slotRecord.totalAmount, result.getMaxStackSize());
+				result.setCount(amount);
+				if (!simulate) {
+					for (int slot: slotRecord.slots) {
+						int extractAmount = Math.min(inv.getStackInSlot(slot).getCount(), amount);
+						amount -= inv.extractItem(slot, extractAmount, false).getCount();
+					}
+				}
+				return result;
 			}
 		}
 		return ItemStack.EMPTY;

--- a/src/main/java/com/simibubi/create/foundation/utility/VisitedItemStackTracker.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/VisitedItemStackTracker.java
@@ -46,7 +46,7 @@ public class VisitedItemStackTracker {
 		public final IntArrayList slots = new IntArrayList();
 		public int totalAmount = 0;
 
-		void add(int slot, int amount) {
+		public void add(int slot, int amount) {
 			slots.add(slot);
 			totalAmount += amount;
 		}

--- a/src/main/java/com/simibubi/create/foundation/utility/VisitedItemStackTracker.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/VisitedItemStackTracker.java
@@ -1,0 +1,54 @@
+package com.simibubi.create.foundation.utility;
+
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class VisitedItemStackTracker {
+	Map<AbstractItemStack, SlotAmountRecord> itemStackMap = new HashMap<>();
+
+	public SlotAmountRecord update(ItemStack itemStack, int slot) {
+		SlotAmountRecord record = itemStackMap.computeIfAbsent(new AbstractItemStack(itemStack), k -> new SlotAmountRecord());
+		record.add(slot, itemStack.getCount());
+		return record;
+	}
+
+	public static class AbstractItemStack {
+		private final ItemStack stack;
+		private boolean initialized = false;
+		private int hashCode;
+
+		AbstractItemStack(ItemStack stack) {
+			this.stack = stack;
+		}
+
+		@Override
+		public int hashCode() {
+			if (!initialized) {
+				initialized = true;
+				hashCode = stack.getItem().hashCode();
+				hashCode = hashCode * 31 + stack.getComponents().hashCode();
+			}
+			return hashCode;
+		}
+
+		@Override
+		public boolean equals(Object other) {
+			if (!(other instanceof AbstractItemStack otherStack))
+				return false;
+			return ItemStack.isSameItemSameComponents(stack, otherStack.stack);
+		}
+	}
+
+	public static class SlotAmountRecord {
+		public final IntArrayList slots = new IntArrayList();
+		public int totalAmount = 0;
+
+		void add(int slot, int amount) {
+			slots.add(slot);
+			totalAmount += amount;
+		}
+	}
+}


### PR DESCRIPTION
_The following content is machine-translated and may contain inaccuracies._

This PR improves the performance of Brass Funnels in `EXACTLY` mode when the filter is configured to allow multiple item types.

### Test

Setup:

* 16 input funnels, each configured to extract up to 16 items
* 4 output funnels, each configured to extract exactly 64 items

Before:
Average cost per output funnel: 45.25 μs/t
<img width="1920" height="986" alt="2026-06-10_15 52 41" src="https://github.com/user-attachments/assets/e46c8678-bf8f-4aed-8f1c-c1192945d70c" />

After:
Average cost per output funnel: 14.5 μs/t
<img width="1920" height="986" alt="2026-06-10_16 00 26" src="https://github.com/user-attachments/assets/19832f61-5bce-4688-a2bd-ab34a03c712a" />
