### PR TITLE
Fix fluid transfer bugs for amounts over one bucket

### DIFF
--- a/src/main/java/com/simibubi/create/content/fluids/OpenEndedPipe.java
+++ b/src/main/java/com/simibubi/create/content/fluids/OpenEndedPipe.java
@@ -255,6 +255,8 @@ public class OpenEndedPipe extends FlowSource {
 			if (action.simulate())
 				return fill;
 
+			containedFluidStack = getFluid();
+			hasBlockState = FluidHelper.hasBlockState(containedFluidStack.getFluid());
 			if (effectHandler != null && !resource.isEmpty()) {
 				// resource should be copied before giving it to the handler.
 				// if hasBlockState is false, it was already copied above.

--- a/src/main/java/com/simibubi/create/content/fluids/hosePulley/HosePulleyFluidHandler.java
+++ b/src/main/java/com/simibubi/create/content/fluids/hosePulley/HosePulleyFluidHandler.java
@@ -39,7 +39,7 @@ public class HosePulleyFluidHandler implements IFluidHandler {
 		}
 
 		if (action.simulate())
-			return diff <= 0 ? resource.getAmount() : internalTank.fill(remaining, action);
+			return diff <= 0 ? resource.getAmount() : internalTank.fill(resource, action);
 		if (diff <= 0) {
 			internalTank.drain(-diff, FluidAction.EXECUTE);
 			return resource.getAmount();


### PR DESCRIPTION
Similar to #9974 , this PR fixes two places that do not correctly handle fluid transfers exceeding `1000 mB` in a single operation.

For example, 8 Mechanical Pumps at 256 RPM produce a transfer rate of 1024 mB/t. When inserting into `HosePulleyFluidHandler`, the simulation incorrectly reports that only 24 mB can be accepted, causing the actual transfer rate to drop to 24 mB/t.

`OpenEndFluidHandler` has a similar issue. When more than 1000 mB is inserted at once, it incorrectly determines that the fluid to be placed in the world is air and rejects the transfer entirely. 

> **Note:** Please use fluids such as Chocolate or Honey for the second test. Water and Lava are not suitable, as they always attempt to fill 1 mB first and then the remaining 999 mB, preventing a single transfer larger than one bucket from occurring.
