### PR TITLE
Fix Sophisticated Storage threshold switches counting empty slots

### DIFF
--- a/src/main/java/com/simibubi/create/compat/thresholdSwitch/SophisticatedStorage.java
+++ b/src/main/java/com/simibubi/create/compat/thresholdSwitch/SophisticatedStorage.java
@@ -3,6 +3,7 @@ package com.simibubi.create.compat.thresholdSwitch;
 import com.simibubi.create.compat.Mods;
 
 import net.createmod.catnip.registry.RegisteredObjectsHelper;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.world.level.block.entity.BlockEntity;
 
 import net.neoforged.neoforge.items.IItemHandler;
@@ -24,7 +25,7 @@ public class SophisticatedStorage implements ThresholdSwitchCompat {
 
 	@Override
 	public long getSpaceInSlot(IItemHandler inv, int slot) {
-		return ((long) inv.getSlotLimit(slot) * inv.getStackInSlot(slot).getMaxStackSize()) / 64;
+		return ((long) inv.getSlotLimit(slot) * inv.getStackInSlot(slot).getOrDefault(DataComponents.MAX_STACK_SIZE, 64)) / 64;
 	}
 
 }


### PR DESCRIPTION
Fixes Sophisticated Storage containers being undercounted by Threshold Switches when slots are empty.

Create's generic threshold switch inventory path already defaults empty stacks to a max stack size of 64, but the Sophisticated Storage compat path bypassed that fallback and used `ItemStack#getMaxStackSize()` directly. For `ItemStack.EMPTY`, this returns `1`, causing empty Sophisticated Storage slots to contribute only `1 / 64` of their expected capacity.

This updates the Sophisticated Storage compat calculation to use the stack's `MAX_STACK_SIZE` component with a fallback of `64`, matching the generic threshold switch behavior for empty slots while preserving existing behavior for occupied slots.