### PR TITLE
fix: redstone requester address box displacement on window resize

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/redstoneRequester/RedstoneRequesterScreen.java
+++ b/src/main/java/com/simibubi/create/content/logistics/redstoneRequester/RedstoneRequesterScreen.java
@@ -73,6 +73,9 @@ public class RedstoneRequesterScreen extends AbstractSimiContainerScreen<Redston
 			addressBox = new AddressEditBox(this, new NoShadowFontWrapper(font), x + 55, y + 68, 110, 10, false);
 			addressBox.setValue(menu.contentHolder.encodedTargetAdress);
 			addressBox.setTextColor(0x555555);
+		} else {
+			addressBox.setX(x + 55);
+			addressBox.setY(y + 68);
 		}
 		addRenderableWidget(addressBox);
 


### PR DESCRIPTION
Fixes #10583

**Changes:**
* Fixed a minor visual bug in `RedstoneRequesterScreen` where the `AddressEditBox`  would not update its position when the game window was resized.
* Added an `else` block in the `init()` method to correctly recalculate and update the `X` and `Y` coordinates of the existing `addressBox` relative to the new screen center.