### PR TITLE
Fix the gauge over-request issue #9987 and #10486

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/packager/InventorySummary.java
+++ b/src/main/java/com/simibubi/create/content/logistics/packager/InventorySummary.java
@@ -92,13 +92,7 @@ public class InventorySummary {
 			}
 		}
 
-		// Always store a defensive copy, never the caller's reference: an inventory slot's ItemStack is
-		// mutated in place when items are extracted (split/shrink → count 0, item AIR), which would
-		// corrupt this entry and make getCountOf report 0 until the summary is rebuilt. The real count
-		// lives in BigItemStack.count, so normalising the stored stack to 1 is sufficient.
-		stack = stack.copyWithCount(1);
-
-		BigItemStack newEntry = new BigItemStack(stack, count);
+		BigItemStack newEntry = new BigItemStack(stack.copyWithCount(1), count);
 		stacks.add(newEntry);
 	}
 

--- a/src/main/java/com/simibubi/create/content/logistics/packager/InventorySummary.java
+++ b/src/main/java/com/simibubi/create/content/logistics/packager/InventorySummary.java
@@ -92,8 +92,11 @@ public class InventorySummary {
 			}
 		}
 
-		if (stack.getCount() > stack.getMaxStackSize())
-			stack = stack.copyWithCount(1);
+		// Always store a defensive copy, never the caller's reference: an inventory slot's ItemStack is
+		// mutated in place when items are extracted (split/shrink → count 0, item AIR), which would
+		// corrupt this entry and make getCountOf report 0 until the summary is rebuilt. The real count
+		// lives in BigItemStack.count, so normalising the stored stack to 1 is sufficient.
+		stack = stack.copyWithCount(1);
 
 		BigItemStack newEntry = new BigItemStack(stack, count);
 		stacks.add(newEntry);

--- a/src/main/java/com/simibubi/create/content/logistics/packager/PackagerBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/packager/PackagerBlockEntity.java
@@ -208,7 +208,12 @@ public class PackagerBlockEntity extends SmartBlockEntity implements Clearable {
 		InventorySummary availableItems = new InventorySummary();
 
 		IItemHandler targetInv = targetInventory.getInventory();
-		if (targetInv == null || targetInv instanceof PackagerItemHandler) {
+		if (targetInv == null) {
+			if (this.availableItems == null)
+				this.availableItems = availableItems;
+			return this.availableItems;
+		}
+		if (targetInv instanceof PackagerItemHandler) {
 			this.availableItems = availableItems;
 			return availableItems;
 		}
@@ -224,7 +229,8 @@ public class PackagerBlockEntity extends SmartBlockEntity implements Clearable {
 		}
 
 		invVersionTracker.awaitNewVersion(targetInventory.getInventory());
-		submitNewArrivals(this.availableItems, availableItems);
+		if (!level.isClientSide)
+			submitNewArrivals(this.availableItems, availableItems);
 		this.availableItems = availableItems;
 		return availableItems;
 	}


### PR DESCRIPTION
Address the over-request issue in #9987 and #10486 . It fixes:
- targetInv == null could caused by block entity update, which may lost all stored item data for one tick if block get updated
- submit arrival runs on both side, which cause double arrival in single player game
- use container's ItemStack as InventorySummary's key reference without make copy