### PR TITLE
Expose a target-side direct item insertion API for Weighted Ejectors and non-SmartBlockEntity targets

### DIFF
--- a/src/main/java/com/simibubi/create/api/behaviour/transport/DirectItemInsertion.java
+++ b/src/main/java/com/simibubi/create/api/behaviour/transport/DirectItemInsertion.java
@@ -1,0 +1,42 @@
+package com.simibubi.create.api.behaviour.transport;
+
+import java.util.Objects;
+
+import com.simibubi.create.api.behaviour.transport.DirectItemReceiver.Context;
+import com.simibubi.create.api.behaviour.transport.DirectItemReceiver.Result;
+import com.simibubi.create.content.kinetics.belt.behaviour.DirectBeltInputBehaviour;
+import com.simibubi.create.foundation.blockEntity.behaviour.BlockEntityBehaviour;
+
+import net.minecraft.world.item.ItemStack;
+
+public final class DirectItemInsertion {
+
+	private DirectItemInsertion() {}
+
+	/**
+	 * Attempt to deliver a stack directly to the target in the given context.
+	 * Existing {@link DirectBeltInputBehaviour} instances take priority over
+	 * {@link DirectItemReceiver#CAPABILITY}.
+	 */
+	public static Result tryInsert(Context context, ItemStack stack, boolean simulate) {
+		Objects.requireNonNull(context, "context");
+		Objects.requireNonNull(stack, "stack");
+
+		DirectBeltInputBehaviour behaviour =
+			BlockEntityBehaviour.get(context.level(), context.targetPos(), DirectBeltInputBehaviour.TYPE);
+		if (behaviour != null) {
+			ItemStack remainder = behaviour.handleInsertion(stack, context.side(), simulate);
+			if (!simulate)
+				return Result.accept(remainder);
+			return remainder.getCount() == stack.getCount() ? Result.reject(stack) : Result.accept(remainder);
+		}
+
+		DirectItemReceiver receiver = context.level()
+			.getCapability(DirectItemReceiver.CAPABILITY, context.targetPos(), context.side());
+		if (receiver == null)
+			return Result.pass(stack);
+
+		return Objects.requireNonNull(receiver.insert(stack.copy(), context, simulate),
+			"DirectItemReceiver returned null");
+	}
+}

--- a/src/main/java/com/simibubi/create/api/behaviour/transport/DirectItemReceiver.java
+++ b/src/main/java/com/simibubi/create/api/behaviour/transport/DirectItemReceiver.java
@@ -1,0 +1,95 @@
+package com.simibubi.create.api.behaviour.transport;
+
+import java.util.Objects;
+
+import org.jetbrains.annotations.Nullable;
+
+import com.simibubi.create.Create;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.phys.Vec3;
+import net.neoforged.neoforge.capabilities.BlockCapability;
+
+/**
+ * A target-side handler for items delivered directly by Create logistics.
+ * <p>
+ * Receivers can be exposed on any block through {@link #CAPABILITY}, including
+ * blocks whose block entities do not extend Create's SmartBlockEntity.
+ */
+@FunctionalInterface
+public interface DirectItemReceiver {
+
+	BlockCapability<DirectItemReceiver, @Nullable Direction> CAPABILITY =
+		BlockCapability.createSided(Create.asResource("direct_item_receiver"), DirectItemReceiver.class);
+
+	/**
+	 * Attempt to receive an item stack.
+	 *
+	 * @param stack a copy of the stack being delivered
+	 * @param context information about the delivery source and target
+	 * @param simulate when true, no state may be changed
+	 * @return a non-null result describing whether the delivery was handled
+	 */
+	Result insert(ItemStack stack, Context context, boolean simulate);
+
+	/**
+	 * @param level the level containing the target
+	 * @param targetPos the target block position
+	 * @param location the world-space delivery location
+	 * @param side the side from which the item is delivered
+	 * @param source the block entity delivering the item, if any
+	 */
+	record Context(Level level, BlockPos targetPos, Vec3 location, Direction side, @Nullable BlockEntity source) {
+
+		public Context {
+			Objects.requireNonNull(level, "level");
+			Objects.requireNonNull(targetPos, "targetPos");
+			Objects.requireNonNull(location, "location");
+			Objects.requireNonNull(side, "side");
+		}
+	}
+
+	/**
+	 * The remainder is applied by the caller only when the status is
+	 * {@link Status#ACCEPT}.
+	 */
+	record Result(Status status, ItemStack remainder) {
+
+		public Result {
+			Objects.requireNonNull(status, "status");
+			Objects.requireNonNull(remainder, "remainder");
+		}
+
+		public static Result pass(ItemStack remainder) {
+			return new Result(Status.PASS, remainder);
+		}
+
+		public static Result accept(ItemStack remainder) {
+			return new Result(Status.ACCEPT, remainder);
+		}
+
+		public static Result reject(ItemStack remainder) {
+			return new Result(Status.REJECT, remainder);
+		}
+	}
+
+	enum Status {
+		/**
+		 * This receiver does not apply. The caller should use its default behavior.
+		 */
+		PASS,
+		/**
+		 * The delivery is accepted. The remainder may be identical to the input
+		 * when receiving it performs an action without consuming the item.
+		 */
+		ACCEPT,
+		/**
+		 * This receiver applies, but cannot currently accept the delivery.
+		 */
+		REJECT
+	}
+}

--- a/src/main/java/com/simibubi/create/content/logistics/depot/EjectorBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/depot/EjectorBlockEntity.java
@@ -9,6 +9,10 @@ import org.jetbrains.annotations.Nullable;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.simibubi.create.AllBlockEntityTypes;
 import com.simibubi.create.AllBlocks;
+import com.simibubi.create.api.behaviour.transport.DirectItemInsertion;
+import com.simibubi.create.api.behaviour.transport.DirectItemReceiver.Context;
+import com.simibubi.create.api.behaviour.transport.DirectItemReceiver.Result;
+import com.simibubi.create.api.behaviour.transport.DirectItemReceiver.Status;
 import com.simibubi.create.content.kinetics.base.KineticBlockEntity;
 import com.simibubi.create.content.kinetics.belt.behaviour.DirectBeltInputBehaviour;
 import com.simibubi.create.content.kinetics.belt.transport.TransportedItemStack;
@@ -433,13 +437,13 @@ public class EjectorBlockEntity extends KineticBlockEntity {
 			}
 		}
 
-		DirectBeltInputBehaviour targetOpenInv = getTargetOpenInv();
-
 		// Do not eject if target cannot accept held item
-		if (targetOpenInv != null && depotBehaviour.heldItem != null
-			&& targetOpenInv.handleInsertion(held, Direction.UP, true)
-				.getCount() == held.getCount())
-			return;
+		if (depotBehaviour.heldItem != null) {
+			float totalTime = Math.max(3, (float) launcher.getTotalFlyingTicks());
+			Result result = insertAtTarget(held, getLaunchedItemLocation(totalTime), true);
+			if (result.status() == Status.REJECT)
+				return;
+		}
 
 		activate();
 		notifyUpdate();
@@ -451,17 +455,15 @@ public class EjectorBlockEntity extends KineticBlockEntity {
 		if (intAttached.getSecond() == trackedItem)
 			trackedItem = null;
 
-		DirectBeltInputBehaviour targetOpenInv = getTargetOpenInv();
-		if (targetOpenInv != null) {
-			ItemStack remainder = targetOpenInv.handleInsertion(intAttached.getValue(), Direction.UP, false);
-			intAttached.setSecond(remainder);
-		}
+		Vec3 ejectVec = earlyTarget != null ? earlyTarget.getFirst() : getLaunchedItemLocation(maxTime);
+		Result result = insertAtTarget(intAttached.getValue(), ejectVec, false);
+		if (result.status() == Status.ACCEPT)
+			intAttached.setSecond(result.remainder());
 
 		if (intAttached.getValue()
 			.isEmpty())
 			return;
 
-		Vec3 ejectVec = earlyTarget != null ? earlyTarget.getFirst() : getLaunchedItemLocation(maxTime);
 		Vec3 ejectMotionVec = getLaunchedItemMotion(maxTime);
 		ItemEntity item = new ItemEntity(level, ejectVec.x, ejectVec.y, ejectVec.z, intAttached.getValue());
 		item.setDeltaMovement(ejectMotionVec);
@@ -470,10 +472,19 @@ public class EjectorBlockEntity extends KineticBlockEntity {
 	}
 
 	public DirectBeltInputBehaviour getTargetOpenInv() {
-		BlockPos targetPos = earlyTarget != null ? earlyTarget.getSecond()
+		return BlockEntityBehaviour.get(level, getInsertionTargetPosition(), DirectBeltInputBehaviour.TYPE);
+	}
+
+	protected Result insertAtTarget(ItemStack stack, Vec3 location, boolean simulate) {
+		BlockPos targetPos = getInsertionTargetPosition();
+		Context context = new Context(level, targetPos, location, Direction.UP, this);
+		return DirectItemInsertion.tryInsert(context, stack, simulate);
+	}
+
+	protected BlockPos getInsertionTargetPosition() {
+		return earlyTarget != null ? earlyTarget.getSecond()
 			: worldPosition.above(launcher.getVerticalDistance())
 				.relative(getFacing(), Math.max(1, launcher.getHorizontalDistance()));
-		return BlockEntityBehaviour.get(level, targetPos, DirectBeltInputBehaviour.TYPE);
 	}
 
 	public Vec3 getLaunchedItemLocation(float time) {


### PR DESCRIPTION
PR from https://github.com/Creators-of-Create/Create/issues/10645