### PR TITLE
fix: treat Factory Gauges as non-colliding for pathfinding

### DIFF
--- a/src/main/java/com/simibubi/create/content/logistics/factoryBoard/FactoryPanelBlock.java
+++ b/src/main/java/com/simibubi/create/content/logistics/factoryBoard/FactoryPanelBlock.java
@@ -59,7 +59,6 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.phys.shapes.CollisionContext;
-import net.minecraft.world.phys.shapes.EntityCollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 
@@ -308,8 +307,8 @@ public class FactoryPanelBlock extends FaceAttachedHorizontalDirectionalBlock
 	@Override
 	public VoxelShape getCollisionShape(BlockState pState, BlockGetter pLevel, BlockPos pPos,
 										CollisionContext pContext) {
-		if (pContext instanceof EntityCollisionContext ecc && ecc.getEntity() == null)
-			return getShape(pState, pLevel, pPos, pContext);
+		// Factory panels are purely visual; entities and pathfinding should treat them
+		// like grass/torches, not like a 2px step that mobs try to hop over.
 		return Shapes.empty();
 	}
 


### PR DESCRIPTION
## Summary

When mobs walk over a Factory Gauge placed on the ground, they keep hopping/bouncing in place instead of walking across it. This PR makes mobs walk over ground-level Factory Gauges normally, like they would over grass or torches.

## Root cause

Factory Gauges (`factory_gauge`) are decorative blocks with a 2px interaction shape (`getShape()`), but their collision shape was non-empty **only for non-entity queries**:

```java
public VoxelShape getCollisionShape(BlockState pState, BlockGetter pLevel, BlockPos pPos,
                                    CollisionContext pContext) {
    if (pContext instanceof EntityCollisionContext ecc && ecc.getEntity() == null)
        return getShape(pState, pLevel, pPos, pContext);
    return Shapes.empty();
}
```

Pathfinding (e.g. `WalkNodeEvaluator#getFloorLevel`) queries collision with `CollisionContext.empty()` — whose `EntityCollisionContext` has a `null` entity — so mobs see the gauge as a 2px "step". Combined with the empty entity collision, mobs repeatedly try to hop onto a block they can never actually stand on, causing the bouncing behavior.

## Fix

Return an empty collision shape unconditionally, so entity movement **and** pathfinding both treat Factory Gauges like grass/torches:

```java
@Override
public VoxelShape getCollisionShape(BlockState pState, BlockGetter pLevel, BlockPos pPos,
                                    CollisionContext pContext) {
    return Shapes.empty();
}
```

`getShape()` is unchanged, so the 2px interaction shape used for mouse targeting still works.

## Reproduction

1. Place a Factory Gauge on the ground (attached to a floor).
2. Let a mob (e.g. a zombie or sheep) walk over it.
3. The mob bounces/hops repeatedly instead of walking over smoothly.

## Verification

- `./gradlew compileJava` passes.
- Tested in-game (1.21.1, Create 6.0.10): mobs now walk over floor gauges like grass.

### Videos

Before fixed: 1.21.1, Create 6.0.10

https://github.com/user-attachments/assets/64e7dd97-6bc4-4c8c-9f11-a997d02fb415

After fixed:

https://github.com/user-attachments/assets/42876dc7-c79d-4a8d-a3c1-8be3daa0bf09
