### PR TITLE
Fix Clipboard allowing arbitrary Components

### DIFF
--- a/src/main/java/com/simibubi/create/content/equipment/clipboard/ClipboardBlock.java
+++ b/src/main/java/com/simibubi/create/content/equipment/clipboard/ClipboardBlock.java
@@ -2,6 +2,16 @@ package com.simibubi.create.content.equipment.clipboard;
 
 import java.util.List;
 
+import com.simibubi.create.AllBlocks;
+import com.simibubi.create.AllDataComponents;
+import com.simibubi.create.api.schematic.requirement.SpecialBlockItemRequirement;
+
+import com.simibubi.create.content.schematics.requirement.ItemRequirement;
+
+import com.simibubi.create.content.schematics.requirement.ItemRequirement.ItemUseType;
+
+import com.simibubi.create.content.schematics.requirement.ItemRequirement.PartialStrictNbtStackRequirement;
+
 import org.jetbrains.annotations.NotNull;
 
 import com.google.common.collect.ImmutableList;
@@ -47,8 +57,10 @@ import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.neoforge.common.util.FakePlayer;
 
+import org.jetbrains.annotations.Nullable;
+
 public class ClipboardBlock extends FaceAttachedHorizontalDirectionalBlock
-	implements IBE<ClipboardBlockEntity>, IWrenchable, ProperWaterloggedBlock {
+	implements IBE<ClipboardBlockEntity>, IWrenchable, ProperWaterloggedBlock, SpecialBlockItemRequirement {
 
 	public static final BooleanProperty WRITTEN = BooleanProperty.create("written");
 
@@ -192,5 +204,15 @@ public class ClipboardBlock extends FaceAttachedHorizontalDirectionalBlock
 	@Override
 	protected @NotNull MapCodec<? extends FaceAttachedHorizontalDirectionalBlock> codec() {
 		return CODEC;
+	}
+
+	@Override
+	public ItemRequirement getRequiredItems(BlockState state, @Nullable BlockEntity blockEntity) {
+		ItemStack clipboardStack = new ItemStack(AllBlocks.CLIPBOARD.asItem());
+		if (blockEntity instanceof ClipboardBlockEntity clipboard) {
+			clipboardStack.applyComponents(clipboard.components());
+		}
+		return new ItemRequirement(List.of(new PartialStrictNbtStackRequirement(clipboardStack, ItemUseType.CONSUME,
+			List.of(AllDataComponents.CLIPBOARD_CONTENT))));
 	}
 }

--- a/src/main/java/com/simibubi/create/content/schematics/requirement/ItemRequirement.java
+++ b/src/main/java/com/simibubi/create/content/schematics/requirement/ItemRequirement.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import net.minecraft.core.component.DataComponentType;
+
 import org.jetbrains.annotations.Nullable;
 
 import com.simibubi.create.api.schematic.requirement.SchematicRequirementRegistries;
@@ -211,6 +213,28 @@ public class ItemRequirement {
 		@Override
 		public boolean matches(ItemStack other) {
 			return ItemStack.isSameItemSameComponents(stack, other);
+		}
+	}
+
+	public static class PartialStrictNbtStackRequirement extends StrictNbtStackRequirement {
+		private final List<DataComponentType<?>> ignoredComponents;
+
+		public PartialStrictNbtStackRequirement(ItemStack stack, ItemUseType usage, List<DataComponentType<?>> ignoredComponents) {
+			super(copyWithoutIgnoredComponents(stack, ignoredComponents), usage);
+			this.ignoredComponents = ignoredComponents;
+		}
+
+		@Override
+		public boolean matches(ItemStack other) {
+			return super.matches(copyWithoutIgnoredComponents(other, ignoredComponents));
+		}
+
+		private static ItemStack copyWithoutIgnoredComponents(ItemStack stack, List<DataComponentType<?>> components) {
+			ItemStack ret = stack.copy();
+			for (DataComponentType<?> component : components) {
+				ret.remove(component);
+			}
+			return ret;
 		}
 	}
 }


### PR DESCRIPTION
Fixes - #10733

Adds a StrictNbtStackRequirment variant that ignores a subset of components (i.e. ones that would be safe to print), and requiring that all other components match, ensuring that the only components you can print are ones you were already able to obtain.