### PR TITLE
feat(logistics): add Packaged Ingredients item attribute

### DIFF
--- a/src/generated/resources/.cache/af1b4964b4b67530aeb67585e9573385e8cab38a
+++ b/src/generated/resources/.cache/af1b4964b4b67530aeb67585e9573385e8cab38a
@@ -1,4 +1,4 @@
-// 1.21.1	2026-03-06T13:40:00.170210212	Registrate Provider for create [Registries, Data Maps, Recipes, Advancements, Loot Tables, Tags (blocks), Tags (enchantments), Tags (items), Tags (fluids), Tags (entity_types), generic_server_provider, Blockstates, Item models, Lang (en_us/en_ud), generic_client_provider]
+// 1.21.1	2026-08-29T22:29:56.060364995	Registrate Provider for create [Registries, Data Maps, Recipes, Advancements, Loot Tables, Tags (blocks), Tags (enchantments), Tags (items), Tags (fluids), Tags (entity_types), generic_server_provider, Blockstates, Item models, Lang (en_us/en_ud), generic_client_provider]
 60bbdf92d2ac9824ea6144955c74043a6005f79d assets/create/blockstates/acacia_window.json
 6a67703c2697d81b7dc83e9d72a66f9c9ff08383 assets/create/blockstates/acacia_window_pane.json
 c3ae87b62e81d8e9476eccd793bb1548d74c66a1 assets/create/blockstates/adjustable_chain_gearshift.json
@@ -642,8 +642,8 @@ b0d8f08968763a5f74e5cd5644377a76a9f39753 assets/create/blockstates/yellow_toolbo
 fe8c497aacc641c2f01cec90bba9f19e59cc2ed2 assets/create/blockstates/yellow_valve_handle.json
 e819e93fdcbe9fd9c050a052d2718ff3b3539365 assets/create/blockstates/zinc_block.json
 64121dcb216381c83b4fe28aa361ea07c24c9ad0 assets/create/blockstates/zinc_ore.json
-cfc04c8bcd7c2935a5b658166cb755299679b729 assets/create/lang/en_ud.json
-2157d86a90660702b4581768ef9e8e6385c53eb5 assets/create/lang/en_us.json
+98c69d8e6c3241ab344e96a7e8442a764cfb7590 assets/create/lang/en_ud.json
+b898023dcace4ce958c5e26112d9c036e922d316 assets/create/lang/en_us.json
 a97e1060e00ae701a02e39cd4ef8054cf345fac4 assets/create/models/block/acacia_window.json
 103e032c0b1a0a6a27c67da8c91179a564bd281c assets/create/models/block/acacia_window_pane_noside.json
 fb00b627abda76ad4fea867ca57dbfadd24fffa3 assets/create/models/block/acacia_window_pane_noside_alt.json

--- a/src/generated/resources/assets/create/lang/en_ud.json
+++ b/src/generated/resources/assets/create/lang/en_ud.json
@@ -1510,6 +1510,8 @@
   "create.item_attributes.max_enchanted.inverted": "ןǝʌǝן xɐɯ ʇɐ pǝʇuɐɥɔuǝ ʇou sı",
   "create.item_attributes.not_stackable": "ʞɔɐʇs ʇouuɐɔ",
   "create.item_attributes.not_stackable.inverted": "pǝʞɔɐʇs ǝq uɐɔ",
+  "create.item_attributes.packaged_ingredients": "sʇuǝıpǝɹbuI pǝbɐʞɔɐԀ suıɐʇuoɔ",
+  "create.item_attributes.packaged_ingredients.inverted": "sʇuǝıpǝɹbuI pǝbɐʞɔɐԀ uıɐʇuoɔ ʇou sǝop",
   "create.item_attributes.placeable": "ǝןqɐǝɔɐןd sı",
   "create.item_attributes.placeable.inverted": "ǝןqɐǝɔɐןd ʇou sı",
   "create.item_attributes.renamed": "ǝɯɐu ɯoʇsnɔ ɐ sɐɥ",

--- a/src/generated/resources/assets/create/lang/en_us.json
+++ b/src/generated/resources/assets/create/lang/en_us.json
@@ -1510,6 +1510,8 @@
   "create.item_attributes.max_enchanted.inverted": "is not enchanted at max level",
   "create.item_attributes.not_stackable": "cannot stack",
   "create.item_attributes.not_stackable.inverted": "can be stacked",
+  "create.item_attributes.packaged_ingredients": "contains Packaged Ingredients",
+  "create.item_attributes.packaged_ingredients.inverted": "does not contain Packaged Ingredients",
   "create.item_attributes.placeable": "is placeable",
   "create.item_attributes.placeable.inverted": "is not placeable",
   "create.item_attributes.renamed": "has a custom name",

--- a/src/main/java/com/simibubi/create/content/logistics/item/filter/attribute/AllItemAttributeTypes.java
+++ b/src/main/java/com/simibubi/create/content/logistics/item/filter/attribute/AllItemAttributeTypes.java
@@ -7,6 +7,7 @@ import com.simibubi.create.AllRecipeTypes;
 import com.simibubi.create.Create;
 import com.simibubi.create.api.registry.CreateBuiltInRegistries;
 import com.simibubi.create.content.kinetics.fan.processing.AllFanProcessingTypes;
+import com.simibubi.create.content.logistics.box.PackageItem;
 import com.simibubi.create.content.logistics.item.filter.attribute.attributes.AddedByAttribute;
 import com.simibubi.create.content.logistics.item.filter.attribute.attributes.BookAuthorAttribute;
 import com.simibubi.create.content.logistics.item.filter.attribute.attributes.BookCopyAttribute;
@@ -17,6 +18,7 @@ import com.simibubi.create.content.logistics.item.filter.attribute.attributes.In
 import com.simibubi.create.content.logistics.item.filter.attribute.attributes.InTagAttribute;
 import com.simibubi.create.content.logistics.item.filter.attribute.attributes.ItemNameAttribute;
 import com.simibubi.create.content.logistics.item.filter.attribute.attributes.ShulkerFillLevelAttribute;
+import com.simibubi.create.content.logistics.stockTicker.PackageOrderWithCrafts;
 
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import net.minecraft.core.Holder;
@@ -62,6 +64,7 @@ public class AllItemAttributeTypes {
 		SMOKABLE = singleton("smokable", (s, w) -> testRecipe(s, w, RecipeType.SMOKING)),
 		BLASTABLE = singleton("blastable", (s, w) -> testRecipe(s, w, RecipeType.BLASTING)),
 		COMPOSTABLE = singleton("compostable", s -> ComposterBlock.getValue(s) > 0),
+		PACKAGED_INGREDIENTS = singleton("packaged_ingredients", s -> PackageItem.isPackage(s) && PackageOrderWithCrafts.hasCraftingInformation(PackageItem.getOrderContext(s))),
 
 	IN_TAG = register("in_tag", new InTagAttribute.Type()),
 		IN_ITEM_GROUP = register("in_item_group", new InItemGroupAttribute.Type()),

--- a/src/main/resources/assets/create/lang/default/interface.json
+++ b/src/main/resources/assets/create/lang/default/interface.json
@@ -571,6 +571,8 @@
 	"create.item_attributes.blastable.inverted": "cannot be Smelted in a Blast Furnace",
 	"create.item_attributes.compostable": "can be composted",
 	"create.item_attributes.compostable.inverted": "cannot be composted",
+	"create.item_attributes.packaged_ingredients": "contains Packaged Ingredients",
+	"create.item_attributes.packaged_ingredients.inverted": "does not contain Packaged Ingredients",
 
 	"create.item_attributes.shulker_level": "is shulker %1$s",
 	"create.item_attributes.shulker_level.inverted": "is shulker not %1$s",

--- a/src/main/resources/assets/create/lang/qep.json
+++ b/src/main/resources/assets/create/lang/qep.json
@@ -1501,6 +1501,8 @@
   "create.item_attributes.max_enchanted.inverted": "is not galed at greatest layer",
   "create.item_attributes.not_stackable": "cannot be heaped",
   "create.item_attributes.not_stackable.inverted": "can heap",
+  "create.item_attributes.packaged_ingredients": "holds Packed Anworks",
+  "create.item_attributes.packaged_ingredients.inverted": "does not hold Packed Anworks",
   "create.item_attributes.placeable": "is layenly",
   "create.item_attributes.placeable.inverted": "is not layenly",
   "create.item_attributes.renamed": "has a bespoke name",


### PR DESCRIPTION
Adds a predicate to the attribute filter so that packages with crafting information can be differentiated from packages without.