### PR TITLE
Fix copper doors and wooden door sounds

### DIFF
--- a/src/main/java/com/simibubi/create/AllInteractionBehaviours.java
+++ b/src/main/java/com/simibubi/create/AllInteractionBehaviours.java
@@ -3,9 +3,11 @@ package com.simibubi.create;
 import com.simibubi.create.api.behaviour.interaction.MovingInteractionBehaviour;
 import com.simibubi.create.api.registry.SimpleRegistry;
 import com.simibubi.create.content.contraptions.behaviour.DoorMovingInteraction;
+import com.simibubi.create.content.contraptions.behaviour.FenceGateMovingInteraction;
 import com.simibubi.create.content.contraptions.behaviour.LeverMovingInteraction;
 import com.simibubi.create.content.contraptions.behaviour.TrapdoorMovingInteraction;
 
+import net.minecraft.sounds.SoundEvents;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.world.level.block.Blocks;
 
@@ -13,8 +15,19 @@ public class AllInteractionBehaviours {
 	static void registerDefaults() {
 		MovingInteractionBehaviour.REGISTRY.register(Blocks.LEVER, new LeverMovingInteraction());
 
-		MovingInteractionBehaviour.REGISTRY.registerProvider(SimpleRegistry.Provider.forBlockTag(BlockTags.WOODEN_DOORS, new DoorMovingInteraction()));
+		MovingInteractionBehaviour.REGISTRY.registerProvider(SimpleRegistry.Provider.forBlockTag(BlockTags.MOB_INTERACTABLE_DOORS, new DoorMovingInteraction()));
 		MovingInteractionBehaviour.REGISTRY.registerProvider(SimpleRegistry.Provider.forBlockTag(BlockTags.WOODEN_TRAPDOORS, new TrapdoorMovingInteraction()));
-		MovingInteractionBehaviour.REGISTRY.registerProvider(SimpleRegistry.Provider.forBlockTag(BlockTags.FENCE_GATES, new TrapdoorMovingInteraction()));
+		MovingInteractionBehaviour.REGISTRY.registerProvider(SimpleRegistry.Provider.forBlockTag(BlockTags.FENCE_GATES, new FenceGateMovingInteraction()));
+
+		TrapdoorMovingInteraction copperTrapdoorInteraction =
+			new TrapdoorMovingInteraction(SoundEvents.COPPER_TRAPDOOR_OPEN, SoundEvents.COPPER_TRAPDOOR_CLOSE);
+		MovingInteractionBehaviour.REGISTRY.register(Blocks.COPPER_TRAPDOOR, copperTrapdoorInteraction);
+		MovingInteractionBehaviour.REGISTRY.register(Blocks.EXPOSED_COPPER_TRAPDOOR, copperTrapdoorInteraction);
+		MovingInteractionBehaviour.REGISTRY.register(Blocks.WEATHERED_COPPER_TRAPDOOR, copperTrapdoorInteraction);
+		MovingInteractionBehaviour.REGISTRY.register(Blocks.OXIDIZED_COPPER_TRAPDOOR, copperTrapdoorInteraction);
+		MovingInteractionBehaviour.REGISTRY.register(Blocks.WAXED_COPPER_TRAPDOOR, copperTrapdoorInteraction);
+		MovingInteractionBehaviour.REGISTRY.register(Blocks.WAXED_EXPOSED_COPPER_TRAPDOOR, copperTrapdoorInteraction);
+		MovingInteractionBehaviour.REGISTRY.register(Blocks.WAXED_WEATHERED_COPPER_TRAPDOOR, copperTrapdoorInteraction);
+		MovingInteractionBehaviour.REGISTRY.register(Blocks.WAXED_OXIDIZED_COPPER_TRAPDOOR, copperTrapdoorInteraction);
 	}
 }

--- a/src/main/java/com/simibubi/create/content/contraptions/behaviour/DoorMovingInteraction.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/behaviour/DoorMovingInteraction.java
@@ -22,9 +22,17 @@ public class DoorMovingInteraction extends SimpleBlockMovingInteraction {
 		if (!(currentState.getBlock() instanceof DoorBlock))
 			return currentState;
 
-		boolean trainDoor = currentState.getBlock() instanceof SlidingDoorBlock;
-		SoundEvent sound = currentState.getValue(DoorBlock.OPEN) ? trainDoor ? null : SoundEvents.WOODEN_DOOR_CLOSE
-			: trainDoor ? SoundEvents.IRON_DOOR_OPEN : SoundEvents.WOODEN_DOOR_OPEN;
+		DoorBlock doorBlock = (DoorBlock) currentState.getBlock();
+		boolean slidingDoor = doorBlock instanceof SlidingDoorBlock;
+		boolean open = currentState.getValue(DoorBlock.OPEN);
+
+		SoundEvent sound = null;
+		if (slidingDoor) {
+			if (!open)
+				sound = SoundEvents.IRON_DOOR_OPEN;
+		} else {
+			sound = open ? doorBlock.type().doorClose() : doorBlock.type().doorOpen();
+		}
 
 		BlockPos otherPos = currentState.getValue(DoorBlock.HALF) == DoubleBlockHalf.LOWER ? pos.above() : pos.below();
 		StructureBlockInfo info = contraption.getBlocks()
@@ -38,7 +46,7 @@ public class DoorMovingInteraction extends SimpleBlockMovingInteraction {
 
 		if (player != null) {
 
-			if (trainDoor) {
+			if (slidingDoor) {
 				DoorHingeSide hinge = currentState.getValue(SlidingDoorBlock.HINGE);
 				Direction facing = currentState.getValue(SlidingDoorBlock.FACING);
 				BlockPos doublePos =

--- a/src/main/java/com/simibubi/create/content/contraptions/behaviour/FenceGateMovingInteraction.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/behaviour/FenceGateMovingInteraction.java
@@ -4,7 +4,6 @@ import com.simibubi.create.content.contraptions.Contraption;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.sounds.SoundEvent;
-import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.block.FenceGateBlock;
 import net.minecraft.world.level.block.state.BlockState;
@@ -13,8 +12,9 @@ public class FenceGateMovingInteraction extends SimpleBlockMovingInteraction {
 
 	@Override
 	protected BlockState handle(Player player, Contraption contraption, BlockPos pos, BlockState currentState) {
-		SoundEvent sound = currentState.getValue(FenceGateBlock.OPEN) ? SoundEvents.FENCE_GATE_CLOSE
-				: SoundEvents.FENCE_GATE_OPEN;
+		FenceGateBlock fenceGateBlock = (FenceGateBlock) currentState.getBlock();
+		SoundEvent sound = currentState.getValue(FenceGateBlock.OPEN) ? fenceGateBlock.closeSound
+				: fenceGateBlock.openSound;
 		float pitch = player.level().random.nextFloat() * 0.1F + 0.9F;
 		playSound(player, sound, pitch);
 		return currentState.cycle(FenceGateBlock.OPEN);

--- a/src/main/java/com/simibubi/create/content/contraptions/behaviour/TrapdoorMovingInteraction.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/behaviour/TrapdoorMovingInteraction.java
@@ -11,10 +11,21 @@ import net.minecraft.world.level.block.state.BlockState;
 
 public class TrapdoorMovingInteraction extends SimpleBlockMovingInteraction {
 
+	private final SoundEvent openSound;
+	private final SoundEvent closeSound;
+
+	public TrapdoorMovingInteraction() {
+		this(SoundEvents.WOODEN_TRAPDOOR_OPEN, SoundEvents.WOODEN_TRAPDOOR_CLOSE);
+	}
+
+	public TrapdoorMovingInteraction(SoundEvent openSound, SoundEvent closeSound) {
+		this.openSound = openSound;
+		this.closeSound = closeSound;
+	}
+
 	@Override
 	protected BlockState handle(Player player, Contraption contraption, BlockPos pos, BlockState currentState) {
-		SoundEvent sound = currentState.getValue(TrapDoorBlock.OPEN) ? SoundEvents.WOODEN_TRAPDOOR_CLOSE
-			: SoundEvents.WOODEN_TRAPDOOR_OPEN;
+		SoundEvent sound = currentState.getValue(TrapDoorBlock.OPEN) ? closeSound : openSound;
 		float pitch = player.level().random.nextFloat() * 0.1F + 0.9F;
 		playSound(player, sound, pitch);
 		return currentState.cycle(TrapDoorBlock.OPEN);


### PR DESCRIPTION
Fixes https://github.com/Creators-of-Create/Create/issues/10435

While I was adding that logic, I noticed that the wood types all sounded the same. Cherry, bamboo, and nether wood should have slightly different sounds for doors, trapdoors, and fence gates (https://minecraft.wiki/w/Door#Cherry_wood). So I fixed that as well.

Note that I'm using the MOB_INTERACTABLE_DOORS block tag to determine which doors are interactable on contraptions since it contains all of the doors we want, ie the non iron doors. You may want to revert that if you believe that mob interactable does not necessarily imply player interactable. 

I don't have an easy way of recording audio so here is a screenshot of the test.

<img width="1708" height="960" alt="doors_on_train" src="https://github.com/user-attachments/assets/6a57c70f-60f3-45d6-b9d6-84581718e571" />
