### PR TITLE
Add Level-aware overload for InventoryIdentifier#contains

### DIFF
--- a/src/main/java/com/simibubi/create/api/packager/InventoryIdentifier.java
+++ b/src/main/java/com/simibubi/create/api/packager/InventoryIdentifier.java
@@ -28,6 +28,14 @@ public interface InventoryIdentifier {
 	 */
 	boolean contains(BlockFace face);
 
+	/***
+	 * Override this method if necessary to obtain more context.
+	 * @return true if the given face is part of the inventory this identifier represents
+	 */
+	default boolean contains(Level level, BlockFace face) {
+		return contains(face);
+	}
+
 	/**
 	 * Get the InventoryIdentifier for the given BlockFace, if present.
 	 */

--- a/src/main/java/com/simibubi/create/content/logistics/packager/PackagerBlockEntity.java
+++ b/src/main/java/com/simibubi/create/content/logistics/packager/PackagerBlockEntity.java
@@ -58,6 +58,7 @@ import net.minecraft.util.Mth;
 import net.minecraft.world.Clearable;
 import net.minecraft.world.Containers;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.entity.SignBlockEntity;
@@ -657,8 +658,9 @@ public class PackagerBlockEntity extends SmartBlockEntity implements Clearable {
 			return false;
 
 		if (inventory.identifier() != null) {
+			Level targetLevel = this.targetInventory.getWorld();
 			BlockFace face = this.targetInventory.getTarget().getOpposite();
-			return inventory.identifier().contains(face);
+			return inventory.identifier().contains(targetLevel, face);
 		} else {
 			return isSameInventoryFallback(targetHandler, inventory.handler());
 		}


### PR DESCRIPTION
## Summary

Some modded storage blocks are not identified solely by their position and direction, but expose specific storage contents through identifiers stored in their Block Entity. Without access to the Block Entity, `InventoryIdentifier` cannot reliably determine whether such blocks belong to the same inventory.

This change adds a overload to `InventoryIdentifier#contains`, allowing implementations to resolve the actual Block Entity when additional context is required.

The existing method is preserved as the functional interface method, with the new overload providing a default fallback. Related call sites have been updated accordingly. This is a small, non-breaking change of roughly 10 lines.

## Related issues

Fixes #10689

[https://github.com/Frostbite-time/BeyondDimensions/issues/76](https://github.com/Frostbite-time/BeyondDimensions/issues/76)