### PR TITLE
Fix tree fertilizer generously replacing your sapling

### DIFF
--- a/src/main/java/com/simibubi/create/content/equipment/TreeFertilizerItem.java
+++ b/src/main/java/com/simibubi/create/content/equipment/TreeFertilizerItem.java
@@ -54,21 +54,26 @@ public class TreeFertilizerItem extends Item {
 			for (BlockPos pos : world.blocksAdded.keySet()) {
 				BlockPos actualPos = pos.offset(saplingPos).below(10);
 				BlockState newState = world.blocksAdded.get(pos);
+				BlockState oldState = context.getLevel().getBlockState(actualPos);
 
 				// Don't replace Bedrock
-				if (context.getLevel()
-					.getBlockState(actualPos)
-					.getDestroySpeed(context.getLevel(), actualPos) == -1)
+				if (oldState.getDestroySpeed(context.getLevel(), actualPos) == -1)
 					continue;
 				// Don't replace solid blocks with leaves
 				if (!newState.isRedstoneConductor(world, pos)
-					&& !context.getLevel()
-						.getBlockState(actualPos)
-						.getCollisionShape(context.getLevel(), actualPos)
+					&& !oldState.getCollisionShape(context.getLevel(), actualPos)
 						.isEmpty())
 					continue;
 
-				context.getLevel().destroyBlock(actualPos, true);
+				// Don't drop blocks that are: unchanged, the same as the fertilized sapling,
+				// or normally replaceable by trees without dropping an item
+				boolean shouldDrop = !(oldState.getBlock() == state.getBlock() ||
+					oldState.getBlock() == newState.getBlock() ||
+					oldState.is(BlockTags.REPLACEABLE_BY_TREES) ||
+					oldState.is(BlockTags.MANGROVE_ROOTS_CAN_GROW_THROUGH) ||
+					oldState.is(BlockTags.MANGROVE_LOGS_CAN_GROW_THROUGH));
+
+				context.getLevel().destroyBlock(actualPos, shouldDrop);
 				context.getLevel()
 					.setBlockAndUpdate(actualPos, newState);
 			}
@@ -87,7 +92,7 @@ public class TreeFertilizerItem extends Item {
 	private BlockState withStage(BlockState original, int stage) {
 		if (!original.hasProperty(BlockStateProperties.STAGE))
 			return original;
-		return original.setValue(BlockStateProperties.STAGE, 1);
+		return original.setValue(BlockStateProperties.STAGE, stage);
 	}
 
 	private static class TreesDreamWorld extends PlacementSimulationServerLevel {

--- a/src/main/java/com/simibubi/create/content/equipment/TreeFertilizerItem.java
+++ b/src/main/java/com/simibubi/create/content/equipment/TreeFertilizerItem.java
@@ -67,7 +67,7 @@ public class TreeFertilizerItem extends Item {
 
 				// Don't drop blocks that are: unchanged, the same as the fertilized sapling,
 				// or normally replaceable by trees without dropping an item
-				boolean shouldDrop = !(oldState.getBlock() == state.getBlock() ||
+				boolean shouldDrop = !(oldState.getBlock() == block ||
 					oldState.getBlock() == newState.getBlock() ||
 					oldState.is(BlockTags.REPLACEABLE_BY_TREES) ||
 					oldState.is(BlockTags.MANGROVE_ROOTS_CAN_GROW_THROUGH) ||


### PR DESCRIPTION
So apparently no one besides @Allmoz is using tree fertilizer. (Edit: the actual bug this fixes is that the fertilized sapling and any identical ones next to it are still dropped when (not even) replaced by the tree)

Without just reverting #9758 some choices have to be made for blocks to exclude from dropping. I settled on:
- Blocks matching the fertilized sapling (due to 2x2 and perhaps modded 3x3 or cross pattern trees), otherwise would've excluded specifically the sapling position (Edit: so this is all that's technically necessary but the next two points seem like sensible blocks to me to also exclude)
- Any blocks that weren't actually replaced by a different block
- Blocks that are normally replaceable by trees (a process which doesn't drop the blocks either)

Also noticed the `withStage` method was not actually using its stage argument (functionally nothing changes because it was already only ever getting passed 1)

