### PR TITLE
Fix fluid network not validating FlowSource

### DIFF
--- a/src/main/java/com/simibubi/create/content/fluids/FlowSource.java
+++ b/src/main/java/com/simibubi/create/content/fluids/FlowSource.java
@@ -3,6 +3,10 @@ package com.simibubi.create.content.fluids;
 import java.lang.ref.WeakReference;
 import java.util.function.Predicate;
 
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.chunk.status.ChunkStatus;
+
 import org.jetbrains.annotations.Nullable;
 
 import com.simibubi.create.foundation.ICapabilityProvider;
@@ -63,6 +67,8 @@ public abstract class FlowSource {
 	public void manageSource(Level world, BlockEntity networkBE) {
 	}
 
+	public abstract boolean isValid(Level world);
+
 	public void whileFlowPresent(Level world, boolean pulling) {}
 
 	public @Nullable ICapabilityProvider<IFluidHandler> provideHandler() {
@@ -106,6 +112,13 @@ public abstract class FlowSource {
 		}
 
 		@Override
+		public boolean isValid(Level world) {
+			if (fluidHandlerCache == null)
+				return false;
+			return world.getGameTime() % 40 != 0 || fluidHandlerCache.getCapability() != null;
+		}
+
+		@Override
 		@Nullable
 		public ICapabilityProvider<IFluidHandler> provideHandler() {
 			return fluidHandlerCache;
@@ -136,6 +149,13 @@ public abstract class FlowSource {
 		}
 
 		@Override
+		public boolean isValid(Level world) {
+			if (cached == null)
+				return false;
+			return world.getGameTime() % 40 != 0 || FluidPropagator.getPipe(world, location.getConnectedPos()) != null;
+		}
+
+		@Override
 		public FluidStack provideFluid(Predicate<FluidStack> extractionPredicate) {
 			if (cached == null || cached.get() == null)
 				return FluidStack.EMPTY;
@@ -162,6 +182,20 @@ public abstract class FlowSource {
 			return false;
 		}
 
+		@Override
+		public boolean isValid(Level world) {
+			if (world.getGameTime() % 40 == 0) {
+				BlockPos relative = location.getConnectedPos();
+				if (world.getChunk(relative.getX() >> 4, relative.getZ() >> 4, ChunkStatus.FULL, false) == null)
+					return true;
+				if (FluidPropagator.isOpenEnd(world, location.getPos(), location.getFace()))
+					return false;
+				if (FluidPropagator.hasFluidCapability(world, relative, location.getFace().getOpposite()))
+					return false;
+				return FluidPropagator.getPipe(world, location.getPos()) == null;
+			}
+			return true;
+		}
 	}
 
 }

--- a/src/main/java/com/simibubi/create/content/fluids/FluidNetwork.java
+++ b/src/main/java/com/simibubi/create/content/fluids/FluidNetwork.java
@@ -160,7 +160,7 @@ public class FluidNetwork {
 
 //		drawDebugOutlines();
 
-		if (source == null)
+		if (source == null || source.getCapability() == null)
 			source = sourceSupplier.get();
 		if (source == null)
 			return;

--- a/src/main/java/com/simibubi/create/content/fluids/OpenEndedPipe.java
+++ b/src/main/java/com/simibubi/create/content/fluids/OpenEndedPipe.java
@@ -81,6 +81,11 @@ public class OpenEndedPipe extends FlowSource {
 	}
 
 	@Override
+	public boolean isValid(Level world) {
+		return world.getGameTime() % 40 != 0 || FluidPropagator.isOpenEnd(world, location.getPos(), location.getFace());
+	}
+
+	@Override
 	@Nullable
 	public ICapabilityProvider<IFluidHandler> provideHandler() {
 		return fluidHandlerProvider;

--- a/src/main/java/com/simibubi/create/content/fluids/PipeConnection.java
+++ b/src/main/java/com/simibubi/create/content/fluids/PipeConnection.java
@@ -87,6 +87,8 @@ public class PipeConnection {
 			return;
 		FlowSource flowSource = source.get();
 		flowSource.manageSource(world, blockEntity);
+		if (!flowSource.isValid(world))
+			source = Optional.empty();
 	}
 
 	public boolean manageFlows(Level world, BlockPos pos, FluidStack internalFluid,
@@ -145,7 +147,8 @@ public class PipeConnection {
 		// Layer III
 		network = retainedNetwork;
 		if (!hasNetwork())
-			network = Optional.of(new FluidNetwork(world, new BlockFace(pos, side), flowSource::provideHandler));
+			network = Optional.of(new FluidNetwork(world, new BlockFace(pos, side),
+				() -> source.map(FlowSource::provideHandler).orElse(null)));
 		network.get()
 			.tick();
 


### PR DESCRIPTION
_The following content is machine-translated and may contain inaccuracies._

In the Forge 1.20.1 version of Create, I noticed that placing a Fluid Tank adjacent to an existing tank does **not** trigger a block update, while current versions no longer exhibit this behavior.

As shown in the first video, placing a tank in this way leaves the fluid network unchanged, causing the connected pipe to continue treating that position as an `OpenEnded` connection. Even on the latest version, the same issue can still be reproduced by placing tanks with the Schematic Cannon, since it bypasses the expected network update.


https://github.com/user-attachments/assets/135388ae-7083-49aa-8535-3cbc746f1531


This reveals a weakness in the fluid network implementation: it relies heavily on block updates while performing very little validation of the current `FlowSource`. The scenario above is only one example of many situations that can leave the network in an inconsistent state.

To improve the robustness of the fluid network, this PR validates the `FlowSource` inside `PipeConnection.manageSource()`. If the cached source is no longer valid, it is discarded and rediscovered, allowing the network to recover automatically instead of depending entirely on external updates.

---

There is, however, another issue that appears superficially similar but has a different root cause.

If part of a multi-block Fluid Tank is broken and immediately replaced, the behavior shown in the second video can occur. Although the symptoms resemble the previous issue, these two problems are actually independent: each fix resolves its own issue without affecting the other. I decided to include both changes in the same PR to keep the issue complete.


https://github.com/user-attachments/assets/a4c1b8a4-0854-419a-bf12-9498972e851d


The first issue comes from `PipeConnection`:

https://github.com/Creators-of-Create/Create/blob/87b3c6a65fd00c023a07b37b0353144bc7e6a5bf/src/main/java/com/simibubi/create/content/fluids/PipeConnection.java#L148

 The `sourceSupplier` captures a reference to the old `flowSource`, meaning that it can never obtain a new `FlowSource` unless the entire network is rebuilt. Updating this logic fixes the issue on 1.20.1.

However, this alone is insufficient for 1.21.1. Looking further into [FluidNetwork#L163](https://github.com/Creators-of-Create/Create/blob/87b3c6a65fd00c023a07b37b0353144bc7e6a5bf/src/main/java/com/simibubi/create/content/fluids/FluidNetwork.java#L163), older versions used `!source.isPresent()`, which implicitly checked both for `null` and `isValid`. In newer versions,  the validity check has been lost.

<img width="999" height="393" alt="debugger" src="https://github.com/user-attachments/assets/cabae682-a106-4d3b-823e-f73855b4e2d8" />

Restoring the validity check completely resolves the remaining issue.