### PR TITLE
Do not call item interaction while player is spectator

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/utility/BlockHelper.java
+++ b/src/main/java/com/simibubi/create/foundation/utility/BlockHelper.java
@@ -454,6 +454,9 @@ public class BlockHelper {
 
 	public static InteractionResult invokeUse(BlockState state, Level level, Player player,
 											   InteractionHand hand, BlockHitResult ray) {
+		if (player.isSpectator()) {
+			return InteractionResult.SUCCESS;
+		}
 		ItemInteractionResult iteminteractionresult = state.useItemOn(
 				player.getItemInHand(hand), level, player, hand, ray
 		);


### PR DESCRIPTION
Fixes #10518 

Follow what performUseItemOn is doing for other blocks.
