### PR TITLE
Resolve advancement icons lazily to avoid an intermittent RegisterEvent boot crash

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/advancement/CreateAdvancement.java
+++ b/src/main/java/com/simibubi/create/foundation/advancement/CreateAdvancement.java
@@ -97,6 +97,10 @@ public class CreateAdvancement {
 		if (createBuilder.func != null)
 			createBuilder.icon(createBuilder.func.apply(registries));
 
+		if (createBuilder.awardOnIconCollected)
+			mcBuilder.addCriterion(String.valueOf(createBuilder.keyIndex++),
+				InventoryChangeTrigger.TriggerInstance.hasItems(createBuilder.icon.getItem()));
+
 		mcBuilder.display(createBuilder.icon, Component.translatable(titleKey()),
 			Component.translatable(descriptionKey()).withStyle(s -> s.withColor(0xDBA213)),
 			id.equals("root") ? BACKGROUND : null, createBuilder.type.advancementType, createBuilder.type.toast,
@@ -141,6 +145,7 @@ public class CreateAdvancement {
 		private int keyIndex;
 		private ItemStack icon;
 		private Function<Provider, ItemStack> func;
+		private boolean awardOnIconCollected;
 
 		Builder special(TaskType type) {
 			this.type = type;
@@ -153,7 +158,11 @@ public class CreateAdvancement {
 		}
 
 		Builder icon(ItemProviderEntry<?, ?> item) {
-			return icon(item.asStack());
+			// Resolve lazily at save() rather than now: AllAdvancements' static
+			// initializer runs inside RegisterEvent, where this Create item may not be
+			// bound yet under some mod-load orders, causing an intermittent
+			// "Trying to access unbound value" boot crash on large modpacks.
+			return icon(registries -> item.asStack());
 		}
 
 		Builder icon(ItemLike item) {
@@ -185,7 +194,12 @@ public class CreateAdvancement {
 		}
 
 		Builder whenIconCollected() {
-			return externalTrigger(InventoryChangeTrigger.TriggerInstance.hasItems(icon.getItem()));
+			// The icon may resolve lazily (see icon(ItemProviderEntry)), so its item
+			// isn't available at build time. Flag externalTrigger so no builtin trigger
+			// is added; the real criterion is appended in save(), once the icon resolves.
+			externalTrigger = true;
+			awardOnIconCollected = true;
+			return this;
 		}
 
 		Builder whenItemCollected(ItemProviderEntry<?, ?> item) {


### PR DESCRIPTION
### Problem

`AllAdvancements`' static initializer builds every `CreateAdvancement` during the `TRIGGER_TYPES` `RegisterEvent` phase. `CreateAdvancement.Builder#icon(ItemProviderEntry)` eagerly resolved the icon `ItemStack` from a Create item entry (`asStack()`) at that point.

On large modpacks, mod-load order can leave a Create item still unbound when this runs, throwing:

```
Trying to access unbound value: ResourceKey[minecraft:item / create:...]
```

and failing the boot. Observed on `create:schedule`, `create:chocolate_bucket`, and others depending on the pack's load order — it's intermittent because it's order-sensitive.

### Fix

Minimal and defensive — no behavior change at datagen:

- `icon(ItemProviderEntry)` now defers resolution to `save()` (where registries are frozen) via the existing `func` path, instead of resolving `asStack()` at build time.
- `whenIconCollected()` no longer reads the not-yet-resolved icon at build time; it flags the builder so the real `InventoryChangeTrigger` criterion is appended in `save()` once the icon resolves.

Icons and the icon-collected criteria resolve at datagen time exactly as before, so generated advancement JSON is unchanged. Verified by building and running on a large NeoForge 1.21.1 pack that previously hit the unbound-value crash — it now boots cleanly.