### PR TITLE
Fix packager simulation for oversized stacks

### DIFF
--- a/src/main/java/com/simibubi/create/impl/unpacking/DefaultUnpackingHandler.java
+++ b/src/main/java/com/simibubi/create/impl/unpacking/DefaultUnpackingHandler.java
@@ -48,39 +48,32 @@ public enum DefaultUnpackingHandler implements UnpackingHandler {
 
 			for (int boxSlot = 0; boxSlot < items.size(); boxSlot++) {
 				ItemStack toInsert = items.get(boxSlot);
+
 				if (toInsert.isEmpty())
 					continue;
 
-				if (targetInv.insertItem(slot, toInsert, true)
-					.getCount() == toInsert.getCount())
+				if (!itemInSlot.isEmpty() && !ItemStack.isSameItemSameComponents(toInsert, itemInSlot))
 					continue;
 
-				if (itemInSlot.isEmpty()) {
-					int maxStackSize = targetInv.getSlotLimit(slot);
-					if (maxStackSize < toInsert.getCount()) {
-						toInsert.shrink(maxStackSize);
-						toInsert = toInsert.copyWithCount(maxStackSize);
-					} else
-						items.set(boxSlot, ItemStack.EMPTY);
+				int simulatedAmount = itemsAddedToSlot + toInsert.getCount();
+				ItemStack simulatedStack = toInsert.copyWithCount(simulatedAmount);
+				int totalInsertable = simulatedAmount - targetInv.insertItem(slot, simulatedStack, true).getCount();
 
-					itemInSlot = toInsert;
-					targetInv.insertItem(slot, toInsert, simulate);
-					continue;
-				}
+				int added = Math.min(toInsert.getCount(),
+					Math.max(0, totalInsertable - itemsAddedToSlot)
+				);
 
-				if (!ItemStack.isSameItemSameComponents(toInsert, itemInSlot))
+				if (added == 0)
 					continue;
 
-				int insertedAmount = toInsert.getCount() - targetInv.insertItem(slot, toInsert, simulate)
-					.getCount();
-				int slotLimit = Math.min(itemInSlot.getMaxStackSize(), targetInv.getSlotLimit(slot));
-				int insertableAmountWithPreviousItems =
-					Math.min(toInsert.getCount(), slotLimit - itemInSlot.getCount() - itemsAddedToSlot);
+				if (itemInSlot.isEmpty())
+					itemInSlot = toInsert.copy();
 
-				int added = Math.min(insertedAmount, Math.max(0, insertableAmountWithPreviousItems));
 				itemsAddedToSlot += added;
 
-				items.set(boxSlot, toInsert.copyWithCount(toInsert.getCount() - added));
+				int remaining = toInsert.getCount() - added;
+
+				items.set(boxSlot, remaining == 0 ? ItemStack.EMPTY : toInsert.copyWithCount(remaining));
 			}
 		}
 


### PR DESCRIPTION
Fixes #10067 and #10313

### What changed

Packager unpacking currently calculates the effective capacity of an occupied slot using the minimum of `ItemStack#getMaxStackSize()` and `IItemHandler#getSlotLimit()`.

This causes the simulated capacity to be underestimated for inventories that support stacks larger than the item's vanilla maximum stack size, such as Sophisticated Storage and Functional Storage.

Instead of reconstructing the slot capacity from those values, this change keeps track of the amount virtually assigned to each slot and includes that amount in subsequent `insertItem(..., true)` simulations.

This lets the target `IItemHandler` determine the actual insertion limit while still accounting for previous simulated insertions into the same slot.

### Testing

Tested manually with:

* Vanilla chests
* Sophisticated Storage with stack upgrades
* Functional Storage
* Multiple stacks of the same item in a package
* Partially filled oversized stacks

I also tested Storage Drawers and found a separate pre-existing issue. Storage Drawers exposes a virtual insertion slot that represents the entire drawer group in addition to the individual drawer slots. The Packager's slot-by-slot simulation can therefore count overlapping storage capacity more than once, causing the simulation to succeed even when the full package cannot actually be inserted.

The subsequent real insertion leaves a remainder, which `DefaultUnpackingHandler` currently does not handle, causing the excess items to be voided. This behavior is reproducible on an unmodified Create build as well and is not introduced by this change.

The Storage Drawers-specific issue is tracked separately in #10747.