### PR TITLE
Allow the water consumption of Steam Engines to be configured

### DIFF
--- a/src/main/java/com/simibubi/create/content/fluids/tank/BoilerData.java
+++ b/src/main/java/com/simibubi/create/content/fluids/tank/BoilerData.java
@@ -6,6 +6,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import com.simibubi.create.infrastructure.config.AllConfigs;
+
 import org.jetbrains.annotations.NotNull;
 
 import com.simibubi.create.AllBlocks;
@@ -45,7 +47,6 @@ public class BoilerData {
 
 	static final int SAMPLE_RATE = 5;
 
-	private static final int waterSupplyPerLevel = 10;
 	private static final float passiveEngineEfficiency = 1 / 8f;
 
 	// pooled water supply
@@ -120,7 +121,7 @@ public class BoilerData {
 		}
 
 		if (controller instanceof CreativeFluidTankBlockEntity)
-			waterSupply = waterSupplyPerLevel * 20;
+			waterSupply = AllConfigs.server().fluids.steamEngineWaterPerLevel.get() * 20;
 
 		if (getActualHeat(controller.getTotalTankSize()) == 18)
 			controller.award(AllAdvancements.STEAM_ENGINE_MAXED);
@@ -163,7 +164,7 @@ public class BoilerData {
 	}
 
 	public int getMaxHeatLevelForWaterSupply() {
-		return (int) Math.min(18, Mth.ceil(waterSupply) / waterSupplyPerLevel);
+		return (int) Math.min(18, Mth.ceil(waterSupply) / AllConfigs.server().fluids.steamEngineWaterPerLevel.get());
 	}
 
 	public boolean isPassive() {
@@ -221,7 +222,7 @@ public class BoilerData {
 				.add(CreateLang.translate("generic.unit.millibuckets"))
 				.add(CreateLang.text(" / ")
 					.style(ChatFormatting.GRAY))
-				.add(CreateLang.translate("boiler.per_tick", CreateLang.number(waterSupplyPerLevel)
+				.add(CreateLang.translate("boiler.per_tick", CreateLang.number(AllConfigs.server().fluids.steamEngineWaterPerLevel.get())
 						.add(CreateLang.translate("generic.unit.millibuckets")))
 					.style(ChatFormatting.DARK_GRAY))
 				.forGoggles(tooltip, 1);

--- a/src/main/java/com/simibubi/create/infrastructure/config/CFluids.java
+++ b/src/main/java/com/simibubi/create/infrastructure/config/CFluids.java
@@ -21,6 +21,8 @@ public class CFluids extends ConfigBase {
 	public ConfigBool fluidFillPlaceFluidSourceBlocks = b(true, "fluidFillPlaceFluidSourceBlocks", Comments.fluidFillPlaceFluidSourceBlocks);
 	public ConfigBool pipesPlaceFluidSourceBlocks = b(true, "pipesPlaceFluidSourceBlocks", Comments.pipesPlaceFluidSourceBlocks);
 
+	public final ConfigInt steamEngineWaterPerLevel = i(10, 1, "steamEngineWaterEfficiency", Comments.millibuckets, Comments.steamEngineWaterEfficiency);
+
 	@Override
 	public String getName() {
 		return "fluids";
@@ -29,6 +31,7 @@ public class CFluids extends ConfigBase {
 	private static class Comments {
 		static String blocks = "[in Blocks]";
 		static String buckets = "[in Buckets]";
+		static String millibuckets = "[in Millibuckets]";
 		static String toDisable = "[-1 to disable this behaviour]";
 
 		static String fluidTankCapacity = "The amount of liquid a tank can hold per block.";
@@ -44,6 +47,8 @@ public class CFluids extends ConfigBase {
 
 		static String fluidFillPlaceFluidSourceBlocks = "Whether hose pulleys should be allowed to place fluid sources.";
 		static String pipesPlaceFluidSourceBlocks = "Whether open-ended pipes should be allowed to place fluid sources.";
+
+		static String steamEngineWaterEfficiency = "How many millibuckets of water per tick a steam engine requires per level.";
 	}
 
 }


### PR DESCRIPTION
This pull request adds a configuration option to adjust the amount of water Steam Engines use per tick, per level.