### PR TITLE
Fix pasting schematic coordinates with spaces

### DIFF
--- a/src/main/java/com/simibubi/create/content/schematics/client/SchematicEditScreen.java
+++ b/src/main/java/com/simibubi/create/content/schematics/client/SchematicEditScreen.java
@@ -127,7 +127,7 @@ public class SchematicEditScreen extends AbstractSimiScreen {
 		if (isPaste(code)) {
 			String coords = minecraft.keyboardHandler.getClipboard();
 			if (coords != null && !coords.isEmpty()) {
-				coords.replaceAll(" ", "");
+				coords = coords.replaceAll(" ", "");
 				String[] split = coords.split(",");
 				if (split.length == 3) {
 					boolean valid = true;


### PR DESCRIPTION
String#replaceAll returns a new string; its result was discarded, so clipboard values like "100, 64, -20" failed to parse and the paste was silently ignored.