### PR TITLE
Fix fluid networks sometimes failing to rebuild in long pipelines

### DIFF
--- a/src/main/java/com/simibubi/create/content/fluids/FluidTransportBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/fluids/FluidTransportBehaviour.java
@@ -40,10 +40,12 @@ public abstract class FluidTransportBehaviour extends BlockEntityBehaviour {
 
 	public Map<Direction, PipeConnection> interfaces;
 	public UpdatePhase phase;
+	public boolean scheduleUpdate;
 
 	public FluidTransportBehaviour(SmartBlockEntity be) {
 		super(be);
 		phase = UpdatePhase.WAIT_FOR_PUMPS;
+		scheduleUpdate = false;
 	}
 
 	public boolean canPullFluidFrom(FluidStack fluid, BlockState state, Direction direction) {
@@ -67,6 +69,13 @@ public abstract class FluidTransportBehaviour extends BlockEntityBehaviour {
 
 		if (interfaces == null)
 			return;
+
+		if (onServer && scheduleUpdate) {
+			FluidPropagator.propagateChangedPipe(world, pos, blockEntity.getBlockState());
+			scheduleUpdate = false;
+			return;
+		}
+
 		Collection<PipeConnection> connections = interfaces.values();
 
 		// Do not provide a lone pipe connection with its own flow input
@@ -159,6 +168,9 @@ public abstract class FluidTransportBehaviour extends BlockEntityBehaviour {
 
 		interfaces.values()
 			.forEach(connection -> connection.deserializeNBT(nbt, registries, blockEntity.getBlockPos(), clientPacket));
+
+		if (nbt.contains("ScheduleUpdate"))
+			scheduleUpdate = nbt.getBoolean("ScheduleUpdate");
 	}
 
 	@Override
@@ -171,6 +183,9 @@ public abstract class FluidTransportBehaviour extends BlockEntityBehaviour {
 
 		interfaces.values()
 			.forEach(connection -> connection.serializeNBT(nbt, registries, clientPacket));
+
+		if (scheduleUpdate)
+			nbt.putBoolean("ScheduleUpdate", true);
 	}
 
 	public FluidStack getProvidedOutwardFluid(Direction side) {

--- a/src/main/java/com/simibubi/create/content/fluids/pump/PumpBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/fluids/pump/PumpBlockEntity.java
@@ -161,8 +161,10 @@ public class PumpBlockEntity extends KineticBlockEntity {
 					BlockFace blockFace = new BlockFace(currentPos, face);
 					BlockPos connectedPos = blockFace.getConnectedPos();
 
-					if (!level.isLoaded(connectedPos))
+					if (!level.isLoaded(connectedPos)) {
+						pipe.scheduleUpdate = true;
 						continue;
+					}
 					if (blockFace.isEquivalent(start))
 						continue;
 					if (hasReachedValidEndpoint(level, blockFace, pull)) {


### PR DESCRIPTION
_The following content is machine-translated and may contain inaccuracies._

A Mechanical Pump scans the connected pipe network to locate its target and applies pressure to the discovered path. However, if a pipe leads into an unloaded chunk, the search simply skips it, even if a valid target exists beyond it.

One detail is that the default value of `mechanicalPumpRange` is `16`, meaning a pump and its target can be at most one chunk apart. When a pump is placed near the edge of a loaded chunk, it can still discover the tank located in the neighboring chunk. Because that chunk is loaded as a **border chunk** and remains accessible in memory. 

The issue becomes reproducible by increasing `mechanicalPumpRange` beyond `64`, setting the simulation and render distances to their minimum values, placing a tank 64 blocks away from the pump, and connecting them while moving from the tank toward the pump. And then the pump never discovers the distant tank.

> **Note:** Perform this experiment far from the world spawn, as spawn chunks are remaining loaded.

This PR marks pipe connections that terminate at unloaded chunks during the pump's search. When those chunks are later loaded, the marked boundary pipes trigger another fluid network update.

After this change, simply loading the missing chunks by moving into the middle of the pipeline allows the entire fluid network to rebuild correctly.

https://github.com/user-attachments/assets/5524eb5b-72d8-455f-bcc1-08ca996f47a0

Although the experiment above requires increasing `mechanicalPumpRange`, I believe that real pipe networks can be much more complex, and the same chunk-loading problem may still occur with the default range. The scenario shown here is simply the easiest one to reproduce.