### PR TITLE
Adds the 1.21 vanilla tuff variants to tuff tag.

### DIFF
--- a/src/generated/resources/data/create/tags/item/stone_types/tuff.json
+++ b/src/generated/resources/data/create/tags/item/stone_types/tuff.json
@@ -14,6 +14,16 @@
     "create:small_tuff_brick_wall",
     "create:layered_tuff",
     "create:tuff_pillar",
-    "minecraft:tuff"
+    "minecraft:tuff",
+    "minecraft:tuff_stairs",
+    "minecraft:tuff_wall",
+    "minecraft:chiseled_tuff",
+    "minecraft:polished_tuff",
+    "minecraft:polished_tuff_stairs",
+    "minecraft:polished_tuff_wall",
+    "minecraft:tuff_bricks",
+    "minecraft:tuff_brick_stairs",
+    "minecraft:tuff_brick_wall",
+    "minecraft:chiseled_tuff_bricks"
   ]
 }


### PR DESCRIPTION
I noticed that you can recylce the create tuff variants into nuggets but not the vanilla ones.  This change fixes that discrepency.