### PR TITLE
Fix size-related issues when printing tanks and vaults

### DIFF
--- a/src/main/java/com/simibubi/create/content/fluids/tank/FluidTankBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/fluids/tank/FluidTankBlockEntity.java
@@ -508,8 +508,8 @@ public class FluidTankBlockEntity extends SmartBlockEntity implements IHaveGoggl
 	public void writeSafe(CompoundTag compound, HolderLookup.Provider registries) {
 		if (isController()) {
 			compound.putBoolean("Window", window);
-			compound.putInt("Size", width);
-			compound.putInt("Height", height);
+			compound.putInt("Size", 1);
+			compound.putInt("Height", 1);
 		}
 	}
 

--- a/src/main/java/com/simibubi/create/content/logistics/vault/ItemVaultBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/vault/ItemVaultBlockEntity.java
@@ -5,6 +5,7 @@ import java.util.List;
 import com.simibubi.create.AllBlockEntityTypes;
 import com.simibubi.create.api.connectivity.ConnectivityHandler;
 import com.simibubi.create.api.packager.InventoryIdentifier;
+import com.simibubi.create.api.schematic.nbt.PartialSafeNBT;
 import com.simibubi.create.foundation.ICapabilityProvider;
 import com.simibubi.create.foundation.blockEntity.IMultiBlockEntityContainer;
 import com.simibubi.create.foundation.blockEntity.SmartBlockEntity;
@@ -39,7 +40,7 @@ import net.neoforged.neoforge.items.IItemHandler;
 import net.neoforged.neoforge.items.IItemHandlerModifiable;
 import net.neoforged.neoforge.items.ItemStackHandler;
 
-public class ItemVaultBlockEntity extends SmartBlockEntity implements IMultiBlockEntityContainer.Inventory, Clearable {
+public class ItemVaultBlockEntity extends SmartBlockEntity implements IMultiBlockEntityContainer.Inventory, Clearable, PartialSafeNBT {
 	protected ICapabilityProvider<IItemHandler> itemCapability = null;
 	protected InventoryIdentifier invId;
 
@@ -312,6 +313,14 @@ public class ItemVaultBlockEntity extends SmartBlockEntity implements IMultiBloc
 		if (!clientPacket) {
 			compound.putString("StorageType", "CombinedInv");
 			compound.put("Inventory", inventory.serializeNBT(registries));
+		}
+	}
+
+	@Override
+	public void writeSafe(CompoundTag compound, HolderLookup.Provider registries) {
+		if (isController()) {
+			compound.putInt("Size", 1);
+			compound.putInt("Length", 1);
 		}
 	}
 


### PR DESCRIPTION
_The following content is machine-translated and may contain inaccuracies._

I noticed that since [commit 1491ed3](https://github.com/Creators-of-Create/Create/commit/1491ed3a620b3f78f02fc09386f3b98bee37b637), the size properties of `FluidTank` have been treated as safe NBT. This fixed some issues, but it also introduced two new ones.

First, players can use schematics to print a single tank with a large capacity. Second, even when printing a normal 3*3 tank, obvious errors still occur if the schematic is rotated by 90°.

For context, the behavior before this commit was: printing large tanks generally worked fine, but printing a single tank block would incorrectly set its capacity to 0. Vaults suffered from the same issue. My previous PR (#10084) attempted to fix this by following the same approach as `commit 1491ed3`, but based on the discussion above, that does not seem to be the right solution.

The root cause is almost certainly a limitation in the multiblock structure detection code. If that code were robust enough, it would correctly identify tanks regardless of how they were printed. However, that codebase is large and complex, and I am not in a position to thoroughly investigate it. Reviewing PRs that touch such systems is also understandably difficult for the maintainers.

Because of that, I chose a different approach that is much simpler, albeit less elegant. Since the multiblock detection logic always works correctly when players place blocks manually, the idea is to make schematic placement resemble manual placement as closely as possible. The implementation is straightforward: always treat printed tank controller as a 1*1 tank.

In `FluidTankBlockEntity.<init>`, both `width` and `height` are initialized to `1`. However, they are later overwritten by values read from NBT. Before `commit 1491ed3`, those values were not present in the NBT at all, causing them to default to `0`, which is the direct reason of the issue.

This effectively restores the pre-`1491ed3` behavior for printing large tanks while also fixing the single-tank issue.

The fix is still not perfect, however. When a tank schematic is printed with rotation, the `window` property can still become inconsistent.