### PR TITLE
Fix re-packager duplicates packages & minor performance optimization

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/factoryBoard/FactoryPanelBehaviour.java
+++ b/src/main/java/com/simibubi/create/content/logistics/factoryBoard/FactoryPanelBehaviour.java
@@ -11,6 +11,8 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.UUID;
 
+import com.simibubi.create.content.logistics.packagerLink.LogisticsManager.CrossNetworkData;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.joml.Math;
@@ -480,11 +482,12 @@ public class FactoryPanelBehaviour extends FilteringBehaviour implements MenuPro
 				.toList());
 
 		// Collect request distributions
+		CrossNetworkData crossNetworkData = new CrossNetworkData();
 		for (Entry<UUID, Collection<BigItemStack>> entry : asMap.entrySet()) {
 			PackageOrderWithCrafts order =
 				new PackageOrderWithCrafts(new PackageOrder(new ArrayList<>(entry.getValue())), craftingContext.orderedCrafts());
-			Multimap<PackagerBlockEntity, PackagingRequest> request =
-				LogisticsManager.findPackagersForRequest(entry.getKey(), order, null, recipeAddress);
+			Multimap<PackagerBlockEntity, PackagingRequest> request = LogisticsManager.findPackagersForRequest(
+				entry.getKey(), order, null, recipeAddress, crossNetworkData);
 			requests.add(request);
 		}
 

--- a/src/main/java/com/simibubi/create/content/logistics/packager/PackagerItemHandler.java
+++ b/src/main/java/com/simibubi/create/content/logistics/packager/PackagerItemHandler.java
@@ -37,10 +37,9 @@ public class PackagerItemHandler implements IItemHandlerModifiable {
 			return stack;
 		if (!isItemValid(slot, stack))
 			return stack;
-		if (!blockEntity.unwrapBox(stack, true))
+		if (!blockEntity.unwrapBox(stack, simulate))
 			return stack;
 		if (!simulate) {
-			blockEntity.unwrapBox(stack, false);
 			blockEntity.triggerStockCheck();
 		}
 		return stack.copyWithCount(stack.getCount() - 1);

--- a/src/main/java/com/simibubi/create/content/logistics/packagerLink/LogisticsManager.java
+++ b/src/main/java/com/simibubi/create/content/logistics/packagerLink/LogisticsManager.java
@@ -83,7 +83,7 @@ public class LogisticsManager {
 			return false;
 
 		Multimap<PackagerBlockEntity, PackagingRequest> requests = findPackagersForRequest(freqId, order,
-			ignoredHandler, address);
+			ignoredHandler, address, null);
 
 		// Check if packagers have accumulated too many packages already
 		for (PackagerBlockEntity packager : requests.keySet())
@@ -95,8 +95,16 @@ public class LogisticsManager {
 		return true;
 	}
 
-	public static Multimap<PackagerBlockEntity, PackagingRequest> findPackagersForRequest(UUID freqId,
-																						  PackageOrderWithCrafts order, @Nullable IdentifiedInventory ignoredHandler, String address) {
+	public static class CrossNetworkData {
+		public boolean hasOrderId = false;
+		public int OrderId = 0;
+		public int usedLinks = 0;
+		public MutableBoolean finalLinkTracker;
+		public PackageOrderWithCrafts firstContextTracker;
+	}
+
+	public static Multimap<PackagerBlockEntity, PackagingRequest> findPackagersForRequest(
+		UUID freqId, PackageOrderWithCrafts order, @Nullable IdentifiedInventory ignoredHandler, String address, @Nullable CrossNetworkData data) {
 		List<BigItemStack> stacks = new ArrayList<>();
 
 		for (BigItemStack stack : order.stacks())
@@ -137,9 +145,27 @@ public class LogisticsManager {
 
 		// First box needs to carry the order specifics for successful defrag
 		PackageOrderWithCrafts context = order;
+		if (data != null) {
+			if (data.firstContextTracker == null) {
+				data.firstContextTracker = order;
+			} else {
+				data.firstContextTracker.stacks().addAll(order.stacks());
+				context = null;
+			}
+		}
 
 		// Packages from future orders should not be merged in the packager queue
 		int orderId = r.nextInt();
+		int linkIndexOffset = 0;
+		if (data != null) {
+			if (data.hasOrderId) {
+				orderId = data.OrderId;
+			} else {
+				data.OrderId = orderId;
+				data.hasOrderId = true;
+			}
+			linkIndexOffset = data.usedLinks;
+		}
 
 		for (int i = 0; i < stacks.size(); i++) {
 			BigItemStack entry = stacks.get(i);
@@ -156,7 +182,7 @@ public class LogisticsManager {
 
 				// Only send context and craftingContext with first package
 				Pair<PackagerBlockEntity, PackagingRequest> request = link.processRequest(requestedItem, remainingCount,
-					address, linkIndex, isFinalLink, orderId, context, ignoredHandler);
+					address, linkIndex + linkIndexOffset, isFinalLink, orderId, context, ignoredHandler);
 				if (request == null)
 					continue;
 
@@ -168,6 +194,9 @@ public class LogisticsManager {
 					context = null;
 					usedLinks.add(link);
 					finalLinkTracker = isFinalLink;
+					if (data != null && data.finalLinkTracker != null) {
+						data.finalLinkTracker.setFalse();
+					}
 				}
 
 				remainingCount -= processedCount;
@@ -178,6 +207,12 @@ public class LogisticsManager {
 				break;
 			}
 		}
+
+		if (data != null) {
+			data.finalLinkTracker = finalLinkTracker;
+			data.usedLinks += usedLinks.size();
+		}
+
 		return requests;
 	}
 

--- a/src/main/java/com/simibubi/create/impl/unpacking/DefaultUnpackingHandler.java
+++ b/src/main/java/com/simibubi/create/impl/unpacking/DefaultUnpackingHandler.java
@@ -51,8 +51,8 @@ public enum DefaultUnpackingHandler implements UnpackingHandler {
 				if (toInsert.isEmpty())
 					continue;
 
-				if (targetInv.insertItem(slot, toInsert, true)
-					.getCount() == toInsert.getCount())
+				int countAfterInsert = targetInv.insertItem(slot, toInsert, true).getCount();
+				if (countAfterInsert == toInsert.getCount())
 					continue;
 
 				if (itemInSlot.isEmpty()) {
@@ -64,15 +64,13 @@ public enum DefaultUnpackingHandler implements UnpackingHandler {
 						items.set(boxSlot, ItemStack.EMPTY);
 
 					itemInSlot = toInsert;
-					targetInv.insertItem(slot, toInsert, simulate);
 					continue;
 				}
 
 				if (!ItemStack.isSameItemSameComponents(toInsert, itemInSlot))
 					continue;
 
-				int insertedAmount = toInsert.getCount() - targetInv.insertItem(slot, toInsert, simulate)
-					.getCount();
+				int insertedAmount = toInsert.getCount() - countAfterInsert;
 				int slotLimit = Math.min(itemInSlot.getMaxStackSize(), targetInv.getSlotLimit(slot));
 				int insertableAmountWithPreviousItems =
 					Math.min(toInsert.getCount(), slotLimit - itemInSlot.getCount() - itemsAddedToSlot);


### PR DESCRIPTION
_The following content is machine-translated and may contain inaccuracies._

This PR contains two changes.

The first one fixes #8600. When a factory gauge sends requests across networks, the package metadata including `orderId`, `link_index`, `is_final_link`, and `ordered_stacks` were incorrect, which naturally caused the re-packager to fail to merge packages correctly.

The fix itself is not complicated. However, what is worth discussing is that someone in the original issue proposed another solution: improving the re-packager's fault tolerance instead. I think this approach is quite interesting. Additionally, some people mentioned that the re-packager may sometimes fail even when handling packages from the same network. I am currently investigating this possibility.

The second change comes from reviewing the code. In Commit 8662470, the implementation of the execute branch was modified, but it seems that some redundant function calls were left behind and not removed. I cleaned them up to improve performance, similar to what was done in Commit 5f0910c.