### PR TITLE
Nullbound Express

### DIFF
--- a/src/main/java/com/simibubi/create/content/trains/entity/TrainRelocationPacket.java
+++ b/src/main/java/com/simibubi/create/content/trains/entity/TrainRelocationPacket.java
@@ -49,7 +49,7 @@ public record TrainRelocationPacket(UUID trainId, BlockPos pos, Vec3 lookAngle, 
 				.getString() + " could not relocate Train ";
 
 		if (train == null || !(entity instanceof CarriageContraptionEntity cce)) {
-			Create.LOGGER.warn(messagePrefix + train.id.toString()
+			Create.LOGGER.warn(messagePrefix + trainId.toString()
 					.substring(0, 5) + ": not present on server");
 			return;
 		}


### PR DESCRIPTION
The warning for a missing train tried to log `train.id`, which is guaranteed null in that exact branch. Use the `trainId` from the packet instead.