### PR TITLE
Fix player walking on contraption causes lag (#9598)

### DIFF
--- a/src/main/java/com/simibubi/create/foundation/mixin/client/EntityContraptionInteractionMixin.java
+++ b/src/main/java/com/simibubi/create/foundation/mixin/client/EntityContraptionInteractionMixin.java
@@ -23,12 +23,14 @@ import com.simibubi.create.content.contraptions.ContraptionHandler;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.BlockParticleOption;
 import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.sounds.SoundEvent;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityDimensions;
 import net.minecraft.world.entity.MoverType;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.RenderShape;
+import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 import net.minecraft.world.phys.Vec3;
@@ -55,7 +57,7 @@ public abstract class EntityContraptionInteractionMixin {
 	protected abstract float nextStep();
 
 	@Shadow
-	protected abstract void playStepSound(BlockPos pos, BlockState state);
+	public abstract void playSound(SoundEvent sound, float volume, float pitch);
 
 	@Unique
 	private Stream<AbstractContraptionEntity> create$getIntersectionContraptionsStream() {
@@ -101,7 +103,8 @@ public abstract class EntityContraptionInteractionMixin {
 		MutableBoolean stepped = new MutableBoolean(false);
 
 		create$forCollision(worldPos, (contraption, state, pos) -> {
-			playStepSound(pos, state);
+			SoundType soundtype = state.getSoundType();
+			playSound(soundtype.getStepSound(), soundtype.getVolume() * 0.15F, soundtype.getPitch());
 			stepped.setTrue();
 		});
 


### PR DESCRIPTION
Related issues: #9153 #4646 #9598 #6855

The bug appears to be caused by the contraption step sound Mixin https://github.com/Creators-of-Create/Create/blob/fdfde66c337e3ae36b260459c3b52802c58630f6/src/main/java/com/simibubi/create/foundation/mixin/client/EntityContraptionInteractionMixin.java#L104 mistakenly passing a contraption-local `BlockPos` into `playStepSound(pos, state)`. For non-player entity like zombie, this method won't use the pos parameter, so nothing happens. 

However, for players this dispatches to `Player.playStepSound`, which treats the position as a world position and performs additional `level.getBlockState(...)` lookups. Then, the server takes the local coordinates and interprets them as world coordinates, repeatedly querying a chunk near (0, 0) that is not loaded, which is an unnecessary cost and causes lag and extra memory usage.

Example of the coordinate mismatch:

player world position:     (10003, 58, 10007)
contraption-local position: (3, 1, 7)
queried world chunk:        (0, 0)

My solution now is to fall back to the implementation of `Entity.playStepSound()`. There might be a better solution, but I don't know much about minecraft sound engine and Mixin so I can't figure it out, though the cause of the bug is now clear.

A temporary workaround for this bug: /forceload the chunks around (0, 0) to mitigate the lag caused by repeated chunk loading.

I have another question. The Mixin class is in `client` package, so in theory it shouldn't cause **server** thread to lag, but it indeed does.