### PR TITLE
Add fallback tool to prevent some crashes

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/utility/BlockHelper.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/BlockHelper.java
@@ -207,7 +207,8 @@ public class BlockHelper {
 
 	public static void destroyBlock(Level world, BlockPos pos, float effectChance,
 									Consumer<ItemStack> droppedItemCallback) {
-		destroyBlockAs(world, pos, null, ItemStack.EMPTY, effectChance, droppedItemCallback);
+		ItemStack fallbackTool = new ItemStack(Items.COBBLESTONE);
+		destroyBlockAs(world, pos, null, fallbackTool, effectChance, droppedItemCallback);
 	}
 
 	public static void destroyBlockAs(Level level, BlockPos pos, @Nullable Player player, ItemStack usedTool,


### PR DESCRIPTION
I Encountered a Strange Crash regarding the Pixelmon mod. If a Create contraption where to break any custom ore the server would crash due to a null Pointer Exception when Pixelmon tries to calculate the XP that should drop. This fix should make the mod more resilient to bad code.

I have to credit Deepseek V4 flash which found the fix.